### PR TITLE
Repairing the data array after cropping/flipping etc.

### DIFF
--- a/ptypy/core/data.py
+++ b/ptypy/core/data.py
@@ -725,6 +725,9 @@ class PtyScan(object):
                         'Binning (%d) is to large or incompatible with array '
                         'shape (%s).' % (rebin, str(tuple(sh))))
 
+                # restore contiguity of the cropped/padded/rotated/flipped array
+                d = np.ascontiguousarray(d)
+
                 if has_data:
                     # Translate back to dictionaries
                     data = dict(zip(indices.node, d))


### PR DESCRIPTION
This fixes MPI data preparation bug #51, by restoring contiguity of data arrays after cropping/padding/binning/flipping/rotating. Please test!