### PR TITLE
Some changes to Ptypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ script:
 
 after_script:
   - coveralls
-  
+
 allow_failures:
 - python: "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_install:
   - conda update -q conda # update this quietly
   - conda install pyyaml
   - conda info -a # and print the info
-  - conda install pyyaml
 
 install:
   - conda env create --file environment.yml #set up the environment thats in the file

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - pyzmq
   - pep8
   - pytest
-  - mpi4py 
+  - mpi4py
   - pil
   - pip:
     - pytest-cov

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,6 @@
 name: test-environment
+channels:
+  - conda-forge
 dependencies:
   - python=2.7
   - numpy
@@ -11,6 +13,7 @@ dependencies:
   - pytest
   - mpi4py
   - pil
+  - pyfftw
   - pip:
     - pytest-cov
     - coveralls

--- a/environment.yml
+++ b/environment.yml
@@ -17,5 +17,3 @@ dependencies:
   - pip:
     - pytest-cov
     - coveralls
-
-

--- a/ptypy/__init__.py
+++ b/ptypy/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 from version import short_version, version, release
 """

--- a/ptypy/__init__.py
+++ b/ptypy/__init__.py
@@ -6,7 +6,7 @@ PTYPY(v%(short)s): A ptychography reconstruction package.
 
 To cite PTYPY in publications, use
  @article{ ... }
- 
+
     :copyright: Copyright 2014 by the PTYPY team, see AUTHORS.
     :license: GPLv2, see LICENSE for details.
     :version: %(version)s
@@ -20,7 +20,7 @@ try:
     __has_zmq__= True
     del zmq
 except ImportError('ZeroMQ not found.\nInteraction server & client disabled.\n\
-Install python-zmq via the package repositories or with `pip install --user pyzmq`'): 
+Install python-zmq via the package repositories or with `pip install --user pyzmq`'):
     __has_zmq__= False
 
 try:
@@ -29,7 +29,7 @@ try:
     del mpi4py
 except ImportError('Message Passaging for Python (mpi4py) not found.\n\
 CPU-parallelization disabled.\n\
-Install python-mpi4py via the package repositories or with `pip install --user mpi4py`'): 
+Install python-mpi4py via the package repositories or with `pip install --user mpi4py`'):
     __has_mpi4py__= False
 
 try:
@@ -40,7 +40,7 @@ except ImportError('Plotting for Python (matplotlib) not found.\n\
 Plotting disabled.\n\
 Install python-matplotlib via the package repositories or with `pip install --user matplotlib`'):
     __has_matplotlib__= False
-       
+
 # Initialize MPI (eventually GPU)
 from utils import parallel
 
@@ -50,13 +50,13 @@ from utils import verbose
 
 import utils
 # Import core modules
-import io 
+import io
 import experiment
 import core
 
 
 #from core import *
-import simulations 
+import simulations
 import resources
 
 if __name__ == "__main__":
@@ -65,9 +65,9 @@ if __name__ == "__main__":
     # Get parameters from command line argument
     param_filename = sys.argv[1]
     p = parameters.load(param_filename)
-    
+
     # Initialize Ptycho object
     pt = Ptycho(p)
-    
+
     # Start reconstruction
     pt.run()

--- a/ptypy/core/classes.py
+++ b/ptypy/core/classes.py
@@ -8,7 +8,7 @@ for ptychographic reconstructions.
 **Container class**
     A high-level container that keeps track of sub-containers (Storage)
     and Views onto them. A container can copy itself to produce a buffer
-    needed for calculations. Some basic Mathematical operations are 
+    needed for calculations. Some basic Mathematical operations are
     implemented at this level as in place operations.
     In general, operations on arrays should be done using the Views, which
     simply return numpy arrays.
@@ -92,17 +92,17 @@ class Base(object):
         Ptypy Base class to support some kind of hierarchy,
         conversion to and from dictionaries as well as a 'cross-node' ID
         management of python objects
-        
+
         Parameters
         ----------
         owner : Other subclass of Base or Base
             Owner gives IDs to other ptypy objects that refer to it
             as owner. Owner also keeps a reference to these objects in
-            its internal _pool where objects are key-sorted according 
+            its internal _pool where objects are key-sorted according
             to their ID prefix
-        
+
         ID : None, str or int
-            
+
         BeOwner : bool
             Set to `False` if this instance is not intended to own other
             ptypy objects.
@@ -125,7 +125,7 @@ class Base(object):
     def _new_ptypy_object(self, obj):
         """
         Registers a new ptypy object into this object's pool.
-        
+
         Parameters:
         -----------
         obj : [any object] or None
@@ -192,7 +192,7 @@ class Base(object):
 
     def _post_dict_import(self):
         """
-        Change here the specific behavior of child classes after 
+        Change here the specific behavior of child classes after
         being imported using _from_dict()
         """
         pass
@@ -280,12 +280,12 @@ class Storage(Base):
     """
     Inner container handling access to data arrays.
 
-    This class essentially manages access to an internal numpy array 
+    This class essentially manages access to an internal numpy array
     buffer called :py:attr:`~Storage.data`
-                
+
     * It returns a view to coordinates given (slicing)
     * It contains a physical coordinate grid
-    
+
     """
 
     _PREFIX = STORAGE_PREFIX
@@ -302,35 +302,35 @@ class Storage(Base):
         ID : None, str or int
             A unique ID, managed by the parent, if None ID is generated
             by parent.
-            
+
         data: ndarray or None
             A numpy array to use as initial buffer.
-        
+
         shape : 3-tuple
             The shape of the buffer
-            
+
         fill : float or complex
             The default value to fill storage with, will be converted to
             data type of owner.
-            
+
         psize : float or 2-tuple of float
             The physical pixel size.
-            
+
         origin : 2-tuple of int
             The physical coordinates of the [0,0] pixel (upper-left
-            corner of the storage buffer). 
-        
+            corner of the storage buffer).
+
         layermap : list or None
             A list (or 1D numpy array) mapping input layer indices
             to the internal buffer. This may be useful if the buffer
             contains only a portion of a larger data set (as when using
             distributed data with MPI). If None, provide direct access.
             to the 3d internal data.
-        
+
         padonly: bool
             If True, reformat() will enlarge the internal buffer if needed,
             but will not shrink it.
-            
+
         """
         super(Storage, self).__init__(container, ID)
 
@@ -434,10 +434,10 @@ class Storage(Base):
     """
     @property
     def datalist(self):
-        
+
         if not hasattr(self,'datalist'):
             self._make_datalist()
-        
+
         return self._datalist
     """
 
@@ -448,16 +448,16 @@ class Storage(Base):
     def copy(self, owner=None, ID=None, fill=None):
         """
         Return a copy of this storage object.
-        
+
         Note: the returned copy has the same container as self.
-        
+
         Parameters
         ----------
         ID : str or int
              A unique ID, managed by the parent
         fill : scalar or None
                If float, set the content to this value. If None, copy the
-               current content. 
+               current content.
         """
         if fill is None:
             # Return a new Storage or sub-class object with a copy of the data.
@@ -480,13 +480,13 @@ class Storage(Base):
 
     def fill(self, fill=None):
         """
-        Fill managed buffer. 
-        
+        Fill managed buffer.
+
         Parameters
         ----------
         fill : scalar, numpy array or None.
                Fill value to use. If fill is a numpy array, it is cast
-               as self.dtype and self.shape is updated to reflect the 
+               as self.dtype and self.shape is updated to reflect the
                new buffer shape. If fill is None, use default value
                (self.fill_value).
         """
@@ -512,7 +512,7 @@ class Storage(Base):
 
     def update(self):
         """
-        Update internal state, including all views on this storage to 
+        Update internal state, including all views on this storage to
         ensure consistency with the physical coordinate system.
         """
         # Update the access information for the views
@@ -522,7 +522,7 @@ class Storage(Base):
     def update_views(self, v=None):
         """
         Update the access information for a given view.
-        
+
         Parameters
         ----------
         v : View or None
@@ -564,13 +564,13 @@ class Storage(Base):
     def reformat(self, newID=None):
         """
         Crop or pad if required.
-        
+
         Parameters
         ----------
         newID : str or int
-            If None (default) act on self. Otherwise create a copy 
+            If None (default) act on self. Otherwise create a copy
             of self before doing the cropping and padding.
-            
+
         Returns
         -------
         s : Storage
@@ -720,7 +720,7 @@ class Storage(Base):
     def _to_pix(self, coord):
         """
         Transforms physical coordinates `coord` to pixel coordinates.
-        
+
         Parameters
         ----------
         coord : tuple or array-like
@@ -731,7 +731,7 @@ class Storage(Base):
     def _to_phys(self, pix):
         """
         Transforms pixel coordinates `pix` to physical coordinates.
-        
+
         Parameters
         ----------
         pix : tuple or array-like
@@ -800,13 +800,13 @@ class Storage(Base):
 
     def allreduce(self, op=None):
         """
-        Performs MPI parallel ``allreduce`` with a default sum as 
+        Performs MPI parallel ``allreduce`` with a default sum as
         reduction operation for internal data buffer ``self.data``.
         This method does nothing if the storage is distributed across
         nodes.
 
         :param op: Reduction operation. If ``None`` uses sum.
-           
+
         See also
         --------
         ptypy.utils.parallel.allreduce
@@ -817,14 +817,14 @@ class Storage(Base):
 
     def zoom_to_psize(self, new_psize, **kwargs):
         """
-        Changes pixel size and zooms the data buffer along last two axis 
+        Changes pixel size and zooms the data buffer along last two axis
         accordingly, updates all attached views and reformats if necessary.
         **untested!!**
-        
+
         Parameters
         ----------
         new_psize : scalar or array_like
-                    new pixel size 
+                    new pixel size
         """
         new_psize = u.expect2(new_psize)
         sh = np.asarray(self.shape[-2:])
@@ -836,7 +836,7 @@ class Storage(Base):
             logger.info('Zooming from %s , %s to %s , %s'
                         % (self.psize, sh, new_psize, new_sh.astype(int)))
 
-            # Zoom data buffer. 
+            # Zoom data buffer.
             # Could be that it is faster and cleaner to loop over first axis
             zoom = new_sh / sh
             self.fill(u.zoom(self.data, [1.0, zoom[0], zoom[1]], **kwargs))
@@ -854,8 +854,8 @@ class Storage(Base):
     def grids(self):
         """
         Returns
-        ------- 
-        x, y: ndarray 
+        -------
+        x, y: ndarray
             grids in the shape of internal buffer
         """
         sh = self.data.shape
@@ -869,11 +869,11 @@ class Storage(Base):
         """
         Creates an array in the shape of internal buffer where the value
         of each pixel represents the number of views that cover that pixel
-                
+
         Returns
-        ------- 
-        ndarray 
-            view coverage in the shape of internal buffer 
+        -------
+        ndarray
+            view coverage in the shape of internal buffer
         """
         coverage = np.zeros_like(self.data)
         for v in self.views:
@@ -901,37 +901,37 @@ class Storage(Base):
                          separator=" : ", include_header=True):
         """
         Returns formatted string and a dict with the respective information
-        
+
         Parameters
         ----------
         table_format : list, optional
-            List of (*item*,*length*) pairs where item is name of the info 
-            to be listed in the report and length is the column width. 
+            List of (*item*,*length*) pairs where item is name of the info
+            to be listed in the report and length is the column width.
             The following items are allowed:
-            
+
             - *memory*, for memory usage of the storages and total use
             - *shape*, for shape of internal storages
             - *dimensions*, is ``shape \* psize``
             - *psize*, for pixel size of storages
             - *views*, for number of views in each storage
-        
+
         offset : int, optional
             First column width
-        
+
         separator : str, optional
             Column separator.
-        
+
         align : str, optional
             Column alignment, either ``'right'`` or ``'left'``.
-            
+
         include_header : bool, optional
             Include a header if True.
-            
+
         Returns
         -------
         fstring : str
-            Formatted string 
-            
+            Formatted string
+
         dct : dict
             Dictionary containing with the respective info to the keys
             in `table_format`
@@ -986,7 +986,7 @@ class Storage(Base):
     def __getitem__(self, v):
         """
         Storage[v]
-        
+
         Returns
         -------
         ndarray
@@ -1015,12 +1015,12 @@ class Storage(Base):
         Storage[v] = newdata
 
         Set internal data buffer to `newdata` for the region of view `v`.
-        
+
         Parameters
         ----------
         v : View
             A View for this storage
-        
+
         newdata : ndarray
             Two-dimensional array that fits the view's shape
         """
@@ -1051,7 +1051,7 @@ class Storage(Base):
 
 def shift(v, sp):
     """
-    Placeholder for future subpixel shifting method. 
+    Placeholder for future subpixel shifting method.
     """
     return v
 
@@ -1059,17 +1059,17 @@ def shift(v, sp):
 class View(Base):
     """
     A "window" on a Container.
-    
+
     A view stores all the slicing information to extract a 2D piece
-    of Container. 
-    
+    of Container.
+
     Note
     ----
     The final structure of this class is yet up to debate
     and the constructor signature may change. Especially since
     "DEFAULT_ACCESSRULE" is yet so small, its contents could be
     incorporated in the constructor call.
-    
+
     """
     ########
     # TODO #
@@ -1087,38 +1087,38 @@ class View(Base):
         ----------
         container : Container
             The Container instance this view applies to.
-        
+
         ID : str or int
             ID for this view. Automatically built from ID if None.
-        
+
         accessrule : dict
             All the information necessary to access the wanted slice.
             Maybe subject to change as code evolve. See keyword arguments
             Almost all keys of accessrule will be available as attributes
             in the constructed View instance.
-        
+
         Keyword Args
         ------------
         storageID : str
-            ID of storage, If the Storage does not exist 
+            ID of storage, If the Storage does not exist
             it will be created! (*default* is ``None``)
-            
+
         shape : int or tuple of int
             Shape of the view in pixels (*default* is ``None``)
-            
-        coord : 2-tuple of float, 
+
+        coord : 2-tuple of float,
             Physical coordinates [meter] of the center of the view.
-            
+
         psize : float or tuple of float
-            Pixel size [meters]. Required for storage initialization, 
+            Pixel size [meters]. Required for storage initialization,
             See :py:data:`DEFAULT_PSIZE`
-            
+
         layer : int
             Index of the third dimension if applicable.
             (*default* is ``0``)
-            
+
         active : bool
-            Whether this view is active (*default* is ``True``) 
+            Whether this view is active (*default* is ``True``)
         """
         super(View, self).__init__(container, ID, False)
 
@@ -1126,21 +1126,21 @@ class View(Base):
         # if not hasattr(self, 'pods'):
         #    self.pods = weakref.WeakValueDictionary()
         self.pods = weakref.WeakValueDictionary()
-        """ Volatile dictionary for all :any:`POD`\ s that connect to 
+        """ Volatile dictionary for all :any:`POD`\ s that connect to
             this view """
 
         # A single pod lookup (weak reference).
         self._pod = None
 
         self.active = True
-        """ Active state. If False this view will be ignored when 
+        """ Active state. If False this view will be ignored when
             resizing the data buffer of the associated :any:`Storage`."""
 
         #: The :any:`Storage` instance that this view applies to by default.
         self.storage = None
 
         self.storageID = None
-        """ The storage ID that this view will be forward to if applied 
+        """ The storage ID that this view will be forward to if applied
             to a :any:`Container`."""
 
         # Numpy buffer arrays
@@ -1155,7 +1155,7 @@ class View(Base):
 
     def _set(self, accessrule, **kwargs):
         """
-        Store internal info to get/set the 2D data in the container. 
+        Store internal info to get/set the 2D data in the container.
         """
         rule = u.Param(self.DEFAULT_ACCESSRULE)
         if accessrule is not None:
@@ -1226,8 +1226,8 @@ class View(Base):
     @property
     def pod(self):
         """
-        Returns first :any:`POD` in the ``self.pods`` dict. 
-        This is a common call in the code and has therefore found 
+        Returns first :any:`POD` in the ``self.pods`` dict.
+        This is a common call in the code and has therefore found
         its way here. May return ``None`` if there is no pod connected.
         """
         return self._pod()  # weak reference
@@ -1367,36 +1367,36 @@ class View(Base):
 class Container(Base):
     """
     High-level container class.
-    
+
     Container can be seen as a "super-numpy-array" which can contain multiple
     sub-containers of type :any:`Storage`, potentially of different shape,
     along with all :any:`View` instances that act on these Storages to extract
-    data from the internal data buffer :any:`Storage.data`. 
-    
+    data from the internal data buffer :any:`Storage.data`.
+
     Typically there will be five such base containers in a :any:`Ptycho`
     reconstruction instance:
-    
-        - `Cprobe`, Storages for the illumination, i.e. **probe**, 
-        - `Cobj`, Storages for the sample transmission, i.e. **object**, 
-        - `Cexit`, Storages for the **exit waves**, 
+
+        - `Cprobe`, Storages for the illumination, i.e. **probe**,
+        - `Cobj`, Storages for the sample transmission, i.e. **object**,
+        - `Cexit`, Storages for the **exit waves**,
         - `Cdiff`, Storages for **diffraction data**, usually one per scan,
         - `Cmask`, Storages for **masks** (and weights), usually one per scan,
-        
-    A container can conveniently duplicate all its internal :any:`Storage` 
-    instances into a new Container using :py:meth:`copy`. This feature is 
-    intensively used in the reconstruction engines where buffer copies 
-    are needed to temporarily store results. These copies are referred 
+
+    A container can conveniently duplicate all its internal :any:`Storage`
+    instances into a new Container using :py:meth:`copy`. This feature is
+    intensively used in the reconstruction engines where buffer copies
+    are needed to temporarily store results. These copies are referred
     by the "original" container through the property :py:meth:`copies` and
-    a copy refers to its original through the attribute :py:attr:`original` 
-    In order to reduce the number of :any:`View` instances, Container copies 
-    do not hold views and use instead the Views held by the original container 
-    
+    a copy refers to its original through the attribute :py:attr:`original`
+    In order to reduce the number of :any:`View` instances, Container copies
+    do not hold views and use instead the Views held by the original container
+
     Attributes
     ----------
     original : Container
         If self is copy of a Container, this attribute refers to the original
         Container. Otherwise it is None.
-    
+
     data_type : str
         Either "single" or "double"
     """
@@ -1408,14 +1408,14 @@ class Container(Base):
         ----------
         ID : str or int
              A unique ID, managed by the parent
-             
+
         ptycho : Ptycho
             The instance of Ptycho associated with this pod.
-             
+
         data_type : str or numpy.dtype
-            data type - either a numpy.dtype object or 'complex' or 
+            data type - either a numpy.dtype object or 'complex' or
             'real' (precision is taken from ptycho.FType or ptycho.CType)
-        
+
         """
         # if ptycho is None:
         #    ptycho = ptypy.currentPtycho
@@ -1443,7 +1443,7 @@ class Container(Base):
     def delete_copy(self, copy_IDs=None):
         """
         Delete a copy or all copies of this container from owner instance.
-        
+
         Parameters
         ----------
         copy_IDs : str
@@ -1473,7 +1473,7 @@ class Container(Base):
     @property
     def S(self):
         """
-        A property that returns the internal dictionary of all 
+        A property that returns the internal dictionary of all
         :any:`Storage` instances in this :any:`Container`
         """
         return self._pool.get(STORAGE_PREFIX, {})
@@ -1481,7 +1481,7 @@ class Container(Base):
     @property
     def storages(self):
         """
-        A property that returns the internal dictionary of all 
+        A property that returns the internal dictionary of all
         :any:`Storage` instances in this :any:`Container`
         """
         return self._pool.get(STORAGE_PREFIX, {})
@@ -1489,7 +1489,7 @@ class Container(Base):
     @property
     def Sp(self):
         """
-        A property that returns the internal dictionary of all 
+        A property that returns the internal dictionary of all
         :any:`Storage` instances in this :any:`Container` as a :any:`Param`
         """
         return u.Param(self.storages)
@@ -1497,7 +1497,7 @@ class Container(Base):
     @property
     def V(self):
         """
-        A property that returns the internal dictionary of all 
+        A property that returns the internal dictionary of all
         :any:`View` instances in this :any:`Container`
         """
         return self._pool.get(VIEW_PREFIX, {})
@@ -1505,7 +1505,7 @@ class Container(Base):
     @property
     def views(self):
         """
-        A property that returns the internal dictionary of all 
+        A property that returns the internal dictionary of all
         :any:`View` instances in this :any:`Container`
         """
         return self._pool.get(VIEW_PREFIX, {})
@@ -1513,7 +1513,7 @@ class Container(Base):
     @property
     def Vp(self):
         """
-        A property that returns the internal dictionary of all 
+        A property that returns the internal dictionary of all
         :any:`View` instances in this :any:`Container` as a :any:`Param`
         """
         return u.Param(self.V)
@@ -1546,7 +1546,7 @@ class Container(Base):
     def views_in_storage(self, s, active=True):
         """
         Return a list of views on :any:`Storage` `s`.
-        
+
         Parameters
         ----------
         s : Storage
@@ -1563,14 +1563,14 @@ class Container(Base):
 
     def copy(self, ID=None, fill=None):
         """
-        Create a new :any:`Container` matching self. 
-        
-        The copy does not manage views. 
-        
+        Create a new :any:`Container` matching self.
+
+        The copy does not manage views.
+
         Parameters
         ----------
         fill : scalar or None
-            If None (default), copy content. If scalar, initializes 
+            If None (default), copy content. If scalar, initializes
             to this value
         """
         # Create an ID for this copy
@@ -1604,10 +1604,10 @@ class Container(Base):
         """
         Performs MPI parallel ``allreduce`` with a sum as reduction
         for all :any:`Storage` instances held by *self*
-        
+
         :param Container c: Input
         :param op: Reduction operation. If ``None`` uses sum.
-           
+
         See also
         --------
         ptypy.utils.parallel.allreduce
@@ -1627,17 +1627,17 @@ class Container(Base):
     def new_storage(self, ID=None, **kwargs):
         """
         Create and register a storage object.
-                
+
         Parameters
         ----------
         ID : str
              An ID for the storage. If None, a new ID is created. An
              error will be raised if the ID already exists.
-             
+
         kwargs : ...
             Arguments for new storage creation. See doc for
             :any:`Storage`.
-        
+
         """
         if self.storages is not None:
             if ID in self.storages:
@@ -1652,11 +1652,11 @@ class Container(Base):
     def reformat(self, also_in_copies=False):
         """
         Reformats all storages in this container.
-        
+
         Parameters
         ----------
         also_in_copies : bool
-            If True, also reformat associated copies of this container 
+            If True, also reformat associated copies of this container
         """
         for ID, s in self.storages.iteritems():
             s.reformat()
@@ -1677,41 +1677,41 @@ class Container(Base):
                          separator=" : ", include_header=True):
         """
         Returns formatted string and a dict with the respective information
-        
+
         Parameters
         ----------
-        table_format : list 
+        table_format : list
             List of (*item*, *length*) pairs where item is name of the info
-            to be listed in the report and length is the column width. 
+            to be listed in the report and length is the column width.
             The following items are allowed:
-            
+
             - *memory*, for memory usage of the storages and total use
             - *shape*, for shape of internal storages
             - *dimensions*, is ``shape \* psize``
             - *psize*, for pixel size of storages
             - *views*, for number of views in each storage
-        
+
         offset : int, optional
             First column width
-        
+
         separator : str, optional
             Column separator
-        
+
         align : str, optional
             Column alignment, either ``'right'`` or ``'left'``
-            
+
         include_header : bool
             Include a header if True
-            
+
         Returns
         -------
         fstring : str
-            Formatted string 
-            
+            Formatted string
+
         dct :dict
             Dictionary containing with the respective info to the keys
             in `table_format`
-            
+
         See also
         --------
         Storage.formatted_report
@@ -1754,7 +1754,7 @@ class Container(Base):
     def __getitem__(self, view):
         """
         Access content through view.
-        
+
         Parameters
         ----------
         view : View
@@ -1773,12 +1773,12 @@ class Container(Base):
     def __setitem__(self, view, newdata):
         """
         Set content given by view.
-        
+
         Parameters
         ----------
         view : View
                A valid :any:`View` for this object
-               
+
         newdata : array_like
                   The data to be stored 2D.
         """
@@ -1795,19 +1795,19 @@ class Container(Base):
     def info(self):
         """
         Returns the container's total buffer space in bytes and storage info.
-        
+
         Returns
         -------
         space : int
             Accumulated memory usage of all data buffers in this Container
-            
+
         fstring : str
-            Formatted string 
-            
+            Formatted string
+
         Note
         ----
         May get **deprecated** in future. Use formatted_report instead.
-        
+
         See also
         --------
         report
@@ -1884,10 +1884,10 @@ class Container(Base):
 class POD(Base):
     """
     POD : Ptychographic Object Descriptor
-    
+
     A POD brings together probe view, object view and diff view. It also
     gives access to "exit", a (coherent) exit wave, and to propagation
-    objects to go from exit to diff space. 
+    objects to go from exit to diff space.
     """
     #: Default set of :any:`View`\ s used by a POD
     DEFAULT_VIEWS = {'probe': None,
@@ -1904,14 +1904,14 @@ class POD(Base):
         Parameters
         ----------
         ptycho : Ptycho
-            The instance of Ptycho associated with this pod. 
-            
+            The instance of Ptycho associated with this pod.
+
         ID : str or int
             The pod ID, If None it is managed by the ptycho.
-            
+
         views : dict or Param
             The views. See :py:attr:`DEFAULT_VIEWS`.
-            
+
         geometry : Geo
             Geometry class instance and attached propagator
 
@@ -1942,11 +1942,11 @@ class POD(Base):
 
         # Convenience access for all views. Note: assignment of the type
         # pod.ob_view = some_view should not be done because consistence with
-        # self.V is not ensured. If this kind of assignment turns out to 
+        # self.V is not ensured. If this kind of assignment turns out to
         # be useful, we should consider declaring ??_view as @property.
         self.ob_view = self.V['obj']
         self.pr_view = self.V['probe']
-        """ A reference to the (pr)obe-view. (ob)ject-, (ma)sk- and 
+        """ A reference to the (pr)obe-view. (ob)ject-, (ma)sk- and
         (di)ff-view are accessible in the same manner (``self.xx_view``). """
 
         self.di_view = self.V['diff']
@@ -1977,7 +1977,7 @@ class POD(Base):
     @property
     def fw(self):
         """
-        Convenience property that returns forward propagator of attached 
+        Convenience property that returns forward propagator of attached
         Geometry instance. Equivalent to ``self.geometry.propagator.fw``.
         """
         return self.geometry.propagator.fw
@@ -1985,7 +1985,7 @@ class POD(Base):
     @property
     def bw(self):
         """
-        Convenience property that returns backward propagator of attached 
+        Convenience property that returns backward propagator of attached
         Geometry instance. Equivalent to ``self.geometry.propagator.bw``.
         """
         return self.geometry.propagator.bw
@@ -2020,7 +2020,7 @@ class POD(Base):
     @property
     def exit(self):
         """
-        Convenience property that links to slice of exit wave 
+        Convenience property that links to slice of exit wave
         :any:`Storage`. Equivalent to ``self.pr_view.data``.
         """
         if self.use_exit_container:
@@ -2038,7 +2038,7 @@ class POD(Base):
     @property
     def diff(self):
         """
-        Convenience property that links to slice of diffraction 
+        Convenience property that links to slice of diffraction
         :any:`Storage`. Equivalent to ``self.di_view.data``.
         """
         return self.di_view.data
@@ -2050,7 +2050,7 @@ class POD(Base):
     @property
     def mask(self):
         """
-        Convenience property that links to slice of masking 
+        Convenience property that links to slice of masking
         :any:`Storage`. Equivalent to ``self.ma_view.data``.
         """
         return self.ma_view.data

--- a/ptypy/core/data.py
+++ b/ptypy/core/data.py
@@ -17,30 +17,23 @@ This file is part of the PTYPY package.
     :copyright: Copyright 2014 by the PTYPY team, see AUTHORS.
     :license: GPLv2, see LICENSE for details.
 """
+from ..utils import parallel
+from ptypy import resources
+from ptypy.core import xy
+import numpy as np
+import os
+import h5py
 if __name__ == "__main__":
     from ptypy import utils as u
     from ptypy import io
-    from ptypy import resources
     from ptypy.core import geometry
     from ptypy.utils.verbose import logger, log, headerline
-    from ..utils import parallel
-    from ptypy import resources
-    from ptypy.core import xy
-    import numpy as np
-    import os
-    import h5py
 else:
     from .. import utils as u
     from .. import io
     from .. import resources
     from ..utils.verbose import logger, log, headerline
-    from ..utils import parallel
-    from ptypy import resources
-    from ptypy.core import xy
     import geometry
-    import numpy as np
-    import os
-    import h5py
 
 PTYD = dict(
     # frames, positions

--- a/ptypy/core/data.py
+++ b/ptypy/core/data.py
@@ -1,13 +1,13 @@
 """
 data - Diffraction data access.
 
-This module defines a PtyScan, a container to hold the experimental 
+This module defines a PtyScan, a container to hold the experimental
 data of a ptychography scan. Instrument-specific reduction routines should
 inherit PtyScan to prepare data for the Ptycho Instance in a uniform format.
 
 The experiment specific child class only needs to overwrite 2 functions
 of the base class:
-        
+
 For the moment the module contains two main objects:
 PtyScan, which holds a single ptychography scan, and DataSource, which
 holds a collection of datascans and feeds the data as required.
@@ -109,16 +109,16 @@ __all__ = ['GENERIC', 'PtyScan', 'PTYD', 'PtydScan', 'MoonFlowerScan']
 class PtyScan(object):
     """
     PtyScan: A single ptychography scan, created on the fly or read from file.
-    
+
     *BASECLASS*
-    
+
     Objectives:
      - Stand alone functionality
      - Can produce .ptyd data formats
      - Child instances should be able to prepare from raw data
      - On-the-fly support in form of chunked data.
      - mpi capable, child classes should not worry about mpi
-     
+
     """
 
     DEFAULT = GENERIC.copy()
@@ -129,9 +129,9 @@ class PtyScan(object):
     def __init__(self, pars=None, **kwargs):
         # filename='./foo.ptyd', shape=None, save=True):
         """
-        Class creation with minimum set of parameters, see :py:data:`GENERIC` 
+        Class creation with minimum set of parameters, see :py:data:`GENERIC`
         Please note that class creation is not meant to load data.
-        
+
         Call :py:data:`initialize` to begin loading and data file creation.
         """
         # Load default parameter structure
@@ -224,19 +224,19 @@ class PtyScan(object):
         # Initialize flags
         self._flags = np.array([0, 0, 0], dtype=int)
         self.is_initialized = False
-        
+
         # post init method call
         self.post_init()
-        
+
     def initialize(self):
         """
-        Begins the Data preparation and intended as the first method 
+        Begins the Data preparation and intended as the first method
         that does read-write access on (large) data. Does the following:
-        
-        * Creates a \*.ptyd data file at location specified by 
+
+        * Creates a \*.ptyd data file at location specified by
           :py:data:`dfile` (master node only)
         * Calls :py:meth:`load_weight`, :py:meth:`load_positions`
-          :py:meth:`load_common` (master node only for 
+          :py:meth:`load_common` (master node only for
           ``load_parallel==None`` or ``load_parallel=='data'``)
         * Sets :py:attr:`num_frames` if needed
         * Calls :py:meth:`post_initialize`
@@ -330,8 +330,8 @@ class PtyScan(object):
         if self.num_frames is None:
             logger.warning(
                 'Number of frames `num_frames` not specified at this stage.')
-        
-        # A note about how much this scan class knows about the number 
+
+        # A note about how much this scan class knows about the number
         # of frames expected. PtydScan uses this information.
         self.info.num_frames_actual = self.num_frames
         parallel.barrier()
@@ -341,7 +341,7 @@ class PtyScan(object):
         parallel.barrier()
         logger.info(headerline('Analysis done',' l') + '\n')
         """
-        
+
         if self.info.save is not None and parallel.master:
             logger.info('Appending info dict to file %s\n' % self.info.dfile)
             io.h5append(self.info.dfile, info=dict(self.info))
@@ -363,31 +363,31 @@ class PtyScan(object):
     def load_weight(self):
         """
         **Override in subclass for custom implementation**
-        
+
         *Called in* :py:meth:`initialize`
-        
+
         Loads a common (2d)-weight for all diffraction patterns. The weight
         loaded here will be available by all processes through the
         attribute ``self.weight2d``. If a *per-frame-weight* is specified
-        in :py:meth:`load` , this function has no effect. 
-        
+        in :py:meth:`load` , this function has no effect.
+
         The purpose of this function is to avoid reloading and parallel
         reads. If that is not critical to the implementation,
         reimplementing this function in a subclass can be ignored.
-        
-        If `load_parallel` is set to `all` or common`, this function is 
+
+        If `load_parallel` is set to `all` or common`, this function is
         executed by all nodes, otherwise the master node executes this
         function and broadcasts the results to other nodes.
-        
+
         Returns
         -------
         weight2d : ndarray
             A two-dimensional array with a shape compatible to the raw
             diffraction data frames
-            
+
         Note
         ----
-        For now, weights will be converted to a mask, 
+        For now, weights will be converted to a mask,
         ``mask = weight2d > 0`` for use in reconstruction algorithms.
         It is planned to use a general weight instead of a mask in future
         releases.
@@ -400,45 +400,45 @@ class PtyScan(object):
     def load_positions(self):
         """
         **Override in subclass for custom implementation**
-        
+
         *Called in* :py:meth:`initialize`
-        
-        Loads all positions for all diffraction patterns in this scan. 
-        The positions loaded here will be available by all processes 
+
+        Loads all positions for all diffraction patterns in this scan.
+        The positions loaded here will be available by all processes
         through the attribute ``self.positions``. If you specify position
-        on a per frame basis in :py:meth:`load` , this function has no 
+        on a per frame basis in :py:meth:`load` , this function has no
         effect.
-        
-        If theoretical positions :py:data:`positions_theory` are 
-        provided in the initial parameter set :py:data:`DEFAULT`, 
+
+        If theoretical positions :py:data:`positions_theory` are
+        provided in the initial parameter set :py:data:`DEFAULT`,
         specifying positions here has NO effect and will be ignored.
-        
+
         The purpose of this function is to avoid reloading and parallel
         reads on files that may require intense parsing to retrieve the
-        information, e.g. long SPEC log files. If parallel reads or 
+        information, e.g. long SPEC log files. If parallel reads or
         log file parsing for each set of frames is not a time critical
         issue of the subclass, reimplementing this function can be ignored
         and it is recommended to only reimplement the :py:meth:`load`
         method.
-        
-        If `load_parallel` is set to `all` or common`, this function is 
+
+        If `load_parallel` is set to `all` or common`, this function is
         executed by all nodes, otherwise the master node executes this
         function and broadcasts the results to other nodes.
-        
+
         Returns
         -------
         positions : ndarray
             A (N,2)-array where *N* is the number of positions.
-            
+
         Note
         ----
         Be aware that this method sets attribute :py:attr:`num_frames`
         in the following manner.
-        
+
         * If ``num_frames == None`` : ``num_frames = N``.
         * If ``num_frames < N`` , no effect.
         * If ``num_frames > N`` : ``num_frames = N``.
-         
+
         """
         if self.num_frames is None:
             return None
@@ -448,26 +448,26 @@ class PtyScan(object):
     def load_common(self):
         """
         **Override in subclass for custom implementation**
-        
+
         *Called in* :py:meth:`initialize`
-        
+
         Loads anything and stores that in a dict. This dict will be
         available to all processes after :py:meth:`initialize` through
         the attribute :py:attr:`common`
-        
+
         The purpose of this method is the same as :py:meth:`load_weight`
         and :py:meth:`load_positions` except for that the contents
         of :py:attr:`common` have no built-in effect of the behavior in
         the processing other than the user specifies it in py:meth:`load`
-        
-        If `load_parallel` is set to `all` or common`, this function is 
+
+        If `load_parallel` is set to `all` or common`, this function is
         executed by all nodes, otherwise the master node executes this
         function and broadcasts the results to other nodes.
-        
+
         Returns
         -------
-        common : dict 
-                    
+        common : dict
+
         """
         return {}
 
@@ -475,8 +475,8 @@ class PtyScan(object):
         """
         Placeholder. Called at the end of :py:meth:`initialize` by all
         processes.
-        
-        Use this method to benefit from 'hard-to-retrieve but now available' 
+
+        Use this method to benefit from 'hard-to-retrieve but now available'
         information after initialize.
         """
         pass
@@ -494,10 +494,10 @@ class PtyScan(object):
         the result with the other nodes.
         This function determines if the end of the scan is reached
         or if there is more data after a pause.
-        
+
         returns:
             - codes WAIT or EOS
-            - or (start, frames) if data can be loaded 
+            - or (start, frames) if data can be loaded
         """
         # Take internal counter if not specified
         s = self.framestart if start is None else int(start)
@@ -805,7 +805,7 @@ class PtyScan(object):
     def auto(self, frames, chunk_form='dp'):
         """
         Repeated calls to this function will process the data.
-        
+
         Parameters
         ----------
         frames : int
@@ -883,13 +883,13 @@ class PtyScan(object):
     def _mpi_pipeline_with_dictionaries(self, indices):
         """
         Example processing pipeline using dictionaries.
-        
+
         return :
             positions, data, weights
              -- Dictionaries. Keys are the respective scan point indices
                 `positions` and `weights` may be empty. If so, the information
                 is taken from the self.common dictionary
-        
+
         """
         if self.load_in_parallel:
             # All nodes load raw_data and slice according to indices
@@ -908,7 +908,7 @@ class PtyScan(object):
             raw = parallel.bcast_dict(raw, indices.node)
             weights = parallel.bcast_dict(weights, indices.node)
 
-        # (re)distribute position information - every node should now be 
+        # (re)distribute position information - every node should now be
         # aware of all positions
         parallel.bcast_dict(pos)
 
@@ -920,40 +920,40 @@ class PtyScan(object):
     def check(self, frames=None, start=None):
         """
         **Override in subclass for custom implementation**
-        
+
         This method checks how many frames the preparation routine may
         process, starting from frame `start` at a request of `frames`.
-        
+
         This method is supposed to return the number of accessible frames
         for preparation and should determine if data acquisition for this
         scan is finished. Its main purpose is to allow for a data
-        acquisition scheme, where the number of frames is not known 
-        when :any:`PtyScan` is constructed, i.e. a data stream or an 
+        acquisition scheme, where the number of frames is not known
+        when :any:`PtyScan` is constructed, i.e. a data stream or an
         on-the-fly reconstructions.
-        
+
         Note
         ----
         If :py:data:`num_frames` is set on ``__init__()`` of the subclass,
         this method can be left as it is.
-        
+
         Parameters
         ----------
-        frames : int or None 
+        frames : int or None
             Number of frames requested.
         start : int or None
             Scanpoint index to start checking from.
-        
-        Returns 
+
+        Returns
         -------
         frames_accessible : int
             Number of frames readable.
-        
+
         end_of_scan : int or None
             is one of the following,
             - 0, end of the scan is not reached
             - 1, end of scan will be reached or is
             - None, can't say
-                    
+
         """
         if start is None:
             start = self.framestart
@@ -992,17 +992,17 @@ class PtyScan(object):
     def load(self, indices):
         """
         **Override in subclass for custom implementation**
-        
+
         Loads data according to node specific scanpoint indices that have
         been determined by :py:class:`LoadManager` or otherwise.
-        
+
         Returns
         -------
         raw, positions, weight : dict
-            Dictionaries whose keys are the given scan point `indices` 
-            and whose values are the respective frame / position according 
+            Dictionaries whose keys are the given scan point `indices`
+            and whose values are the respective frame / position according
             to the scan point index. `weight` and `positions` may be empty
-            
+
         Note
         ----
         This is the *most* important method to change when subclassing
@@ -1020,18 +1020,18 @@ class PtyScan(object):
     def correct(self, raw, weights, common):
         """
         **Override in subclass for custom implementation**
-        
-        Place holder for dark and flatfield correction. If :any:`load` 
+
+        Place holder for dark and flatfield correction. If :any:`load`
         already provides data in the form of photon counts, and no frame
         specific weight is needed, this method may be left as it is.
-        
+
         May get *merged* with :any:`load` in future.
-    
+
         Returns
         -------
         data, weights : dict
             Flat and dark-corrected data dictionaries. These dictionaries
-            must have the same keys as the input `raw` and contain 
+            must have the same keys as the input `raw` and contain
             corrected frames (`data`) and statistical weights (`weights`)
             which are zero for invalid or masked pixel other the number
             of detector counts that correspond to one photon count
@@ -1084,25 +1084,25 @@ class PtyScan(object):
 
         It works by gathering weights and data to the master node.
         Master node then writes to disk.
-        
-        In case you support parallel hdf5 writing, please modify this 
+
+        In case you support parallel hdf5 writing, please modify this
         function to suit your installation.
-        
+
         2 out of 3 modes currently supported
-        
+
         kind : 'merge','append','link'
-            
+
             'append' : appends chunks of data in same file
             'link' : saves chunks in separate files and adds ExternalLinks
-            
-        TODO: 
+
+        TODO:
             * For the 'link case, saving still requires access to
               main file `dfile` even so for just adding the link.
               This may result in conflict if main file is polled often
               by separate read process.
               Workaround would be to write the links on startup in
-              initialise() 
-            
+              initialise()
+
         """
         # Gather all distributed dictionary data.
         c = chunk if chunk is not None else self.chunk
@@ -1136,7 +1136,7 @@ class PtyScan(object):
                 h5address = 'chunks/%d' % num
                 hddaddress = self.dfile + '.part%03d' % num
                 io.h5write(hddaddress, todisk)
-                
+
                 with h5py.File(self.dfile) as f:
                     f[h5address] = h5py.ExternalLink(hddaddress, '/')
                     f.close()
@@ -1156,10 +1156,10 @@ class PtydScan(PtyScan):
     def __init__(self, pars=None, source=None, **kwargs):
         """
         PtyScan provided by native "ptyd" file format.
-        
-        :param source: Explicit source file. If not None or 'file', 
+
+        :param source: Explicit source file. If not None or 'file',
                        the data may get processed depending on user input
-                       
+
         :param pars: Input like PtyScan
         """
         # Create parameter set
@@ -1208,22 +1208,22 @@ class PtydScan(PtyScan):
             # Get number of frames supposedly in the file
             source_frames = f.get('info/num_frames_actual')[...].item()
             f.close()
-            
-        if check is None: 
+
+        if check is None:
             raise IOError('Ptyd source %s contains no data. Load aborted'
                           % source)
-        
+
         if source_frames is None:
             logger.warning('Ptyd source is not aware of the total'
                            'number of diffraction frames expected')
 
         # Get meta information
         meta = u.Param(io.h5read(self.source, 'meta')['meta'])
-        
+
         if len(meta) == 0:
             logger.warning('There should be meta information in '
                            '%s. Something is odd here.' % source)
-        
+
         # Update given parameters when they are None
         if not manipulate:
             super(PtydScan, self).__init__(meta, **kwargs)
@@ -1242,10 +1242,10 @@ class PtydScan(PtyScan):
                 self.num_frames = source_frames
         else:
             # Ptyd source doesn't know its total number of frames
-            # but we cannot do anything about it. This should be dealt 
+            # but we cannot do anything about it. This should be dealt
             # with with a flag in the meta package probably.
             pass
-            
+
         # Other instance attributes
         self._checked = {}
         self._ch_frame_ind = None
@@ -1253,7 +1253,7 @@ class PtydScan(PtyScan):
     def check(self, frames=None, start=None):
         """
         Implementation of the check routine for a .ptyd file format.
-        
+
         See also
         --------
         PtyScan.check
@@ -1278,7 +1278,7 @@ class PtydScan(PtyScan):
             for ch_key in ch_items[0][1].keys():
                 d[ch_key] = np.array([(int(k),) + v[ch_key].shape
                                       for k, v in ch_items if v is not None])
-                    
+
             f.close()
 
         self._checked = d
@@ -1289,7 +1289,7 @@ class PtydScan(PtyScan):
                 ch_frame_ind.append((dd[0], frame))
 
         self._ch_frame_ind = np.array(ch_frame_ind)
-        
+
         # Accessible frames
         frames_accessible = min((frames, all_frames - start))
         # end_of_scan = source_frames <= start + frames_accessible
@@ -1362,7 +1362,7 @@ class MoonFlowerScan(PtyScan):
 
     def __init__(self, pars=None, **kwargs):
         """
-        Parent pars are for the 
+        Parent pars are for the
         """
         p = geometry.DEFAULT.copy()
         if pars is not None:
@@ -1439,14 +1439,14 @@ class DataSource(object):
 
         Parameters
         ----------
-        scans : 
+        scans :
             a dictionary of scan structures.
-        
-        frames_per_call : (optional) 
+
+        frames_per_call : (optional)
             number of frames to load in one call.
             By default, load as many as possible.
-        
-        feed_format : 
+
+        feed_format :
             the format in with the data is packaged.
             For now only 'dp' is implemented.
         """

--- a/ptypy/core/data_old.py
+++ b/ptypy/core/data_old.py
@@ -1,13 +1,13 @@
 """
 data - Diffraction data access
 
-This module defines a PtyScan, a container to hold the experimental 
+This module defines a PtyScan, a container to hold the experimental
 data of a ptychography scan. Instrument-specific reduction routines should
 inherit PtyScan to prepare data for the Ptycho Instance in a uniform format.
 
 The experiment specific child class only needs to overwrite 2 functions
 of the base class:
-        
+
 For the moment the module contains two main objects:
 PtyScan, which holds a single ptychography scan, and DataSource, which
 holds a collection of datascans and feeds the data as required.
@@ -48,7 +48,7 @@ PTYD = dict(
 """ Basic Structure of a .ptyd datafile """
 
 META = dict(
-    label=None,   # label will be set internally 
+    label=None,   # label will be set internally
     experimentID=None, # a unique label of user choice
     version='0.1',
     shape=None,
@@ -63,7 +63,7 @@ GENERIC = dict(
     chunk_format='.chunk%02d',  # Format for chunk file appendix.
     #roi = None,  # 2-tuple or int for the desired fina frame size
     save = None,  # None, 'merge', 'append', 'extlink'
-    auto_center = None,  # False: no automatic center,None only  if center is None, True it will be enforced   
+    auto_center = None,  # False: no automatic center,None only  if center is None, True it will be enforced
     load_parallel = 'data',  # None, 'data', 'common', 'all'
     rebin = None,  # rebin diffraction data
     orientation = None,  # None,int or 3-tuple switch, actions are (transpose, invert rows, invert cols)
@@ -90,14 +90,14 @@ class PtyScan(object):
     """\
     PtyScan: A single ptychography scan, created on the fly or read from file.
     BASECLASS
-    
+
     Objectives:
      - Stand alone functionality
      - Can produce .ptyd data formats
      - Child instances should be able to prepare from raw data
      - On-the-fly support in form of chunked data.
      - mpi capable, child classes should not worry about mpi
-     
+
     """
 
     DEFAULTS = GENERIC
@@ -146,7 +146,7 @@ class PtyScan(object):
         # None for rebin should be allowed, as in "don't rebin".
         if info.rebin is None:
             info.rebin = 1
-        
+
         self.info = info
 
         # Print a report
@@ -174,7 +174,7 @@ class PtyScan(object):
         self.has_positions = None
         self.dfile = None
         self.save = self.info.save
-        
+
         # copy all values for meta
         for k in self.meta.keys():
             self.meta[k] = self.info[k]
@@ -212,8 +212,8 @@ class PtyScan(object):
             # FIXME
             # Replace Nones, because we cannot broadcast them later
             # I don't get it, why didn't we allow for a missing key?
-            # Also I disagree that we should enforce a 'weight2d' or 
-            # positions. The user can very well add them later. 
+            # Also I disagree that we should enforce a 'weight2d' or
+            # positions. The user can very well add them later.
             self.common = dict([(k,v) if v is not None else (k,np.array([])) for k,v in self.common.items() ])
 
         # broadcast
@@ -222,14 +222,14 @@ class PtyScan(object):
 
         self.common = u.Param(self.common)
         assert 'weight2d' in self.common and 'positions_scan' in self.common
-            
+
         logger.info('\n'+headerline('Analysis of the "common" arrays','l'))
         # Check if weights (or mask) have been loaded by load_common.
         weight2d = self.common.weight2d
         self.has_weight2d = weight2d is not None and len(weight2d)>0
         logger.info('Check for weight or mask,  "weight2d"  .... %s : shape = %s' % (str(self.has_weight2d),str(weight2d.shape)))
 
-            
+
         # Check if positions have been loaded by load_common
         positions = self.common.positions_scan
         self.has_positions = positions is not None and len(positions)>0
@@ -260,12 +260,12 @@ class PtyScan(object):
                     #                    % (num_pos, self.info.num_frames))
         else:
             logger.info('No scanning position have been provided at this stage.')
-        
+
         if self.num_frames is None:
             logger.warning('Number of frames `num_frames` not specified at this stage\n.')
-        
+
         parallel.barrier()
-        
+
         #logger.info('#######  MPI Report: ########\n')
         log(4,u.verbose.report(self.common),True)
         parallel.barrier()
@@ -290,39 +290,39 @@ class PtyScan(object):
     def load_common(self):
         """
         **Overwrite in child class**
-        
-        Loads arrays that are common and needed for preparation of all 
-        other data frames coming in. Any array loaded here and returned 
-        in a dict will be distributed afterwards through a broadcoast. 
+
+        Loads arrays that are common and needed for preparation of all
+        other data frames coming in. Any array loaded here and returned
+        in a dict will be distributed afterwards through a broadcoast.
         It is not intended to load diffraction data in this step.
-        
+
         The main purpose is that there may be common data to all processes, that
         is slow to retrieve or large files, such that if all processes
-        attempt to get the data, perfomance will decline or RAM usage 
+        attempt to get the data, perfomance will decline or RAM usage
         may be too large.
-                       
+
         It is a good idea to load dark field, flat field, etc
         Also positions may be handy to load here
-        
-        If `load_parallel` is set to `all` or common`, this function is 
+
+        If `load_parallel` is set to `all` or common`, this function is
         executed by all nodes, otherwise the master node executes this
-        function and braodcasts the results to other nodes. 
-        
+        function and braodcasts the results to other nodes.
+
         Returns
         -------
         common : dict of numpy arrays
-            At least two keys, `weight2d` and `positions_scan` must be 
+            At least two keys, `weight2d` and `positions_scan` must be
             given (they can be None). The return dictionary is available
             throught
-                    
+
         Note
         ----
-        The return signature of this function is not yet fixed and may 
+        The return signature of this function is not yet fixed and may
         get altered in near future. One Option would be to include
         `weight2d` and `positions_scan` as part of the return signature
         and thus fixing them in the Base class.
         """
-        weight2d = None if self.info.shape is None else np.ones(u.expect2(self.info.shape), dtype='bool') 
+        weight2d = None if self.info.shape is None else np.ones(u.expect2(self.info.shape), dtype='bool')
         positions_scan = None if self.num_frames is None else np.indices((self.num_frames, 2)).sum(0)
         return {'weight2d': weight2d,
                 'positions_scan': positions_scan}
@@ -333,10 +333,10 @@ class PtyScan(object):
         the result with the other nodes.
         This function determines if the end of the scan is reached
         or if there is more data after a pause.
-        
+
         returns:
             - codes WAIT or EOS
-            - or (start, frames) if data can be loaded 
+            - or (start, frames) if data can be loaded
         """
         # take internal counter if not specified
         s = self.framestart if start is None else int(start)
@@ -352,11 +352,11 @@ class PtyScan(object):
         parallel.barrier()
         # communicate result
         self._flags = parallel.bcast(self._flags)
-        
+
         # abort here if the flag was set
         if self.abort:
             raise RuntimeError('Load routine incapable to determine end-of-scan.')
-            
+
         N = self.frames_accessible
         # wait if too few frames are available and we are not at the end
         if N < self.min_frames and not self.end_of_scan:
@@ -408,8 +408,8 @@ class PtyScan(object):
             data, positions, weights = self._mpi_pipeline_with_dictionaries(indices)
             # all these dictionaries could be empty
             # fill weights dictionary with references to the weights in common
-            
-            has_data = (len(data) > 0) 
+
+            has_data = (len(data) > 0)
             has_weights = (len(weights) > 0) and len(weights.values()[0])>0
 
             if has_data:
@@ -432,7 +432,7 @@ class PtyScan(object):
                 weights = dict.fromkeys(data.keys(), altweight)
 
             assert len(weights) == len(data), 'Data and Weight frames unbalanced %d vs %d' % (len(data), len(weights))
-                       
+
             sh = self.info.shape
             # adapt roi if not set
             if sh is None:
@@ -440,26 +440,26 @@ class PtyScan(object):
                 sh = dsh
             else:
                 sh = u.expect2(sh)
-                
+
             # only allow square slices in data
             if sh[0] != sh[1]:
                 roi = u.expect2(sh.min())
                 logger.warning('Asymmetric data ROI not allowed. Setting ROI from (%d,%d) to (%d,%d)' % (sh[0],sh[1],roi[0],roi[1]))
                 sh = roi
-            
+
             self.info.shape = sh
 
             cen = self.info.center
             if str(cen)==cen:
                 cen=geometry.translate_to_pix(sh,cen)
-                
-            auto = self.info.auto_center 
+
+            auto = self.info.auto_center
             # get center in diffraction image
             if auto is None or auto is True:
                 auto_cen = self._mpi_autocenter(data, weights)
             else:
                 auto_cen = None
-                
+
             if cen is None and auto_cen is not None:
                 logger.info('Setting center for ROI from %s to %s.' %(str(cen),str(auto_cen)))
                 cen = auto_cen
@@ -470,11 +470,11 @@ class PtyScan(object):
                 cen = u.expect2(cen[-2:])
                 if auto_cen is not None:
                     logger.info('ROI center is %s, automatic guess is %s.' %(str(cen),str(auto_cen)))
-                    
+
             # It is important to set center again in order to NOT have different centers for each chunk
             # the downside is that the center may be off if only a few diffraction patterns were
             # used for the analysis. In such case it is beneficial to set the center in the parameters
-            self.info.center = cen  
+            self.info.center = cen
 
             # make sure center is in the image frame
             assert (cen > 0).all() and (
@@ -490,12 +490,12 @@ class PtyScan(object):
                             (str(do_crop), str(do_flip), str(do_rebin)))
                 # we proceed with numpy arrays. That is probably now
                 # more memory intensive but shorter in writing
-                if has_data:                       
+                if has_data:
                     d = np.array([data[ind] for ind in indices.node])
                     w = np.array([weights[ind] for ind in indices.node])
                 else:
                     d = np.ones((1,)+tuple(dsh))
-                    w = np.ones((1,)+tuple(dsh))    
+                    w = np.ones((1,)+tuple(dsh))
 
                 # flip, rotate etc.
                 d, tmp = u.switch_orientation(d, self.orientation, cen)
@@ -517,7 +517,7 @@ class PtyScan(object):
                     w[mask < 1] = 0
                 else:
                     raise RuntimeError('Binning (%d) is to large or incompatible with array shape (%s)' % (rebin,str(tuple(sh))))
-                                    
+
                 if has_data:
                     # translate back to dictionaries
                     data = dict(zip(indices.node, d))
@@ -527,7 +527,7 @@ class PtyScan(object):
             self.meta.center = cen / float(self.rebin)
             self.meta.shape = u.expect2(sh) / self.rebin
             self.meta.psize = u.expect2(self.info.psize) * self.rebin if self.info.psize is not None else None
-            
+
             # prepare chunk of data
             chunk = u.Param()
             chunk.indices = indices.chunk
@@ -535,7 +535,7 @@ class PtyScan(object):
             chunk.num = self.chunknum
             chunk.data = data
 
-            # if there were weights we add them to chunk, 
+            # if there were weights we add them to chunk,
             # otherwise we push it into meta
             if has_weights:
                 chunk.weights = weights
@@ -569,7 +569,7 @@ class PtyScan(object):
                     self.meta[k] = self.__dict__.get(k, self.info.get(k)) if v is None else v
                 self.meta['center'] = cen
                 """
-                
+
                 if self.info.save is not None and parallel.master:
                     io.h5append(self.dfile, meta=dict(self.meta))
                 parallel.barrier()
@@ -582,12 +582,12 @@ class PtyScan(object):
     def auto(self, frames, chunk_form='dp'):
         """
         Repeated calls to this function will process the data
-        
+
         Parameters
         ----------
         frames : int
             Number of frames to process.
-            
+
         Returns
         -------
         variable
@@ -651,13 +651,13 @@ class PtyScan(object):
     def _mpi_pipeline_with_dictionaries(self, indices):
         """
         example processing pipeline using dictionaries.
-        
+
         return :
             positions, data, weights
              -- Dictionaries. Keys are the respective scan point indices
                 `positions` and `weights` may be empty. If so, the information
                 is taken from the self.common dictionary
-        
+
         """
         if self.load_in_parallel:
             # all nodes load raw_data and slice according to indices
@@ -676,11 +676,11 @@ class PtyScan(object):
             raw = parallel.bcast_dict(raw, indices.node)
             weights = parallel.bcast_dict(weights, indices.node)
 
-        # (re)distribute position information - every node should now be 
+        # (re)distribute position information - every node should now be
         # aware of all positions
         parallel.bcast_dict(pos)
 
-        # prepare data across nodes    
+        # prepare data across nodes
         data, weights = self.correct(raw, weights, self.common)
 
         return data, pos, weights
@@ -688,31 +688,31 @@ class PtyScan(object):
     def check(self, frames=None, start=None):
         """
         **Overwrite in child class**
-        
+
         This method checks how many frames the preparation routine may
         process, starting from frame `start` at a request of `frames_requested`.
-        
+
         This method is supposed to return the number of accessible frames
         for preparation and should determine if data acquistion for this
         scan is finished.
-        
+
         Parameters
         ----------
-        frames : int or None 
+        frames : int or None
             Number of frames requested.
         start : int or None
             Scanpoint index to start checking from.
-        
-        Returns 
+
+        Returns
         -------
         frames_accessible : int
-            Number of frames readable.  
+            Number of frames readable.
         end_of_scan : int or None
             is one of the following:
              - 0, end of the scan is not reached
              - 1, end of scan will be reached or is
              - None, can't say
-                    
+
         """
         if start is None:
             start = self.framestart
@@ -738,7 +738,7 @@ class PtyScan(object):
     @frames_accessible.setter
     def frames_accessible(self, frames):
         self._flags[0] = frames
-    
+
     @property
     def abort(self):
         return not (self._flags[2] == 0)
@@ -750,15 +750,15 @@ class PtyScan(object):
     def load(self, indices):
         """
         **Overwrite in child class**
-        
-        Loads data according to node specific scanpoint indeces that have 
+
+        Loads data according to node specific scanpoint indeces that have
         been determined by the loadmanager from utils.parallel or otherwise
-    
+
         Returns
         -------
         raw, positions, weight : dict
-            Dictionaries whose keys are the given scan point `indices` 
-            and whose values are the respective frame / position according 
+            Dictionaries whose keys are the given scan point `indices`
+            and whose values are the respective frame / position according
             to the scan point index. `weight` and `positions` may be empty
         """
         # dummy fill
@@ -768,18 +768,18 @@ class PtyScan(object):
     def correct(self, raw, weights, common):
         """
         **Overwrite in child class**
-        
-        Place holder for dark and flatfield correction. If :any:`load` 
+
+        Place holder for dark and flatfield correction. If :any:`load`
         already provides data in the form of photon counts, and no frame
         specific weight is needed, this method may be left as is
-        
+
         May get *merged* with :any:`load` in future.
-    
+
         Returns
         -------
         data,weights : dict
             Flat and dark-corrected data dictionaries. These dictionaries
-            must have the same keys as the input `raw` and contain 
+            must have the same keys as the input `raw` and contain
             corrected frames (`data`) and statistical weights (`weights`)
             which are zero for invalid or masked pixel other the number
             of detector counts that correspond to one photon count
@@ -822,29 +822,29 @@ class PtyScan(object):
         Saves data chunk to hdf5 file specified with `dfile`
         It works by gathering weights and data to the master node.
         Master node then writes to disk.
-        
-        In case you support parallel hdf5 writing, please modify this 
+
+        In case you support parallel hdf5 writing, please modify this
         function to suit your installation.
-        
+
         2 out of 3 modes currently supported
-        
+
         kind : 'merge','append','link'
-            
+
             'append' : appends chunks of data in same file
             'link' : saves chunks in seperate files and adds ExternalLinks
-            
-        TODO: 
+
+        TODO:
             * For the 'link case, saving still requires access to
               main file `dfile` even so for just adding the link.
               This may result in conflict if main file is polled often
               by seperate read process.
               Workaraound would be to write the links on startup in
-              initialise() 
-            
+              initialise()
+
         """
         # gather all distributed dictionary data.
         c = chunk if chunk is not None else self.chunk
-        
+
         # shallow copy
         todisk = dict(c)
         num = todisk.pop('num')
@@ -880,20 +880,20 @@ class PtyScan(object):
             elif str(kind) == 'merge':
                 raise NotImplementedError('Merging all data into single chunk is not yet implemented')
         parallel.barrier()
-        
+
 class PtydScan(PtyScan):
     """
     PtyScan provided by native "ptyd" file format.
     """
     DEFAULT = GENERIC.copy()
-    
+
     def __init__(self, pars=None, source=None,**kwargs):
         """
         PtyScan provided by native "ptyd" file format.
-        
-        :param source: Explicit source file. If not None or 'file', 
+
+        :param source: Explicit source file. If not None or 'file',
                        the data may get processed depending on user input
-                       
+
         :param pars: Input like PtyScan
         """
         # create parameter set
@@ -902,7 +902,7 @@ class PtydScan(PtyScan):
         # copy the label
         #if pars is not None:
         #    p.label = pars.get('label')
-        
+
         if source is None or str(source)=='file':
             # this is the case of absolutely no additional work
             logger.info('No explicit source file was given. Will continue read only')
@@ -920,20 +920,20 @@ class PtydScan(PtyScan):
                 dfile = os.path.splitext(dfile)
                 dfile = dfile[0] +'_n.'+ dfile[1]
                 logger.info('Will instead save to %s if necessary.' % os.path.split(dfile)[1])
-            
+
             pars['dfile']= dfile
             manipulate = True
             p.update(pars)
-            
-        
+
+
         # make sure the source exists.
         assert os.path.exists(u.unique_path(source)), 'Source File (%s) not found' % source
-        
+
         self.source = source
-        
+
         # get meta information
         meta = u.Param(io.h5read(self.source, 'meta')['meta'])
-        
+
         # update given parameters when they are None
         if not manipulate:
             super(PtydScan, self).__init__(meta,  **kwargs)
@@ -944,7 +944,7 @@ class PtydScan(PtyScan):
                     p[k] = v
             # Initialize parent class and fill self
             super(PtydScan, self).__init__(p, **kwargs)
-        
+
         # enforce that orientations are correct
         # Other instance attributes
         self._checked = {}
@@ -954,7 +954,7 @@ class PtydScan(PtyScan):
     def check(self, frames=None, start=None):
         """
         Implementation of the check routine for a .ptyd file format
-        
+
         See also
         --------
         Ptyscan.check
@@ -992,7 +992,7 @@ class PtydScan(PtyScan):
 
     def load(self, indices):
         """
-        Load from ptyd. Due to possible chunked data, slicing frames is 
+        Load from ptyd. Due to possible chunked data, slicing frames is
         non-trivial
         """
         # ok we need to communicate the some internal info
@@ -1000,7 +1000,7 @@ class PtydScan(PtyScan):
         self._ch_frame_ind=parallel.bcast(self._ch_frame_ind)
         parallel.barrier()
         parallel.bcast_dict(self._checked)
-        
+
         # get the coordinates in the chunks
         coords = self._ch_frame_ind[indices]
         calls = {}
@@ -1018,7 +1018,7 @@ class PtydScan(PtyScan):
         # Dangerous and not yet implemented
         # indices = out.get('indices',indices)
 
-        # wrap in a dict 
+        # wrap in a dict
         for k, v in out.iteritems():
             out[k] = dict(zip(indices, v))
 
@@ -1030,26 +1030,26 @@ class MoonFlowerScan(PtyScan):
     Test Ptyscan class producing a romantic ptychographic dataset of a moon
     illuminating flowers.
     """
-    
+
     DEFAULT = GENERIC.copy().update(geometry.DEFAULT.copy())
-    
+
     def __init__(self, pars = None, **kwargs):
         """
-        Parent pars are for the 
+        Parent pars are for the
         """
         p = geometry.DEFAULT.copy()
         if pars is not None:
             p.update(pars)
         # Initialize parent class
         super(MoonFlowerScan, self).__init__(p, **kwargs)
-        
+
         from ptypy import resources
         from ptypy.core import xy
-        
+
         # derive geometry from input
         G = geometry.Geo(pars = self.meta)
         #G._initialize(self.meta)
-        
+
         # derive scan pattern
         pos = u.Param()
         pos.spacing = G.resolution * G.shape / 5.
@@ -1069,14 +1069,14 @@ class MoonFlowerScan(PtyScan):
         #plt.figure(200);plt.imshow(u.imsave(G.propagator.pre_ifft))
         #plt.figure(101);plt.imshow(G.propagator.grids_det[0]**2+G.propagator.grids_det[1]**2)
         # get object
-        self.obj = resources.flower_obj(frame) 
-        
+        self.obj = resources.flower_obj(frame)
+
         # get probe
         moon = resources.moon_pr(self.G.shape)
         moon /= np.sqrt(u.abs2(moon).sum() / 1e8)
         self.pr = moon
         self.load_common_in_parallel = True
-        
+
     def load_common(self):
         """
         Transmit positions
@@ -1096,7 +1096,7 @@ class MoonFlowerScan(PtyScan):
             raw[i]=np.random.poisson(u.abs2(self.G.propagator.fw(self.pr * self.obj[p[i][0]:p[i][0]+s[0],p[i][1]:p[i][1]+s[1]]))).astype(np.int32)
         return raw, {}, {}
 
-        
+
 
 class DataSource(object):
     """
@@ -1131,19 +1131,19 @@ class DataSource(object):
 
             # Copy other relevant information
             prep = s.data.copy()
-            
+
             # Assign label
             prep.label = label
-            
+
             source = prep.source
             recipe = prep.get('recipe',{})
             if prep.get('positions_theory') is None:
                 prep.positions_theory = scan['pos_theory']
-            
+
             prep.dfile = s.data_file
             #prep.geometry = s.geometry.copy()
             #prep.xy = s.xy.copy()
-            
+
             if source is not None:
                 source = source.lower()
 
@@ -1182,7 +1182,7 @@ class DataSource(object):
         # get PtyScan instance to scan_number
         PS = self.PS[self.scan_current]
         label = self.labels[self.scan_current]
-        
+
         # initialize if that has not been done yet
         if not PS.is_initialized:
             PS.initialize()

--- a/ptypy/core/data_old.py
+++ b/ptypy/core/data_old.py
@@ -17,24 +17,21 @@ This file is part of the PTYPY package.
     :copyright: Copyright 2014 by the PTYPY team, see AUTHORS.
     :license: GPLv2, see LICENSE for details.
 """
+import numpy as np
+import os
+import h5py
 if __name__ == "__main__":
     from ptypy import utils as u
     from ptypy import io
     from ptypy import resources
     from ptypy.core import geometry
     from ptypy.utils.verbose import logger, log, headerline
-    import numpy as np
-    import os
-    import h5py
 else:
     from .. import utils as u
     from .. import io
     from .. import resources
     from ..utils.verbose import logger, log, headerline
     import geometry
-    import numpy as np
-    import os
-    import h5py
 
 parallel = u.parallel
 

--- a/ptypy/core/geometry.py
+++ b/ptypy/core/geometry.py
@@ -65,44 +65,44 @@ _old2new = u.Param(
 class Geo(Base):
     """
     Hold and keep consistent the information about experimental parameters.
-    
+
     Keeps also reference to the Propagator and updates this reference
     when resolution, pixel size, etc. is changed in `Geo`. Reference to
-    :py:data:`.io.paths.recons`.          
-    
+    :py:data:`.io.paths.recons`.
+
     Attributes
     ----------
     interact : bool (True)
         If set to True, changes to properties like :py:meth:`energy`,
-        :py:meth:`lam`, :py:meth:`shape` or :py:meth:`psize` will cause 
+        :py:meth:`lam`, :py:meth:`shape` or :py:meth:`psize` will cause
         a call to :py:meth:`update`
-    
+
     """
 
     DEFAULT = DEFAULT
     _keV2m = 1.23984193e-09
     _PREFIX = GEO_PREFIX
-    
+
     def __init__(self, owner=None, ID=None, pars=None, **kwargs):
         """
         Parameters
         ----------
         owner : Base or subclass
             Instance of a subclass of :any:`Base` or None. That is usually
-            :any:`Ptycho` for a Geo instance.            
-        
+            :any:`Ptycho` for a Geo instance.
+
         ID : str or int
             Identifier. Use ``ID=None`` for automatic ID assignment.
-            
+
         pars : dict or Param
             The configuration parameters. See `Geo.DEFAULT`.
-            Any other kwarg will update internal p dictionary 
+            Any other kwarg will update internal p dictionary
             if the key exists in `Geo.DEFAULT`.
         """
         super(Geo, self).__init__(owner, ID)
         # if len(kwargs)>0:
         #     self._initialize(**kwargs)
-    
+
     # def _initialize(self, pars=None, **kwargs):
 
         # Starting parameters
@@ -115,22 +115,22 @@ class Geo(Base):
         for k, v in kwargs.iteritems():
             if k in p:
                 p[k] = v
-        
+
         self.p = p
         self.interact = False
-        
+
         # Set distance
         if self.p.distance is None or self.p.distance == 0:
             raise ValueError(
                 'Distance (geometry.distance) must not be None or 0')
-        
+
         # Set frame shape
         if self.p.shape is None or (np.array(self.p.shape) == 0).any():
             raise ValueError(
                 'Frame size (geometry.shape) must not be None or 0')
         else:
             self.p.shape = u.expect2(p.shape)
-            
+
         # Set energy and wavelength
         if p.energy is None:
             if p.lam is None:
@@ -143,21 +143,21 @@ class Geo(Base):
             if p.lam is not None:
                 logger.debug('Energy and wavelength both specified. '
                              'Energy takes precedence over wavelength')
-            
+
             self.energy = p.energy
-            
+
         # Set initial geometrical misfit to 0
         self.p.misfit = u.expect2(0.)
-        
+
         # Pixel size
         self.p.psize_is_fix = p.psize is not None
         self.p.resolution_is_fix = p.resolution is not None
-        
+
         if not self.p.psize_is_fix and not self.p.resolution_is_fix:
             raise ValueError(
                 'Pixel size in sample plane (geometry.resolution) and '
                 'detector plane \n(geometry.psize) must not both be None')
-        
+
         # Fill pixel sizes
         if self.p.resolution_is_fix:
             self.p.resolution = u.expect2(p.resolution)
@@ -168,10 +168,10 @@ class Geo(Base):
             self.p.psize = u.expect2(p.psize)
         else:
             self.p.psize = u.expect2(1.0)
-        
+
         # Update other values
         self.update(False)
-        
+
         # Attach propagator
         self._propagator = self._get_propagator()
         self.interact = True
@@ -205,22 +205,22 @@ class Geo(Base):
                 # Frame misfit that would make it work
                 self.p.misfit[:] = (self.lz / self.p.resolution / self.p.psize
                                     - self.p.shape)
-            else: 
+            else:
                 self.p.misfit[:] = self.p.resolution - self.p.psize
-            
+
         # Update the propagator too (optionally pass the dictionary,
         # but Geometry & Propagator should share a dict
-        
+
         if update_propagator:
             self.propagator.update(self.p)
-           
+
     @property
     def energy(self):
         """
         Property to get and set the energy
         """
         return self.p.energy
-        
+
     @energy.setter
     def energy(self, v):
         self.p.energy = v
@@ -228,79 +228,79 @@ class Geo(Base):
         self.p.lam = self._keV2m / v
         if self.interact:
             self.update()
-        
+
     @property
     def lam(self):
         """
         Property to get and set the wavelength
         """
         return self.p.lam
-        
+
     @lam.setter
     def lam(self, v):
         # changing wavelengths never changes N, only psize
         # for changing N, please do so manually
         self.p.lam = v
-        self.p.energy = self._keV2m / v 
+        self.p.energy = self._keV2m / v
         if self.interact:
             self.update()
-            
+
     @property
     def resolution(self):
         """
         Property to get and set the pixel size in source plane
         """
         return self.p.resolution
-    
+
     @resolution.setter
     def resolution(self, v):
         """
-        changing source space pixel size 
+        changing source space pixel size
         """
         self.p.resolution[:] = u.expect2(v)
         if self.interact:
             self.update()
-        
+
     @property
     def psize(self):
         """
         Property to get and set the pixel size in the propagated plane
         """
         return self.p.psize
-    
+
     @psize.setter
     def psize(self, v):
         self.p.psize[:] = u.expect2(v)
         if self.interact:
             self.update()
-        
+
     @property
     def lz(self):
         """
         Retrieves product of wavelength and propagation distance
         """
         return self.p.lam * self.p.distance
-        
+
     @property
     def shape(self):
         """
         Property to get and set the *shape* i.e. the frame dimensions
         """
         return self.p.shape
-    
+
     @shape.setter
     def shape(self, v):
         self.p.shape[:] = u.expect2(v).astype(int)
         if self.interact:
             self.update()
-    
+
     @property
     def distance(self):
         """
         Propagation distance in meters
         """
         return self.p.distance
-        
+
     @property
     def propagator(self):
         """
@@ -308,9 +308,9 @@ class Geo(Base):
         """
         if not hasattr(self, '_propagator'):
             self._propagator = self._get_propagator()
-        
+
         return self._propagator
-        
+
     def __str__(self):
         keys = self.p.keys()
         keys.sort()
@@ -318,27 +318,27 @@ class Geo(Base):
         for key in keys:
             start += "%25s : %s\n" % (str(key), str(self.p[key]))
         return start
-        
+
     def _to_dict(self):
         # Delete propagator reference
         del self._propagator
         # Return internal dicts
         return self.__dict__.copy()
-    
+
     # def _post_dict_import(self):
     #    self.propagator = get_propagator(self.p)
     #    self.interact = True
-        
+
     def _get_propagator(self):
         # attach desired datatype for propagator
         try:
             dt = self.owner.CType
         except:
             dt = np.complex64
-        
+
         return get_propagator(self.p, dtype=dt)
-            
-        
+
+
 def get_propagator(geo_dct, **kwargs):
     """
     Helper function to determine propagator to be attached to Geometry class.
@@ -352,25 +352,25 @@ def get_propagator(geo_dct, **kwargs):
 class BasicFarfieldPropagator(object):
     """
     Basic single step Farfield Propagator.
-    
+
     Includes quadratic phase factors and arbitrary origin in array.
-    
-    Be aware though, that if the origin is not in the center of the frame, 
+
+    Be aware though, that if the origin is not in the center of the frame,
     coordinates are rolled periodically, just like in the conventional fft case.
     """
     DEFAULT = DEFAULT
-    
+
     def __init__(self, geo_pars=None, ffttype='numpy', **kwargs):
         """
         Parameters
         ----------
         geo_pars : Param or dict
             Parameter dictionary as in :py:attr:`DEFAULT`.
-        
+
         ffttype : str or other
             Type of CPU-based FFT implementation. One of
-            
-            - 'numpy' for numpy.fft.fft2 
+
+            - 'numpy' for numpy.fft.fft2
             - 'scipy' for scipy.fft.fft2
             - 2 or 4-tuple of (forward_fft2(), inverse_fft2(),
               [scaling, inverse_scaling])
@@ -407,16 +407,16 @@ class BasicFarfieldPropagator(object):
         for k, v in kwargs.iteritems():
             if k in p:
                 p[k] = v
-               
+
         # Wavelength * distance factor
         lz = p.lam * p.distance
-        
+
         # Calculate real space pixel size.
         if p.resolution is not None:
             resolution = p.resolution
         else:
             resolution = lz / p.shape / p.psize
-        
+
         # Calculate array shape from misfit
         mis = u.expect2(p.misfit)
         self.crop_pad = np.round(mis / 2.0).astype(int) * 2
@@ -424,7 +424,7 @@ class BasicFarfieldPropagator(object):
 
         # Undo rounding error
         lz /= (self.sh[0] + mis[0] - self.crop_pad[0]) / self.sh[0]
-        
+
         # Calculate the grids
         if str(p.origin) == p.origin:
             c_sam = p.origin
@@ -472,9 +472,9 @@ class BasicFarfieldPropagator(object):
         # Factors for inverse operation
         self.pre_ifft = self.post_fft.conj()
         self.post_ifft = self.pre_fft.conj()
-        
+
         self._assign_fft(self.ffttype)
-        
+
     def fw(self, W):
         """
         Computes forward propagated wavefront of input wavefront W.
@@ -484,15 +484,15 @@ class BasicFarfieldPropagator(object):
             w = u.crop_pad(W, self.crop_pad)
         else:
             w = W
-        
-        w = self.post_fft * self.sc * self.fft(self.pre_fft * w) 
-        
+
+        w = self.post_fft * self.sc * self.fft(self.pre_fft * w)
+
         # Cropping again
         if (self.crop_pad != 0).any():
             return u.crop_pad(w, -self.crop_pad)
         else:
             return w
-        
+
     def bw(self, W):
         """
         Computes backward propagated wavefront of input wavefront W.
@@ -502,16 +502,16 @@ class BasicFarfieldPropagator(object):
             w = u.crop_pad(W, self.crop_pad)
         else:
             w = W
-            
+
         # Compute transform
         w = self.ifft(self.pre_ifft * w) * self.isc * self.post_ifft
-        
+
         # Cropping again
         if (self.crop_pad != 0).any():
             return u.crop_pad(w, -self.crop_pad)
         else:
             return w
-            
+
     def _assign_fft(self, ffttype='std'):
         self.sc = 1. / np.sqrt(np.prod(self.sh))
         # self.sc = 1. / np.sqrt(
@@ -545,7 +545,7 @@ def translate_to_pix(sh, center):
     elif center is not None:
         # cen = sh * np.asarray(center) % sh - 0.5
         cen = np.asarray(center) % sh
-        
+
     return cen
 
 
@@ -554,18 +554,18 @@ class BasicNearfieldPropagator(object):
     Basic two step (i.e. two ffts) Nearfield Propagator.
     """
     DEFAULT = DEFAULT
-    
+
     def __init__(self, geo_pars=None, ffttype='scipy', **kwargs):
         """
         Parameters
         ----------
         geo_pars : Param or dict
             Parameter dictionary as in :py:data:`DEFAULT`.
-        
+
         ffttype : str or other
             Type of CPU-based FFT implementation. One of
-            
-            - 'numpy' for numpy.fft.fft2 
+
+            - 'numpy' for numpy.fft.fft2
             - 'scipy' for scipy.fft.fft2
             - 2 or 4-tuple of (forward_fft2(),inverse_fft2(),
               [scaling,inverse_scaling])
@@ -582,7 +582,7 @@ class BasicNearfieldPropagator(object):
         self.dtype = kwargs['dtype'] if 'dtype' in kwargs else np.complex128
         self.update(geo_pars, **kwargs)
         self._assign_fft(ffttype=ffttype)
-    
+
     def update(self, geo_pars=None, **kwargs):
         """
         Update internal p dictionary. Recompute all internal array buffers.
@@ -617,19 +617,19 @@ class BasicNearfieldPropagator(object):
             2j * np.pi * (p.distance / p.lam) * (np.sqrt(1-a2) - 1))
         # self.kernel = np.fft.fftshift(self.kernel)
         self.ikernel = self.kernel.conj()
-        
+
     def fw(self, W):
         """
         Computes forward propagated wavefront of input wavefront W.
         """
         return self.ifft(self.fft(W) * self.kernel)
-        
+
     def bw(self, W):
         """
         Computes backward propagated wavefront of input wavefront W.
         """
         return self.ifft(self.fft(W) * self.ikernel)
-            
+
     def _assign_fft(self, ffttype='std'):
         self.sc = 1. / np.sqrt(np.prod(self.sh))
         self.isc = np.sqrt(np.prod(self.sh))

--- a/ptypy/core/illumination.py
+++ b/ptypy/core/illumination.py
@@ -98,7 +98,7 @@ DEFAULT = u.Param(
         # Label of the scan of whose diffraction data to initialize stxm.
         # If None, use own scan_label
         label=None,
-    ), 
+    ),
     # Diversity parameters, can be None = no diversity
     diversity=DEFAULT_diversity,
     # Aperture parameters, can be None = no aperture
@@ -132,22 +132,22 @@ def ellipsis(grids, dims=None, ew=2):
 
 def aperture(A, grids=None, pars=None, **kwargs):
     """
-    Creates an aperture in the shape and dtype of `A` according 
-    to x,y-grids `grids`. Keyword Arguments may be any of 
+    Creates an aperture in the shape and dtype of `A` according
+    to x,y-grids `grids`. Keyword Arguments may be any of
     :any:`DEFAULT`.aperture.
-    
+
     Parameters
     ----------
     A : ndarray
         Model array (at least 2-dimensional) to place aperture on top.
-        
+
     pars: dict or ptypy.utils.Param
         Parameters, see :any:`DEFAULT`.aperture
-        
+
     grids : ndarray
         Cartesian coordinate grids, if None, they will be created with
         ``grids = u.grids(sh[-2:], psize=(1.0, 1.0))``
-        
+
     Returns
     -------
     ap : ndarray
@@ -157,7 +157,7 @@ def aperture(A, grids=None, pars=None, **kwargs):
     if pars is not None:
         p.update(pars)
         p.update(**kwargs)
-    
+
     sh = A.shape
     if grids is not None:
         grids = np.array(grids).copy()
@@ -168,12 +168,12 @@ def aperture(A, grids=None, pars=None, **kwargs):
     else:
         psize = u.expect2(1.0)
         grids = u.grids(sh[-2:], psize=psize)
-        
+
     ap = np.ones(sh[-2:], dtype=A.dtype)
 
     if p.diffuser is not None:
         ap *= u.parallel.MPInoise2d(sh[-2:], *p.diffuser)
-        
+
     if p.form is not None:
         off = u.expect2(p.offset)
         cgrid = grids[0].astype(complex) + 1j*grids[1]
@@ -207,14 +207,14 @@ def aperture(A, grids=None, pars=None, **kwargs):
 def init_storage(storage, pars, energy=None, **kwargs):
     """
     Initializes :any:`Storage` `storage` with parameters from `pars`
-    
+
     Parameters
     ----------
     storage : ptypy.core.Storage
         A :any:`Storage` instance in the *probe* container of :any:`Ptycho`
-        
+
     pars : Param
-        Parameter structure for creating a probe / illumination. 
+        Parameter structure for creating a probe / illumination.
         See :any:`DEFAULT`
         Also accepted as argument:
          * string giving the filename of a previous reconstruction to
@@ -222,29 +222,29 @@ def init_storage(storage, pars, energy=None, **kwargs):
          * string giving the name of an available TEMPLATE
          * FIXME: document other string cases.
          * numpy array: interpreted as initial illumination.
-        
+
     energy : float, optional
         Energy associated with this storage. If None, tries to retrieve
-        the energy from the already initialized ptypy network. 
+        the energy from the already initialized ptypy network.
     """
     s = storage
     prefix = "[Object %s] " % str(s.ID)
-    
+
     p = DEFAULT.copy(depth=3)
     model = None
     if hasattr(pars, 'items') or hasattr(pars, 'iteritems'):
         # This is a dict
-        p.update(pars, in_place_depth=3)    
-    
+        p.update(pars, in_place_depth=3)
+
     # First we check for scripting shortcuts. This is only convenience.
     elif str(pars) == pars:
         # This maybe a template now or a file
-        
+
         # Deactivate further processing
         p.aperture = None
         p.propagation = None
         p.diversity = None
-        
+
         if pars.endswith('.ptyr'):
             recon = u.Param(rfile=pars, layer=None, ID=s.ID)
             p.recon = recon
@@ -261,7 +261,7 @@ def init_storage(storage, pars, energy=None, **kwargs):
             return
         elif pars in TEMPLATES.keys():
             init_storage(s, TEMPLATES[pars])
-            return 
+            return
         elif pars in resources.probes or pars == 'stxm':
             p.model = pars
             init_storage(s, p)
@@ -280,7 +280,7 @@ def init_storage(storage, pars, energy=None, **kwargs):
         return
     else:
         ValueError(prefix + 'Shortcut for probe creation is not understood.')
-        
+
     if p.model is None:
         model = np.ones(s.shape, s.dtype)
         if p.photons is not None:
@@ -327,13 +327,13 @@ def init_storage(storage, pars, energy=None, **kwargs):
             curve = pod.geometry.propagator.post_curve
         except:
             # Ok this is nearfield
-            curve = 1.0 
-            
+            curve = 1.0
+
         model = pod.bw(curve * np.sqrt(alldiff))
     else:
         raise ValueError(
             prefix + 'Value to `model` key not understood in probe creation')
-        
+
     assert type(model) is np.ndarray, "".join(
         [prefix, "Internal model should be numpy array now but it is %s."
          % str(type(model))])
@@ -351,15 +351,15 @@ def init_storage(storage, pars, energy=None, **kwargs):
                         'Could not retrieve energy from pod network... '
                         'Maybe there are no pods yet created?')
     s._energy = energy
-        
+
     # Perform aperture multiplication, propagation etc.
     model = _process(model, p.aperture, p.propagation,
                      p.photons, energy, s.psize, prefix)
-    
+
     # Apply diversity
     if p.diversity is not None:
         u.diversify(model, **p.diversity)
-    
+
     # Fill storage array
     s.fill(model)
 
@@ -369,7 +369,7 @@ def _process(model, aperture_pars=None, prop_pars=None, photons=1e7,
     """
     Processes 3d stack of incoming wavefronts `model`. Applies aperture
     according to `aperture_pars` and propagates according to `prop_pars`
-    and other keywords arguments. 
+    and other keywords arguments.
     """
     # Create the propagator
     ap_size, grids, prop = _propagation(prop_pars,
@@ -377,7 +377,7 @@ def _process(model, aperture_pars=None, prop_pars=None, photons=1e7,
                                         resolution,
                                         energy,
                                         prefix)
-        
+
     # Form the aperture on top of the model
     if type(aperture_pars) is np.ndarray:
         model *= np.resize(aperture_pars, model.shape)
@@ -393,11 +393,11 @@ def _process(model, aperture_pars=None, prop_pars=None, photons=1e7,
 
     # Propagate
     model = prop(model)
-    
+
     # apply photon count
     if photons is not None:
         model *= np.sqrt(photons / u.norm2(model))
-    
+
     return model
 
 
@@ -414,7 +414,7 @@ def _propagation(prop_pars, shape=None, resolution=None, energy=None,
     p = prop_pars
     grids = None
     if p is not None and len(p) > 0:
-        ap_size = p.spot_size if p.spot_size is not None else None 
+        ap_size = p.spot_size if p.spot_size is not None else None
         ffGeo = None
         nfGeo = None
         fdist = p.focussed
@@ -460,7 +460,7 @@ def _propagation(prop_pars, shape=None, resolution=None, energy=None,
                 prefix +
                 'Model illumination is propagated over a distance %3.3g m.'
                 % p.parallel)
-            
+
         if ffGeo is not None and nfGeo is not None:
             prop = lambda x: nfGeo.propagator.fw(ffGeo.propagator.fw(x * phase))
         elif ffGeo is not None and nfGeo is None:
@@ -474,7 +474,7 @@ def _propagation(prop_pars, shape=None, resolution=None, energy=None,
         grids = u.grids(u.expect2(shape), psize=u.expect2(resolution))
         prop = lambda x: x
         ap_size = None
-        
+
     return ap_size, grids, prop
 
 DEFAULT_old = u.Param(

--- a/ptypy/core/manager.py
+++ b/ptypy/core/manager.py
@@ -92,22 +92,22 @@ DEFAULT = u.Param(
 class ModelManager(object):
     """
     Manages ptypy objects creation and update.
-    
+
     The main task of ModelManager is to follow the rules for a given
     reconstruction model and create:
-    
+
      - the probe, object, exit, diff and mask containers
      - the views
-     - the PODs 
-     
+     - the PODs
+
     A ptychographic problem is defined by the combination of one or
     multiple scans. ModelManager uses encapsulate
     scan-specific elements in .scans und .scans_pars
-    
+
     Note
     ----
     This class is densely connected to :any:`Ptycho` the separation
-    in two classes is more history than reason and these classes may get 
+    in two classes is more history than reason and these classes may get
     merged in future releases
     """
     DEFAULT = DEFAULT
@@ -118,26 +118,26 @@ class ModelManager(object):
 
     def __init__(self, ptycho, pars=None, scans=None, **kwargs):
         """
-        
+
         Parameters
         ----------
         ptycho: Ptycho
             The parent Ptycho object
-            
+
         pars : dict or Param
             Input parameters (see :py:attr:`DEFAULT`)
             If None uses defaults
-            
+
         scans : dict or Param
             Scan-specific parameters, Values should be dict Param that
             follow the structure of `pars`.
-            If None, tries in ptycho.p.scans else becomes empty dict  
+            If None, tries in ptycho.p.scans else becomes empty dict
         """
         # Initialize the input parameters
         p = u.Param(self.DEFAULT.copy())
         p.update(pars, in_place_depth=4)
         self.p = p
-        
+
         self.ptycho = ptycho
 
         # Abort if ptycho is None:
@@ -296,7 +296,7 @@ class ModelManager(object):
         """
         Creates a static datasource from parameters in the self.scans dict.
 
-        For any additional file in data.filelist it will create a new entry in 
+        For any additional file in data.filelist it will create a new entry in
         self.scans with generic parameters given by the current model.
         """
         """
@@ -314,7 +314,7 @@ class ModelManager(object):
             #    scan.pars['data_file'] = self.ptycho.paths.get_data_file(
             #        label=label)
             scan.pars['label'] = label
-             
+
         return data.DataSource(self.scans)
 
     def new_data(self):
@@ -330,7 +330,7 @@ class ModelManager(object):
         logger.info('Processing new data.')
         used_scans = []
         not_initialized = []
-        
+
         # For some funny reason the Generator construct used to fail.
         while True:
             dp = self.ptycho.datasource.feed_data()
@@ -338,36 +338,36 @@ class ModelManager(object):
                 break
             """
             A dp (data package) contains the following:
-            
+
             common : dict or Param
-                    Meta information common to all datapoints in the 
+                    Meta information common to all datapoints in the
                     data package. Variable names need to be consistent with
                     those in the rest of ptypy package.
                     (TODO further description)
-                    
+
                     Important info:
                     ------------------------
-                    shape : (tuple or array) 
+                    shape : (tuple or array)
                            expected frame shape
                     label : (string)
                             Script label. This label is matched to the parameter
                             tree, a string signifying to which scan this package
                             belongs to.
-                   
-            
+
+
             iterable : An iterable structure that yields for each iteration
                        a dict with the following fields:
-            
-                        data     : (np.2darray, float) 
-                                    diffraction data 
+
+                        data     : (np.2darray, float)
+                                    diffraction data
                                     In MPI case, data can be None if distributed
                                     to other nodes
-                        mask     : (np.2darray, bool) 
+                        mask     : (np.2darray, bool)
                                     masked out areas in diffraction data array
                         index    : (int)
                                     diffraction datapoint index in scan
                         position : (tuple or array)
-                                    scan position 
+                                    scan position
             """
             meta = dp['common']
             label = meta['ptylabel']
@@ -408,10 +408,10 @@ class ModelManager(object):
                     spectrum = spec(energies)
                 else:
                     spectrum = np.resize(np.asarray(spec), (len(energies), 1))
-                    
+
                 spectrum /= spectrum.sum()
                 scan.spectrum = spectrum
-                
+
                 for ii, fac in enumerate(energies):
                     geoID = geometry.Geo._PREFIX + '%02d' % ii + label
                     g = geometry.Geo(self.ptycho, geoID, pars=geo)
@@ -426,7 +426,7 @@ class ModelManager(object):
                     g.p.spectral = spectrum[ii]
                     # Append the geometry
                     scan.geometries.append(g)
-                    
+
                 # Create a buffer
                 scan.iterable = []
 
@@ -517,7 +517,7 @@ class ModelManager(object):
                     pos = scan.pos_theory[index]
                 else:
                     pos = dct.get('position')  # ,positions_theory[index])
-                
+
                 if pos is None:
                     logger.warning('No position set to scan point %d of scan %s'
                                    % (index, label))
@@ -601,12 +601,12 @@ class ModelManager(object):
                                           len(new_probe_ids),
                                           len(new_object_ids)),
                         extra={'allprocesses': True})
-    
-            # Adjust storages      
+
+            # Adjust storages
             self.ptycho.probe.reformat(True)
             self.ptycho.obj.reformat(True)
             self.ptycho.exit.reformat()
-    
+
             self._initialize_probe(new_probe_ids)
             self._initialize_object(new_object_ids)
             self._initialize_exit(new_pods)
@@ -620,7 +620,7 @@ class ModelManager(object):
             # Pick scanmanagers from scan_label for illumination parameters
             # For now, the scanmanager of the first label is chosen
             scan = self.scans[labels[0]]
-            
+
             # Pick storage from container
             s = self.ptycho.probe.storages.get(pid)
             if s is None:
@@ -630,15 +630,15 @@ class ModelManager(object):
                             % (pid, scan.label))
 
             illu_pars = scan.pars.illumination
-            
+
             if type(illu_pars) is u.Param:
                 # If not a short cut but a Param, modify content from deep copy
-                illu_pars = illu_pars.copy(depth=10) 
+                illu_pars = illu_pars.copy(depth=10)
 
                 # If photon count is None, assign a number from the stats.
                 phot = illu_pars.get('photons')
                 phot_max = scan.diff.max_power
-                
+
                 if phot is None:
                     logger.info(
                         'Found no photon count for probe in parameters.\n'
@@ -650,7 +650,7 @@ class ModelManager(object):
                         'Photon count from input parameters (%.2e) differs '
                         'from statistics (%.2e) by more than a magnitude.'
                         % (phot, phot_max))
-    
+
                 # Quickfix spectral contribution.
                 if (scan.pars.coherence.probe_dispersion
                         not in [None, 'achromatic']):
@@ -658,7 +658,7 @@ class ModelManager(object):
                     illu_pars['photons'] *= s.views[0].pod.geometry.p.spectral
 
             illumination.init_storage(s, illu_pars)
-            
+
             s.reformat()  # Maybe not needed
             s.model_initialized = True
 
@@ -671,7 +671,7 @@ class ModelManager(object):
             # Pick scanmanagers from scan_label for illumination parameters
             # For now, the scanmanager of the first label is chosen
             scan = self.scans[labels[0]]
-            
+
             # Pick storage from container
             s = self.ptycho.obj.storages.get(oid)
             if s is None or s.model_initialized:
@@ -679,13 +679,13 @@ class ModelManager(object):
             else:
                 logger.info('Initializing object storage %s using scan %s.'
                             % (oid, scan.label))
-        
-            sample_pars = scan.pars.sample   
-            
+
+            sample_pars = scan.pars.sample
+
             if type(sample_pars) is u.Param:
                 # Deep copy
-                sample_pars = sample_pars.copy(depth=10)          
-                
+                sample_pars = sample_pars.copy(depth=10)
+
                 # Quickfix spectral contribution.
                 if (scan.pars.coherence.object_dispersion
                         not in [None, 'achromatic']
@@ -694,9 +694,9 @@ class ModelManager(object):
                     logger.info(
                         'Applying spectral distribution input to object fill.')
                     sample_pars['fill'] *= s.views[0].pod.geometry.p.spectral
-            
+
             sample.init_storage(s,sample_pars)
-            
+
             """"
             if sample_pars.get('source') == 'diffraction':
                 logger.info('STXM initialization using diffraction data')
@@ -725,11 +725,11 @@ class ModelManager(object):
             if not pod.active:
                 continue
             pod.exit = pod.probe * pod.object
-        
+
     def _create_pods(self, new_scans):
         """
         Create all pods associated with the scan labels in 'scans'.
-        
+
         Return the list of new pods, probe and object ids (to allow for
         initialization).
         """
@@ -757,16 +757,16 @@ class ModelManager(object):
             positions = scan.new_positions
             di_views = scan.new_diff_views
             ma_views = scan.new_mask_views
-            
+
             # Compute sharing rules
             share = scan.pars.sharing
             alt_obj = share.object_share_with if share is not None else None
             alt_pr = share.probe_share_with if share is not None else None
-                
+
             obj_label = label if alt_obj is None else alt_obj
             pr_label = label if alt_pr is None else alt_pr
-            
-            # Loop through diffraction patterns             
+
+            # Loop through diffraction patterns
             for i in range(len(di_views)):
                 dv, mv = di_views.pop(0), ma_views.pop(0)
                 index = dv.layer
@@ -783,13 +783,13 @@ class ModelManager(object):
                 for ii, geometry in enumerate(scan.geometries):
                     # Make new IDs and keep them in record
                     # sharing_rules is not aware of IDs with suffix
-                    
+
                     pdis = scan.pars.coherence.probe_dispersion
                     if pdis is None or str(pdis) == 'achromatic':
-                        gind = 0 
+                        gind = 0
                     else:
                         gind = ii
-                                         
+
                     probe_id_suf = probe_id + 'G%02d' % gind
                     if (probe_id_suf not in new_probe_ids.keys()
                             and probe_id_suf not in existing_probes):
@@ -798,10 +798,10 @@ class ModelManager(object):
 
                     odis = scan.pars.coherence.object_dispersion
                     if odis is None or str(odis) == 'achromatic':
-                        gind = 0 
+                        gind = 0
                     else:
                         gind = ii
-                    
+
                     object_id_suf = object_id + 'G%02d' % gind
                     if (object_id_suf not in new_object_ids.keys()
                             and object_id_suf not in existing_objects):
@@ -867,7 +867,7 @@ class ModelManager(object):
                             # If Empty Probe sharing is enabled,
                             # adjust POD accordingly.
                             if share is not None:
-                                pod.probe_weight = share.probe_share_power 
+                                pod.probe_weight = share.probe_share_power
                                 pod.object_weight = share.object_share_power
                                 if share.EP_sharing:
                                     pod.is_empty = True
@@ -894,18 +894,18 @@ class ModelManager(object):
         """
         *DEPRECATED*
         attempt to save diffraction data
-        
+
         Parameters
         ----------
-        
+
         label : str
-                ptypy label of the scan to save 
-                if None, tries to save ALL diffraction data 
-                
+                ptypy label of the scan to save
+                if None, tries to save ALL diffraction data
+
         filename : str
                 override the file path to write to
                 will change `data_filename` in `scan_info` dict
-        
+
         all other kwargs are added to 'scan_info' key in the '.h5' file
         """
 

--- a/ptypy/core/model.py
+++ b/ptypy/core/model.py
@@ -48,7 +48,7 @@ class BasicSharingModel(object):
     def __init__(self, sharing_dct, scan_per_probe, scan_per_object, npts=None):
         """
         BasicSharingModel: implements the most common scan-sharing patterns.
-        
+
         Parameters:
         -----------
         scan_per_probe: float < 1 or int
@@ -84,7 +84,7 @@ class BasicSharingModel(object):
             logger.info(
                 'Model: splitting scans (every %d diffraction patter)'
                 % self.diff_per_probe)
-            
+
         # Prepare object sharing
         if scan_per_object == 0:
             self.single_object = True
@@ -104,11 +104,11 @@ class BasicSharingModel(object):
         self.scan_labels = []
         self.probe_ids = sharing_dct['probe_ids']
         self.object_ids = sharing_dct['object_ids']
-        
+
     def __call__(self, scan_label, diff_index):
         """
         Return probe and object ids given a scan and diffraction pattern index.
-        
+
         Parameters:
         -----------
         scan_label: str or int
@@ -136,19 +136,19 @@ class BasicSharingModel(object):
         else:
             probe_id = (scan_index * (self.npts // self.diff_per_probe)
                         + diff_index // self.diff_per_probe)
-        
+
         # Follow the format specified in Viewmanager
         probe_id = STORAGE_PREFIX + '%02d' % probe_id
-        
+
         # ... and the rules for object sharing
         if self.single_object:
             object_id = 0
         else:
             object_id = scan_index // self.scan_per_object
-            
+
         # Follow the format specified in Viewmanager
         object_id = STORAGE_PREFIX + '%02d' % object_id
-        
+
         logger.debug(
             "Model assigned frame %d of scan %s to probe %s & object %s"
             % (diff_index, str(scan_label), probe_id, object_id))
@@ -163,5 +163,5 @@ class BasicSharingModel(object):
         if scan_label not in ol:
             ol.append(scan_label)
         self.object_ids[object_id] = ol
-        
+
         return probe_id, object_id

--- a/ptypy/core/paths.py
+++ b/ptypy/core/paths.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
 # for in package use #####
 else:
     from .. import utils as u
-    
+
 __all__ = ['DEFAULT', 'Paths']
 
 DEFAULT = u.Param(
@@ -67,11 +67,11 @@ class Paths(object):
             self.recon = io.rfile
         except:
             self.recon = self.DEFAULT.recon
-        
+
         sep = os.path.sep
         if not self.home.endswith(sep):
             self.home += sep
-        
+
         for key in ['autosave', 'autoplot', 'recon']:
             v = self.__dict__[key]
             if isinstance(v, str):
@@ -83,23 +83,23 @@ class Paths(object):
         Determine run name
         """
         return self.runtime.run if run is None else run
-    
+
     def auto_file(self, runtime=None):
         """ File path for autosave file """
         return self.get_path(self.autosave, runtime)
-    
+
     def recon_file(self, runtime=None):
-        """ File path for reconstruction file """           
+        """ File path for reconstruction file """
         return self.get_path(self.recon, runtime)
-    
+
     def plot_file(self, runtime=None):
-        """ 
-        File path for plot file 
+        """
+        File path for plot file
         """
         p = self.get_path(self.autoplot, runtime)
         print p
         return self.get_path(self.autoplot, runtime)
-    
+
     def get_path(self, path, runtime):
         if runtime is not None:
             try:
@@ -112,7 +112,7 @@ class Paths(object):
             out = os.path.abspath(os.path.expanduser(path % self.runtime))
 
         return out
-    
+
 ############
 # TESTING ##
 ############

--- a/ptypy/core/pattern.py
+++ b/ptypy/core/pattern.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-This module generates the scan patterns. 
+This module generates the scan patterns.
 
 This file is part of the PTYPY package.
 
@@ -8,25 +8,25 @@ This file is part of the PTYPY package.
     :license: GPLv2, see LICENSE for details.
 """
 from .. import utils as u
-#from ..utils import prop 
+#from ..utils import prop
 from ..utils.verbose import logger
 import numpy as np
 
 __all__=['DEFAULT','from_pars','round_scan','round_scan_roi'\
          'raster_scan','spiral_scan','spiral_scan_roi']
 DEFAULT=u.Param(
-    #### Paramaters for popular scan methods 
+    #### Paramaters for popular scan methods
     scan_type = None, # [None,'round', 'raster', 'round_roi','spiral','spiral_roi','custom']
-    dr = 1.5e-6,             # round,round_roi :width of shell 
-    nr = 5,                 # round : number of intervals (# of shells - 1) 
-    nth = 5,                 # round,round_roi: number of points in the first shell 
-    lx = 15e-6,               # round_roi: Width of ROI 
-    ly = 15e-6,               # round_roi: Height of ROI 
+    dr = 1.5e-6,             # round,round_roi :width of shell
+    nr = 5,                 # round : number of intervals (# of shells - 1)
+    nth = 5,                 # round,round_roi: number of points in the first shell
+    lx = 15e-6,               # round_roi: Width of ROI
+    ly = 15e-6,               # round_roi: Height of ROI
     nx = 10,                 # raster scan: number of steps in x
     ny = 10,                 # raster scan: number of steps in y
     dx = 1.5e-6,               # raster scan: step size (grid spacing)
     dy = 1.5e-6,               # raster scan: step size (grid spacing)
-    #### other 
+    #### other
     positions = None,        # fill this list with your own script if you want other scan patterns, choose 'custom' as san type
 )
 
@@ -40,18 +40,18 @@ DEFAULT = u.validator.make_sub_default('.scan.xy',depth=3)
 def from_pars(pars=None):
     """
     Creates position array from parameter tree `pars`. See :py:data:`DEFAULT`
-    
+
     :param Param pars: Input parameters
     :returns ndarray pos: A numpy.ndarray of shape ``(N,2)`` for *N* positios
     """
     p=u.Param(DEFAULT)
     if pars is not None: # and (isinstance(pars,dict) or isinstance(pars,u.Param)):
         p.update(pars)
-    
+
     if p.type is None:
         logger.debug('Scan_type `None` is chosen . Will use positions provided by meta information')
         return None
-        
+
     elif p.type=='round':
         pos=round_scan(**p.round)
     elif p.type=='round_roi':
@@ -62,52 +62,52 @@ def from_pars(pars=None):
         pos=spiral_scan_roi(**p.spiral_roi)
     elif p.type=='raster':
         pos=raster(**p.raster)
-    else: 
+    else:
         pos = p.positions
     pos=np.asarray(pos)
     logger.info('Prepared %d positions' % len(pos))
     return pos
-    
+
 
 
 def augment_to_coordlist(a,Npos):
- 
+
     # force into a 2 column matrix
     # drop element if size is not a modulo of 2
     a = np.asarray(a)
     if a.size == 1:
         a=np.atleast_2d([a,a])
-        
+
     if a.size % 2 != 0:
         a=a.flatten()[:-1]
-    
+
     a=a.reshape(a.size//2,2)
     # append multiples of a until length is greater equal than Npos
     if a.shape[0] < Npos:
         b=np.concatenate((1+Npos//a.shape[0])*[a],axis=0)
     else:
         b=a
-    
+
     return b[:Npos,:2]
-    
+
 def raster_scan(ny=10,nx=10,dy=1.5e-6,dx=1.5e-6):
     """
     Generates as raster scan.
-    
+
     Parameters
     ----------
     ny, nx : int
         Number of steps in *y* (vertical) and *x* (horizontal) direction
         *x* is the fast axis
-        
+
     dy, dx : float
-        Step size (grid spacinf) in *y* and *x*  
-        
+        Step size (grid spacinf) in *y* and *x*
+
     Returns
     -------
     pos : ndarray
         A (N,2)-array of positions.
-        
+
     Examples
     --------
     >>> from ptypy.core import import xy
@@ -153,7 +153,7 @@ def spiral_scan(dr,r_out=None,maxpts=None):
     """
     alpha = np.sqrt(4*np.pi)
     beta = dr/(2*np.pi)
-    
+
     if maxpts is None:
         assert r_out is not None
         maxpts = 100000000
@@ -175,7 +175,7 @@ def spiral_scan_roi(dr,lx,ly):
     """
     alpha = np.sqrt(4*np.pi)
     beta = dr/(2*np.pi)
-    
+
     rmax = .5*np.sqrt(lx**2 + ly**2)
     positions = []
     for k in xrange(1000000000):

--- a/ptypy/core/ptycho.py
+++ b/ptypy/core/ptycho.py
@@ -86,35 +86,35 @@ DEFAULT = u.Param(
 class Ptycho(Base):
     """
     Ptycho : A ptychographic data holder and reconstruction manager.
-    
+
     This is the highest level class. It organizes and contains the data,
     manages the reconstruction engines, and interacts with the outside world.
-    
-    If MPI is enabled, this class acts both as a manager (rank = 0) and 
+
+    If MPI is enabled, this class acts both as a manager (rank = 0) and
     a worker (any rank), and most information exists on all processes.
     In principle the only part that is divided between processes is the
     diffraction data.
-    
+
     By default Ptycho is instantiated once per process, but it can also
     be used as a managed container to load past runs.
-    
+
     Attributes
-    ----------    
+    ----------
     CType,FType : numpy.dtype
         numpy dtype for arrays. `FType` is for data, i.e. real-valued
         arrays, `CType` is for complex-valued arrays
-        
+
     interactor : ptypy.io.interaction.Server
         ZeroMQ interaction server for communication with e.g. plotting
         clients
-    
+
     runtime : Param
         Runtime information, e.g. errors, iteration etc.
-    
+
     modelm : ModelManager
-        THE managing instance for :any:`POD`, :any:`View` and 
+        THE managing instance for :any:`POD`, :any:`View` and
         :any:`Geo` instances
-        
+
     probe,obj,exit,diff,mask : Container
         Container instances for illuminations, samples, exit waves,
         diffraction data and detector masks / weights
@@ -122,46 +122,46 @@ class Ptycho(Base):
     DEFAULT = DEFAULT
     """ Default ptycho parameters which is the trunk of the
         default :ref:`ptypy parameter tree <parameters>`"""
-    
+
     _PREFIX = PTYCHO_PREFIX
-    
+
     def __init__(self, pars=None, level=2, **kwargs):
-        """        
+        """
         Parameters
         ----------
         pars : Param
-            Input parameters, subset of the 
+            Input parameters, subset of the
             :ref:`ptypy parameter tree<parameters>`
-            
+
         level : int
             Determines how much is initialized.
-            
+
             - <= 0 : empty ptypy structure
-            - 1 : reads parameters, configures interaction server, 
+            - 1 : reads parameters, configures interaction server,
                   see :py:meth:`init_structures`
             - 2 : also configures Containers, initializes ModelManager
                   see :py:meth:`init_data`
-            - 3 : also initializes ZeroMQ-communication 
+            - 3 : also initializes ZeroMQ-communication
                   :py:meth:`init_communication`
-            - 4 : also initializes reconstruction engines, 
+            - 4 : also initializes reconstruction engines,
                   see :py:meth:`init_engine`
             - >= 4 : also and starts reconstruction
                     see :py:meth:`run`
         """
         super(Ptycho, self).__init__(None, 'Ptycho')
-        
+
         # Abort if we load complete structure
-        if level <= 0: 
+        if level <= 0:
             return
 
         self.p = self.DEFAULT.copy(depth=99)
         """ Reference for parameter tree, with which
             this instance was constructed. """
-        
+
         # Continue with initialization from parameters
         if pars is not None:
             self.p.update(pars, in_place_depth=3)
-        
+
         # That may be a little dangerous
         self.p.update(kwargs)
 
@@ -184,7 +184,7 @@ class Ptycho(Base):
 
         # Early boot strapping
         self._configure()
-        
+
         if level >= 1:
             logger.info('\n' + headerline('Ptycho init level 1', 'l'))
             self.init_structures()
@@ -200,7 +200,7 @@ class Ptycho(Base):
         if level >= 5:
             self.run()
             self.finalize()
-            
+
     def _configure(self):
         """
         Early boot strapping.
@@ -233,32 +233,32 @@ class Ptycho(Base):
         # Check if there is already a runtime container
         if not hasattr(self, 'runtime'):
             self.runtime = u.Param()  # DEFAULT_runtime.copy()
-            
+
         if not hasattr(self, 'engines'):
             # Create an engines entry if it does not already exist
             from collections import OrderedDict
             self.engines = OrderedDict()
-        
+
         # Generate all the paths
         self.paths = paths.Paths(p.io)
-        
+
         # Find run name
         self.runtime.run = self.paths.run(p.run)
-    
+
     def init_communication(self):
         """
         Called on __init__ if ``level >= 3``.
-        
+
         Initializes ZeroMQ communication on the master node and
         spawns an optional plotting client.
         """
-        iaction = self.p.io.interaction 
+        iaction = self.p.io.interaction
         autoplot = self.p.io.autoplot
-        
+
         if parallel.master and iaction:
             # Create the interaction server
             self.interactor = interaction.Server(iaction)
-            
+
             # Register self as an accessible object for the client
             self.interactor.objects['Ptycho'] = self
 
@@ -266,7 +266,7 @@ class Ptycho(Base):
             logger.info('Will start interaction server here: %s:%d'
                         % (self.interactor.address, self.interactor.port))
             port = self.interactor.activate()
-            
+
             if port is None:
                 logger.warn('Interaction server initialization failed. '
                             'Continuing without server.')
@@ -275,11 +275,11 @@ class Ptycho(Base):
             else:
                 # Modify port
                 iaction.port = port
-                
+
                 # Inform the audience
                 log(4, 'Started interaction got the following parameters:'
                     + report(self.interactor.p, noheader=True))
-                
+
                 # Start automated plot client
                 self.plotter = None
                 if (parallel.master and autoplot and autoplot.threaded and
@@ -293,57 +293,57 @@ class Ptycho(Base):
             # No interaction wanted
             self.interactor = None
             self.plotter = None
-            
+
         parallel.barrier()
-    
+
     def init_structures(self):
         """
         Called on __init__ if ``level >= 1``.
-        
+
         Prepare everything for reconstruction. Creates attributes
-        :py:attr:`modelm` and the containers :py:attr:`probe` for 
+        :py:attr:`modelm` and the containers :py:attr:`probe` for
         illumination, :py:attr:`obj` for the samples, :py:attr:`exit` for
-        the exit waves, :py:attr:`diff` for diffraction data and 
+        the exit waves, :py:attr:`diff` for diffraction data and
         :py:attr:`mask` for detectors masks
         """
         p = self.p
-               
+
         # Initialize the reconstruction containers
         self.probe = Container(ptycho=self, ID='Cprobe', data_type='complex')
         self.obj = Container(ptycho=self, ID='Cobj', data_type='complex')
         self.exit = Container(ptycho=self, ID='Cexit', data_type='complex')
         self.diff = Container(ptycho=self, ID='Cdiff', data_type='real')
         self.mask = Container(ptycho=self, ID='Cmask', data_type='bool')
-       
+
         ###################################
         # Initialize data sources load data
         ###################################
-        
+
         # Initialize the model manager
         self.modelm = ModelManager(self, p.scan)
-    
+
     def init_data(self, print_stats=True):
         """
         Called on __init__ if ``level >= 2``.
-        
+
         Creates a datasource and calls for :py:meth:`ModelManager.new_data()`
         Prints statistics on the ptypy structure if ``print_stats=True``
         """
         # Create the data source object, which give diffraction frames one
         # at a time, supporting MPI sharing.
-        self.datasource = self.modelm.make_datasource() 
-       
+        self.datasource = self.modelm.make_datasource()
+
         # Load the data. This call creates automatically the scan managers,
         # which create the views and the PODs.
         self.modelm.new_data()
-        
+
         # Print stats
         parallel.barrier()
         if print_stats:
             self.print_stats()
-        
+
         # Create plotting instance (maybe)
-        
+
     def _init_engines(self):
         """
         * deprecated*
@@ -351,46 +351,46 @@ class Ptycho(Base):
         """
         # Store the engines in a dict
         self.engines = {}
-        
+
         # Store the run labels in a list to ensure precedence is preserved.
         self.run_labels = []
-        
+
         # Loop through p.engines sub-dictionaries
         for run_label, pars in self.p.engines.iteritems():
             # Copy common parameters
             engine_pars = self.p.engine.common.copy()
-            
+
             # Identify engine by name
             engine_class = engines.by_name(pars.name)
-            
+
             # Update engine type specific parameters
             engine_pars.update(self.p.engine[pars.name])
-            
+
             # Update engine instance specific parameters
             engine_pars.update(pars)
-            
+
             # Create instance
             engine = engine_class(self, engine_pars)
-            
+
             # Store info
             self.engines[run_label] = engine
             self.run_labels.append(run_label)
-    
+
     def init_engine(self, label=None, epars=None):
         """
         Called on __init__ if ``level >= 4``.
-        
+
         Initializes engine with label `label` from parameters and lists
         it internally in ``self.engines`` which is an ordered dictionary.
-        
+
         Parameters
         ----------
         label : str
-            Label of engine which is to be created from parameter set of 
-            the same label in input parameter tree. If ``None``, an engine 
-            is created for each available parameter set in input parameter 
+            Label of engine which is to be created from parameter set of
+            the same label in input parameter tree. If ``None``, an engine
+            is created for each available parameter set in input parameter
             tree sorted by label.
-        
+
         epars : Param or dict
             Set of engine parameters. The created engine is listed as
             *auto00*, *auto01* , etc in ``self.engines``
@@ -399,15 +399,15 @@ class Ptycho(Base):
             # Receiving a parameter set means a new engine parameter set
             # needs to be listed in self.p
             engine_label = 'auto%02d' + len(self.engines)
-            
+
             # List parameters
             self.p.engines[engine_label] = epars
-            
+
             # Start over
             self.init_engine(engine_label)
-        
+
             return engine_label
-            
+
         elif label is not None:
             try:
                 pars = self.p.engines[label]
@@ -416,22 +416,22 @@ class Ptycho(Base):
                 pass
             # Copy common parameters
             engine_pars = self.p.engine.common.copy()
-            
+
             # Identify engine by name
             engine_class = engines.by_name(pars.name)
-            
+
             # Update engine type specific parameters
             engine_pars.update(self.p.engine[pars.name])
-            
+
             # Update engine instance specific parameters
             engine_pars.update(pars)
-            
+
             # Create instance
             engine = engine_class(self, engine_pars)
-            
+
             # Attach label
             engine.label = label
-            
+
             # Store info
             self.engines[label] = engine
         else:
@@ -443,7 +443,7 @@ class Ptycho(Base):
     def pods(self):
         """ Dict of all :any:`POD` instances in the pool of self """
         return self._pool.get('P', {})
-        
+
     @property
     def containers(self):
         """ Dict of all :any:`Container` instances in the pool of self """
@@ -452,62 +452,62 @@ class Ptycho(Base):
     def run(self, label=None, epars=None, engine=None):
         """
         Called on __init__ if ``level >= 5``.
-        
+
         Start the reconstruction with at least one engine.
         As a consequence, ``self.runtime`` will be filled with content.
-        
+
         Parameters
         ----------
         label : str, optional
-            Engine label of engine to run. If ``None`` all available 
-            engines are run in the order they were stored in 
-            ``self.engines``. If the engine is not yet created, 
+            Engine label of engine to run. If ``None`` all available
+            engines are run in the order they were stored in
+            ``self.engines``. If the engine is not yet created,
             :py:meth:`init_engine` is called for that label.
-        
+
         epars : dict or Param, optional
             Engine parameter set. An engine is created from this set,
             using :py:meth:`init_engine` and run immediately afterwards.
             For parameters see :py:data:`.engine`
-            
+
         engine : BaseEngine, optional
-            An engine instance that should be a subclass of 
+            An engine instance that should be a subclass of
             :py:class:`BaseEngine` or have the same methods.
         """
         if engine is not None:
             # Work with that engine
             if self.runtime.get('start') is None:
                 self.runtime.start = time.asctime()
-        
+
             # Check if there is already a runtime info collector
             if self.runtime.get('iter_info') is None:
                 self.runtime.iter_info = []
-            
+
             # Note when the last autosave was carried out
             if self.runtime.get('last_save') is None:
                 self.runtime.last_save = 0
-            
+
             # Maybe not needed
             if self.runtime.get('last_plot') is None:
                 self.runtime.last_plot = 0
-            
+
             # Prepare the engine
             engine.initialize()
-                
+
             # Start the iteration loop
             while not engine.finished:
                 # Check for client requests
-                if parallel.master and self.interactor is not None: 
+                if parallel.master and self.interactor is not None:
                     self.interactor.process_requests()
-                
+
                 parallel.barrier()
-                
+
                 # Check for new data
                 self.modelm.new_data()
-                
+
                 # Last minute preparation before a contiguous block of
                 # iterations
                 engine.prepare()
-                
+
                 auto_save = self.p.io.autosave
                 if auto_save is not None and auto_save.interval > 1:
                     if engine.curiter % auto_save.interval == 0:
@@ -519,9 +519,9 @@ class Ptycho(Base):
 
                 # One iteration
                 engine.iterate()
-                
+
                 # Display runtime information and do saving
-                if parallel.master: 
+                if parallel.master:
                     info = self.runtime.iter_info[-1]
                     # Calculate error:
                     # err = np.array(info['error'].values()).mean(0)
@@ -530,12 +530,12 @@ class Ptycho(Base):
                                 'Time %(duration).2f' % info)
                     logger.info('Errors :: Fourier %.2e, Photons %.2e, '
                                 'Exit %.2e' % tuple(err))
-                
+
                 parallel.barrier()
 
-            # Done. Let the engine finish up    
+            # Done. Let the engine finish up
             engine.finalize()
-    
+
             # Save
             if self.p.io.rfile:
                 self.save_run()
@@ -543,12 +543,12 @@ class Ptycho(Base):
                 pass
             # Time the initialization
             self.runtime.stop = time.asctime()
-        
+
         elif epars is not None:
             # A fresh set of engine parameters arrived.
             label = self.init_engine(epars=epars)
             self.run(label=label)
-        
+
         elif label is not None:
             # Looks if there already exists a prepared engine
             # If so, use it, else create one and use it
@@ -572,7 +572,7 @@ class Ptycho(Base):
         """
         # 'allstop' will be interpreted as 'quit' on threaded plot clients
         self.runtime.allstop = time.asctime()
-        if parallel.master and self.interactor is not None: 
+        if parallel.master and self.interactor is not None:
             self.interactor.process_requests()
         if self.plotter and self.p.io.autoplot.make_movie:
             logger.info('Waiting for Client to make movie ')
@@ -586,7 +586,7 @@ class Ptycho(Base):
             self.interactor.stop()
         except BaseException:
             pass
-                    
+
     def _run(self, run_label=None):
         """
         *deprecated*
@@ -595,44 +595,44 @@ class Ptycho(Base):
         # Time the initialization
         if self.runtime.get('start') is None:
             self.runtime.start = time.asctime()
-    
+
         # Check if there is already a runtime info collector
         if self.runtime.get('iter_info') is None:
             self.runtime.iter_info = []
-        
+
         # Note when the last autosave was carried out
         if self.runtime.get('last_save') is None:
             self.runtime.last_save = 0
-        
+
         # Maybe not needed
         if self.runtime.get('last_plot') is None:
             self.runtime.last_plot = 0
-            
+
         # Run all engines sequentially
         for run_label in self.run_labels:
-            
+
             # Set a new engine
             engine = self.engines[run_label]
             # self.current_engine = engine
-            
+
             # Prepare the engine
             engine.initialize()
 
             # Start the iteration loop
             while not engine.finished:
                 # Check for client requests
-                if parallel.master and self.interactor is not None: 
+                if parallel.master and self.interactor is not None:
                     self.interactor.process_requests()
-                
+
                 parallel.barrier()
-                
+
                 # Check for new data
                 self.modelm.new_data()
-                
+
                 # Last minute preparation before a contiguous block of
                 # iterations
                 engine.prepare()
-                
+
                 if self.p.autosave is not None and self.p.autosave.interval > 1:
                     if engine.curiter % self.p.autosave.interval == 0:
                         auto = self.paths.auto_file(self.runtime)
@@ -643,9 +643,9 @@ class Ptycho(Base):
 
                 # One iteration
                 engine.iterate()
-                
+
                 # Display runtime information and do saving
-                if parallel.master: 
+                if parallel.master:
                     info = self.runtime.iter_info[-1]
                     # Calculate error:
                     err = np.array(info['error'].values()).mean(0)
@@ -653,40 +653,40 @@ class Ptycho(Base):
                                 'Time %(duration).2f' % info)
                     logger.info('Errors :: Fourier %.2e, Photons %.2e, '
                                 'Exit %.2e' % tuple(err))
-                
+
                 parallel.barrier()
-            # Done. Let the engine finish up    
+            # Done. Let the engine finish up
             engine.finalize()
-    
+
             # Save
             # Deactivated for now as something fishy happens through MPI
             self.save_run()
 
         # Clean up - if needed.
-        
+
         # Time the initialization
         self.runtime.stop = time.asctime()
-        
+
     @classmethod
     def _from_dict(cls, dct):
         # This method will be called from save_load on linking
         inst = cls(level=0)
         inst.__dict__.update(dct)
         return inst
-        
+
     @classmethod
     def load_run(cls, runfile, load_data=True):
         """
         Load a previous run.
-        
+
         Parameters
         ----------
         runfile : str
                 file dump of Ptycho class
         load_data : bool
-                If `True` also load data (thus regenerating pods & views 
+                If `True` also load data (thus regenerating pods & views
                 for 'minimal' dump
-        
+
         Returns
         -------
         P : Ptycho
@@ -694,7 +694,7 @@ class Ptycho(Base):
         """
         import save_load
         from .. import io
-        
+
         # Determine if this is a .pty file
         # FIXME: do not rely on ".pty" extension.
         if not runfile.endswith('.pty') and not runfile.endswith('.ptyr'):
@@ -702,16 +702,16 @@ class Ptycho(Base):
                 'Only ptypy file type allowed for continuing a reconstruction')
             logger.warning('Exiting..')
             return None
-        
+
         logger.info('Creating Ptycho instance from %s' % runfile)
         header = u.Param(io.h5read(runfile, 'header')['header'])
         if header['kind'] == 'minimal':
             logger.info('Found minimal ptypy dump')
             content = u.Param(io.h5read(runfile, 'content')['content'])
-            
+
             logger.info('Creating new Ptycho instance')
             P = Ptycho(content.pars, level=1)
-            
+
             logger.info('Attaching probe and object storages')
             for ID, s in content['probe'].items():
                 s['owner'] = P.probe
@@ -722,14 +722,14 @@ class Ptycho(Base):
                 S = Storage._from_dict(s)
                 P.obj._new_ptypy_object(S)
                 # S.owner=P.obj
-                
+
             logger.info('Attaching original runtime information')
             P.runtime = content['runtime']
             # P.paths.runtime = P.runtime
-        
+
         elif header['kind'] == 'fullflat':
             P = save_load.link(io.h5read(runfile, 'content')['content'])
-            
+
             logger.info('Configuring data types, verbosity '
                         'and server-client communication')
 
@@ -739,57 +739,57 @@ class Ptycho(Base):
             print u.verbose.report(P.p)
             P.modelm.sharing_rules = model.parse_model(P.modelm.p['sharing'],
                                                        P.modelm.sharing)
-            
+
             logger.info('Regenerating exit waves')
             P.exit.reformat()
             P.modelm._initialize_exit(P.pods.values())
             """
             logger.info('Attaching datasource')
             P.datasource = P.modelm.make_datasource(P.p.data)
-            
+
             logger.info('Reconfiguring sharing rules and loading data')
             P.modelm.sharing_rules = model.parse_model(P.p.model['sharing'],
                                                        P.modelm.sharing)
             P.modelm.new_data()
-            
+
 
             """
         if load_data:
             logger.info('Loading data')
             P.init_data()
         return P
-        
+
     def save_run(self, alt_file=None, kind='minimal', force_overwrite=True):
         """
         Save run to file.
-        
+
         As for now, diffraction / mask data is not stored
-        
+
         Parameters
         ----------
         alt_file : str
             Alternative filepath, will override io.save_file
-            
+
         kind : str
             Type of saving, one of:
-            
-                - *'minimal'*, only initial parameters, probe and object 
+
+                - *'minimal'*, only initial parameters, probe and object
                   storages and runtime information is saved.
                 - *'full_flat'*, (almost) complete environment
-               
+
         """
         import save_load
         from .. import io
-        
+
         dest_file = None
-        
+
         if parallel.master:
 
-            if alt_file is not None: 
+            if alt_file is not None:
                 dest_file = u.clean_path(alt_file)
             else:
                 dest_file = self.paths.recon_file(self.runtime)
-    
+
             header = {'kind': kind,
                       'description': 'Ptypy .h5 compatible storage format'}
 
@@ -805,8 +805,8 @@ class Ptycho(Base):
                     ans = raw_input('File %s exists! Overwrite? [Y]/N'
                                     % dest_file)
                     if ans and ans.upper() != 'Y':
-                        raise RuntimeError('Operation cancelled by user.') 
-            
+                        raise RuntimeError('Operation cancelled by user.')
+
             if kind == 'fullflat':
                 self.interactor.stop()
                 logger.info('Deleting references for interactor, '
@@ -830,13 +830,13 @@ class Ptycho(Base):
                         del pod.exit
                 except AttributeError:
                     self.exit.clear()
-                    
+
                 self.diff.clear()
                 self.mask.clear()
                 logger.info('Unlinking and saving to %s' % dest_file)
                 content = save_load.unlink(self)
                 # io.h5write(dest_file, header=header, content=content)
-                
+
             elif kind == 'dump':
                 # if self.interactor is not None:
                 #    self.interactor.stop()
@@ -854,7 +854,7 @@ class Ptycho(Base):
                     dump.runtime.iter_info = [self.runtime.iter_info[-1]]
 
                 content = dump
-                
+
             elif kind == 'minimal':
                 # if self.interactor is not None:
                 #    self.interactor.stop()
@@ -868,7 +868,7 @@ class Ptycho(Base):
                 minimal.pars = self.p.copy()  # _to_dict(Recursive=True)
                 minimal.runtime = self.runtime.copy()
                 content = minimal
-                        
+
             h5opt = io.h5options['UNSUPPORTED']
             io.h5options['UNSUPPORTED'] = 'ignore'
             logger.info('Saving to %s' % dest_file)
@@ -880,7 +880,7 @@ class Ptycho(Base):
         # finished after saving
         parallel.barrier()
         return dest_file
-        
+
     def print_stats(self, table_format=None, detail='summary'):
         """
         Calculates the memory usage and other info of ptycho instance
@@ -892,7 +892,7 @@ class Ptycho(Base):
                 "Process #%d ---- Total Pods %d (%d active) ----"
                 % (parallel.rank, all_pods, active_pods) + '\n',
                 '-' * 80 + '\n']
-           
+
         header = True
         for ID, C in self.containers.iteritems():
             info.append(C.formatted_report(table_format,
@@ -900,7 +900,7 @@ class Ptycho(Base):
                                            include_header=header))
             if header:
                 header = False
-            
+
         info.append('\n')
         if str(detail) != 'summary':
             for ID, C in self.containers.iteritems():

--- a/ptypy/core/xy.py
+++ b/ptypy/core/xy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-This module generates the scan patterns. 
+This module generates the scan patterns.
 
 This file is part of the PTYPY package.
 
@@ -13,7 +13,7 @@ import numpy as np
 import warnings
 warnings.simplefilter('always', DeprecationWarning)
 __all__ = ['DEFAULT', 'from_pars', 'round_scan', 'raster_scan', 'spiral_scan']
-         
+
 TEMPLATES = u.Param()
 
 DEFAULT = u.Param(
@@ -38,7 +38,7 @@ DEFAULT = u.Param(
 def from_pars(xypars=None):
     """
     Creates position array from parameter tree `pars`. See :py:data:`DEFAULT`
-    
+
     :param xypars: TreeDict
         Input parameters
     :return: ndarray pos
@@ -53,7 +53,7 @@ def from_pars(xypars=None):
         return None
     elif str(xypars) == xypars:
         if xypars in TEMPLATES.keys():
-            return from_pars(TEMPLATES[sam])          
+            return from_pars(TEMPLATES[sam])
         else:
             raise RuntimeError(
                 'Template string `%s` for pattern creation is not understood'
@@ -63,10 +63,10 @@ def from_pars(xypars=None):
     else:
         ValueError('Input type `%s` for scan pattern creation is not understood'
                    % str(type(xypars)))
-    
+
     if p.override is not None:
         return np.asarray(p.override)
-        
+
     elif p.model is None:
         logger.debug('Scan pattern model `None` is chosen.\n'
                      'Will use positions provided by meta information.')
@@ -85,7 +85,7 @@ def from_pars(xypars=None):
             pos = raster_scan(s[0], s[1], l[0], l[1])
         else:
             raise NameError('Unknown pattern type %s' % str(p.model))
-        
+
         if p.offset is not None:
             pos += u.expect2(p.offset)
         # Filter roi
@@ -98,15 +98,15 @@ def from_pars(xypars=None):
                         and (posi[1] >= -roi[1])
                         and (posi[1] <= roi[1])):
                     new.append(posi)
-                
+
             pos = np.array(new)
-            
+
         if p.jitter is not None:
             pos = pos
-        
+
         if p.count is not None and p.count > 0:
             pos = pos[:int(p.count)]
-            
+
         logger.info('Prepared %d positions' % len(pos))
         return pos
 
@@ -119,7 +119,7 @@ def _complete(extent, steps, spacing):
     elif steps is None:
         e = u.expect2(extent)
         s = u.expect2(spacing)
-        l = (e / s).astype(np.int) 
+        l = (e / s).astype(np.int)
     elif spacing is None:
         e = u.expect2(extent)
         l = u.expect2(steps)
@@ -128,7 +128,7 @@ def _complete(extent, steps, spacing):
         l = u.expect2(steps)
         s = u.expect2(spacing)
         e = l * s
-        
+
     return e, l, s
 
 
@@ -138,33 +138,33 @@ def augment_to_coordlist(a, Npos):
     a = np.asarray(a)
     if a.size == 1:
         a = np.atleast_2d([a, a])
-        
+
     if a.size % 2 != 0:
         a = a.flatten()[:-1]
-    
+
     a = a.reshape(a.size//2, 2)
     # Append multiples of a until length is greater equal than Npos
     if a.shape[0] < Npos:
         b = np.concatenate((1 + Npos//a.shape[0]) * [a], axis=0)
     else:
         b = a
-    
+
     return b[:Npos, :2]
 
 
 def raster_scan(ny=10, nx=10, dy=1.5e-6, dx=1.5e-6):
     """
     Generates a raster scan.
-    
+
     Parameters
     ----------
     ny, nx : int
         Number of steps in *y* (vertical) and *x* (horizontal) direction
         *x* is the fast axis
-        
+
     dy, dx : float
         Step size (grid spacing) in *y* and *x*
-        
+
     Returns
     -------
     pos : ndarray
@@ -185,21 +185,21 @@ def raster_scan(ny=10, nx=10, dy=1.5e-6, dx=1.5e-6):
 def round_scan(dr=1.5e-6, nr=5, nth=5, bullseye=True):
     """
     Generates a round scan
-    
+
     Parameters
     ----------
     nr : int
         Number of radial steps from center, ``nr + 1`` shells will be made
-        
+
     dr : float
         Step size (shell spacing)
-        
+
     nth : int, optional
         Number of points in first shell
 
     bullseye : bool
         If set false, point of origin will be ignored
-        
+
     Returns
     -------
     pos : ndarray
@@ -216,7 +216,7 @@ def round_scan(dr=1.5e-6, nr=5, nth=5, bullseye=True):
         positions = [(0., 0.)]
     else:
         positions = []
-        
+
     for ir in range(1, nr+2):
         rr = ir * dr
         dth = 2 * np.pi / (nth * ir)
@@ -228,18 +228,18 @@ def round_scan(dr=1.5e-6, nr=5, nth=5, bullseye=True):
 def spiral_scan(dr=1.5e-6, r=7.5e-6, maxpts=None):
     """
     Generates a spiral scan.
-    
+
     Parameters
     ----------
     r : float
         Number of radial steps from center, ``nr + 1`` shells will be made
-        
+
     dr : float
         Step size (shell spacing)
-        
+
     nth : int, optional
         Number of points in first shell
-        
+
     Returns
     -------
     pos : ndarray
@@ -254,7 +254,7 @@ def spiral_scan(dr=1.5e-6, r=7.5e-6, maxpts=None):
     """
     alpha = np.sqrt(4 * np.pi)
     beta = dr / (2*np.pi)
-    
+
     if maxpts is None:
         maxpts = 100000
 
@@ -271,7 +271,7 @@ def spiral_scan(dr=1.5e-6, r=7.5e-6, maxpts=None):
 def raster_scan_legacy(nx, ny, dx, dy):# pragma: no cover
     """
     Generates a raster scan.
-    
+
     Legacy function. May get deprecated in future.
     """
 
@@ -284,7 +284,7 @@ def raster_scan_legacy(nx, ny, dx, dy):# pragma: no cover
 def round_scan_legacy(r_in, r_out, nr, nth):# pragma: no cover
     """
     Generates a round scan,
-    
+
     Legacy function. May get deprecated in future.
     """
     warnings.warn('This function is deprecated and will be removed from the package on 30/11/16',DeprecationWarning)
@@ -301,7 +301,7 @@ def round_scan_legacy(r_in, r_out, nr, nth):# pragma: no cover
 def round_scan_roi_legacy(dr, lx, ly, nth):# pragma: no cover
     """
     Round scan positions with ROI, defined as in spec and matlab.
-    
+
     Legacy function. May get deprecated in future.
     """
     warnings.warn('This function is deprecated and will be removed from the package on 30/11/16',DeprecationWarning)
@@ -329,7 +329,7 @@ def spiral_scan_legacy(dr, r_out=None, maxpts=None):# pragma: no cover
 
     alpha = np.sqrt(4 * np.pi)
     beta = dr / (2*np.pi)
-    
+
     if maxpts is None:
         assert r_out is not None
         maxpts = 100000000
@@ -350,7 +350,7 @@ def spiral_scan_legacy(dr, r_out=None, maxpts=None):# pragma: no cover
 def spiral_scan_roi_legacy(dr, lx, ly):# pragma: no cover
     """\
     Spiral scan positions. ROI
-    
+
     Legacy function. May get deprecated in future.
     """
     warnings.warn('This function is deprecated and will be removed from the package on 30/11/16',DeprecationWarning)

--- a/ptypy/core/xy_old.py
+++ b/ptypy/core/xy_old.py
@@ -8,7 +8,7 @@ This file is part of the PTYPY package.
     :license: GPLv2, see LICENSE for details.
 """
 from .. import utils as u
-#from ..utils import prop 
+#from ..utils import prop
 from ..utils.verbose import logger
 import numpy as np
 import os
@@ -17,18 +17,18 @@ warnings.simplefilter('always', DeprecationWarning)
 warnings.warn('This module is deprecated and will be removed from the package on 30/11/16',DeprecationWarning)
 
 DEFAULT=u.Param(
-    #### Paramaters for popular scan methods 
+    #### Paramaters for popular scan methods
     scan_type = None, # [None,'round', 'raster', 'round_roi','spiral','spiral_roi','custom']
-    dr = 1.5e-6,             # round,round_roi :width of shell 
-    nr = 5,                 # round : number of intervals (# of shells - 1) 
-    nth = 5,                 # round,round_roi: number of points in the first shell 
-    lx = 15e-6,               # round_roi: Width of ROI 
-    ly = 15e-6,               # round_roi: Height of ROI 
+    dr = 1.5e-6,             # round,round_roi :width of shell
+    nr = 5,                 # round : number of intervals (# of shells - 1)
+    nth = 5,                 # round,round_roi: number of points in the first shell
+    lx = 15e-6,               # round_roi: Width of ROI
+    ly = 15e-6,               # round_roi: Height of ROI
     nx = 10,                 # raster scan: number of steps in x
     ny = 10,                 # raster scan: number of steps in y
     dx = 1.5e-6,               # raster scan: step size (grid spacing)
     dy = 1.5e-6,               # raster scan: step size (grid spacing)
-    #### other 
+    #### other
     positions = None,        # fill this list with your own script if you want other scan patterns, choose 'custom' as san type
 )
 """Default pattern parameters. See :py:data:`.scan.xy` and a short listing below"""
@@ -39,11 +39,11 @@ def from_pars(pars=None):
     p=u.Param(DEFAULT)
     if pars is not None: # and (isinstance(pars,dict) or isinstance(pars,u.Param)):
         p.update(pars)
-    
+
     if p.scan_type is None:
         logger.debug('Scan_type `None` is chosen . Will use positions provided by meta information')
         return None
-        
+
     elif p.scan_type=='round':
         pos=round_scan_positions(0,p.dr*p.nr,p.nr,p.nth)
     elif p.scan_type=='round_roi':
@@ -54,12 +54,12 @@ def from_pars(pars=None):
         pos=spiral_scan_ROI_positions(p.dr,p.lx,p.ly)
     elif p.scan_type=='raster':
         pos=raster_scan_positions(p.nx, p.ny, p.dx,p.dy)
-    else: 
+    else:
         pos = p.positions
     pos=np.asarray(pos)
     logger.info('Prepared %d positions' % len(pos))
     return pos
-    
+
 def scanpositions(scandict):
     warnings.warn('This function is deprecated and will be removed from the package on 30/11/16',DeprecationWarning)
 
@@ -71,34 +71,34 @@ def scanpositions(scandict):
     elif sd['scan_type']=='spiral':
         positions=spiral_scan_positions(sd['dr'],sd['dr']*sd['nr'])
     elif sd['scan_type']=='spiral_roi':
-        positions=spiral_scan_ROI_positions(sd['dr'],sd['lx'],sd['ly'])        
+        positions=spiral_scan_ROI_positions(sd['dr'],sd['lx'],sd['ly'])
     elif sd['scan_type']=='raster':
         positions=raster_scan_positions(sd['nx'], sd['ny'], sd['dx'],sd['dy'])
-    else: 
+    else:
         positions=sd['positions']
     return np.asarray(positions)
 
 def augment_to_coordlist(a,Npos):
     warnings.warn('This function is deprecated and will be removed from the package on 30/11/16',DeprecationWarning)
- 
+
     # force into a 2 column matrix
     # drop element if size is not a modulo of 2
     a = np.asarray(a)
     if a.size == 1:
         a=np.atleast_2d([a,a])
-        
+
     if a.size % 2 != 0:
         a=a.flatten()[:-1]
-    
+
     a=a.reshape(a.size//2,2)
     # append multiples of a until length is greater equal than Npos
     if a.shape[0] < Npos:
         b=np.concatenate((1+Npos//a.shape[0])*[a],axis=0)
     else:
         b=a
-    
+
     return b[:Npos,:2]
-    
+
 def raster_scan_positions(nx,ny,sx,sy):
     warnings.warn('This function is deprecated and will be removed from the package on 30/11/16',DeprecationWarning)
     iix, iiy = np.indices((nx+1,ny+1))
@@ -145,7 +145,7 @@ def spiral_scan_positions(dr,r_out=None,maxpts=None):
     warnings.warn('This function is deprecated and will be removed from the package on 30/11/16',DeprecationWarning)
     alpha = np.sqrt(4*np.pi)
     beta = dr/(2*np.pi)
-    
+
     if maxpts is None:
         assert r_out is not None
         maxpts = 100000000
@@ -169,7 +169,7 @@ def spiral_scan_ROI_positions(dr,lx,ly):
 
     alpha = np.sqrt(4*np.pi)
     beta = dr/(2*np.pi)
-    
+
     rmax = .5*np.sqrt(lx**2 + ly**2)
     positions = []
     for k in xrange(1000000000):

--- a/ptypy/debug/ipython_kernel.py
+++ b/ptypy/debug/ipython_kernel.py
@@ -14,7 +14,7 @@ __all__ = ['IPythonKernelThread', 'start_ipython_kernel']
 try:
     from IPython import embed_kernel
     import mock
-    
+
     class IPythonKernelThread(threading.Thread):
         def __init__(self, ns):
             threading.Thread.__init__(self)

--- a/ptypy/engines/DM_simple.py
+++ b/ptypy/engines/DM_simple.py
@@ -100,10 +100,10 @@ class DM_simple(BaseEngine):
                 # Stop iteration if probe change is small
                 if change < self.p.overlap_converge_factor:
                     break
-            
+
             # needed for BaseEngine
-            self.curiter += 1 
-            
+            self.curiter += 1
+
             t2 = time.time()
             to = t2 - t1
 

--- a/ptypy/engines/ML.py
+++ b/ptypy/engines/ML.py
@@ -33,7 +33,7 @@ DEFAULT = u.Param(
 
 
 class ML(BaseEngine):
-    
+
     DEFAULT = DEFAULT
 
     def __init__(self, ptycho_parent, pars=None):
@@ -63,7 +63,7 @@ class ML(BaseEngine):
         self.tmin = None
         self.ML_model = None
         self.smooth_gradient = None
-        
+
     def engine_initialize(self):
         """
         Prepare for ML reconstruction.
@@ -76,9 +76,9 @@ class ML(BaseEngine):
         # Probe gradient and minimization direction
         self.pr_grad = self.pr.copy(self.pr.ID + '_grad', fill=0.)
         self.pr_h = self.pr.copy(self.pr.ID + '_h', fill=0.)
-   
+
         self.tmin = 1.
-        
+
         # Create noise model
         if self.p.ML_type.lower() == "gaussian":
             self.ML_model = ML_Gaussian(self)
@@ -88,7 +88,7 @@ class ML(BaseEngine):
             self.ML_model = ML_Gaussian(self)
         else:
             raise RuntimeError("Unsupported ML_type: '%s'" % self.p.ML_type)
-            
+
         # Other options
         self.smooth_gradient = prepare_smoothing_preconditioner(
             self.p.smooth_gradient)
@@ -97,7 +97,7 @@ class ML(BaseEngine):
         """
         Last minute initialization, everything, that needs to be recalculated,
         when new data arrives.
-        """     
+        """
         # - # fill object with coverage of views
         # - for name,s in self.ob_viewcover.S.iteritems():
         # -    s.fill(s.get_view_coverage())
@@ -115,25 +115,25 @@ class ML(BaseEngine):
         ta = time.time()
         for it in range(num):
             t1 = time.time()
-            new_ob_grad, new_pr_grad, error_dct = self.ML_model.new_grad() 
+            new_ob_grad, new_pr_grad, error_dct = self.ML_model.new_grad()
             tg += time.time() - t1
-            
+
             if self.p.probe_update_start <= self.curiter:
                 # Apply probe support if needed
                 for name, s in new_pr_grad.storages.iteritems():
                     support = self.probe_support.get(name)
-                    if support is not None: 
+                    if support is not None:
                         s.data *= support
             else:
                 new_pr_grad.fill(0.)
-    
+
             # Smoothing preconditioner
             # !!! Lets make this consistent with
             # the smoothing already done in DM
             # if self.smooth_gradient:
             #     for name, s in new_ob_grad.storages.iteritems():
             #         s.data[:] = self.smooth_gradient(s.data)
-    
+
             # probe/object rescaling
             if self.p.scale_precond:
                 scale_p_o = (self.p.scale_probe_object * Cnorm2(new_ob_grad)
@@ -141,7 +141,7 @@ class ML(BaseEngine):
                 logger.debug('Scale P/O: %6.3g' % scale_p_o)
             else:
                 scale_p_o = self.p.scale_probe_object
-    
+
             ############################
             # Compute next conjugate
             ############################
@@ -155,11 +155,11 @@ class ML(BaseEngine):
                              - np.real(Cdot(new_ob_grad, self.ob_grad))))
 
                 bt_denom = scale_p_o*Cnorm2(self.pr_grad) + Cnorm2(self.ob_grad)
-    
+
                 bt = max(0, bt_num/bt_denom)
-    
+
             # verbose(3,'Polak-Ribiere coefficient: %f ' % bt)
-    
+
             self.ob_grad << new_ob_grad
             self.pr_grad << new_pr_grad
             """
@@ -178,7 +178,7 @@ class ML(BaseEngine):
             for name,s in self.ob_h.storages.iteritems():
                 s.data *= bt
                 s.data -= self.ob_grad.storages[name].data
-                
+
             for name,s in self.pr_h.storages.iteritems():
                 s.data *= bt
                 s.data -= scale_p_o * self.pr_grad.storages[name].data
@@ -186,17 +186,17 @@ class ML(BaseEngine):
             # 3. Next conjugate
             # ob_h = self.ob_h
             # ob_h *= bt
-            
+
             # Smoothing preconditioner not implemented.
             # if self.smooth_gradient:
             #    ob_h -= object_smooth_filter(grad_obj)
             # else:
             #    ob_h -= ob_grad
-            
+
             # ob_h -= ob_grad
             # pr_h *= bt
             # pr_h -= scale_p_o * pr_grad
-            
+
             # Minimize - for now always use quadratic approximation
             # (i.e. single Newton-Raphson step)
             # In principle, the way things are now programmed this part
@@ -204,13 +204,13 @@ class ML(BaseEngine):
             t2 = time.time()
             B = self.ML_model.poly_line_coeffs(self.ob_h, self.pr_h)
             tc += time.time() - t2
-            
+
             if np.isinf(B).any() or np.isnan(B).any():
                 logger.warning(
                     'Warning! inf or nan found! Trying to continue...')
                 B[np.isinf(B)] = 0.
                 B[np.isnan(B)] = 0.
-                
+
             self.tmin = -.5 * B[1] / B[2]
             self.ob_h *= self.tmin
             self.pr_h *= self.tmin
@@ -223,10 +223,10 @@ class ML(BaseEngine):
                 s.data += tmin*self.pr_h.storages[name].data
             """
             # Newton-Raphson loop would end here
-            
+
             # increase iteration counter
             self.curiter +=1
-        
+
         logger.info('Time spent in gradient calculation: %.2f' % tg)
         logger.info('  ....  in coefficient calculation: %.2f' % tc)
         return error_dct  # np.array([[self.ML_model.LL[0]] * 3])
@@ -248,10 +248,10 @@ class ML(BaseEngine):
 class ML_Gaussian(object):
     """
     """
-        
+
     def __init__(self, MLengine):
         """
-        Core functions for ML computation using a Gaussian model. 
+        Core functions for ML computation using a Gaussian model.
         """
         self.engine = MLengine
 
@@ -314,7 +314,7 @@ class ML_Gaussian(object):
         del self.ob_grad
         del self.engine.ptycho.containers[self.pr_grad.ID]
         del self.pr_grad
-        
+
         # Remove working attributes
         for name, diff_view in self.di.views.iteritems():
             if not diff_view.active:
@@ -343,27 +343,27 @@ class ML_Gaussian(object):
         for dname, diff_view in self.di.views.iteritems():
             if not diff_view.active:
                 continue
-            
+
             # Weights and intensities for this view
             w = self.weights[diff_view]
             I = diff_view.data
-            
+
             Imodel = np.zeros_like(I)
             f = {}
-            
+
             # First pod loop: compute total intensity
             for name, pod in diff_view.pods.iteritems():
                 if not pod.active:
                     continue
                 f[name] = pod.fw(pod.probe * pod.object)
                 Imodel += u.abs2(f[name])
-        
+
             # Floating intensity option
             if self.p.floating_intensities:
                 diff_view.float_intens_coeff = ((w * Imodel * I).sum()
                                                 / (w * Imodel**2).sum())
-                Imodel *= diff_view.float_intens_coeff 
-            
+                Imodel *= diff_view.float_intens_coeff
+
             DI = Imodel - I
 
             # Second pod loop: gradients computation
@@ -393,7 +393,7 @@ class ML_Gaussian(object):
             parallel.allreduce(s.data)
         """
         parallel.allreduce(LL)
-        
+
         # Object regularizer
         if self.regularizer:
             for name, s in self.ob.storages.iteritems():
@@ -401,7 +401,7 @@ class ML_Gaussian(object):
                     s.data)
 
         self.LL = LL / self.tot_measpts
-        
+
         return self.ob_grad, self.pr_grad, error_dct
 
     def poly_line_coeffs(self, ob_h, pr_h):
@@ -409,15 +409,15 @@ class ML_Gaussian(object):
         Compute the coefficients of the polynomial for line minimization
         in direction h
         """
-        
+
         B = np.zeros((3,), dtype=np.longdouble)
         Brenorm = 1. / self.LL[0]**2
-        
+
         # Outer loop: through diffraction patterns
         for dname, diff_view in self.di.views.iteritems():
             if not diff_view.active:
                 continue
-            
+
             # Weights and intensities for this view
             w = self.weights[diff_view]
             I = diff_view.data
@@ -425,7 +425,7 @@ class ML_Gaussian(object):
             A0 = None
             A1 = None
             A2 = None
-            
+
             for name, pod in diff_view.pods.iteritems():
                 if not pod.active:
                     continue
@@ -433,8 +433,8 @@ class ML_Gaussian(object):
                 a = pod.fw(pod.probe * ob_h[pod.ob_view]
                            + pr_h[pod.pr_view] * pod.object)
                 b = pod.fw(pr_h[pod.pr_view] * ob_h[pod.ob_view])
-    
-                if A0 is None: 
+
+                if A0 is None:
                     A0 = u.abs2(f).astype(np.longdouble)
                     A1 = 2 * np.real(f * a.conj()).astype(np.longdouble)
                     A2 = (2 * np.real(f * b.conj()).astype(np.longdouble)
@@ -449,11 +449,11 @@ class ML_Gaussian(object):
                 A1 *= diff_view.float_intens_coeff
                 A2 *= diff_view.float_intens_coeff
             A0 -= I
-    
+
             B[0] += np.dot(w.flat, (A0**2).flat) * Brenorm
             B[1] += np.dot(w.flat, (2 * A0 * A1).flat) * Brenorm
             B[2] += np.dot(w.flat, (A1**2 + 2*A0*A2).flat) * Brenorm
- 
+
         parallel.allreduce(B)
 
         # Object regularizer
@@ -463,7 +463,7 @@ class ML_Gaussian(object):
                     ob_h.storages[name].data, s.data)
 
         self.B = B
-        
+
         return B
 
 # Regul class does not exist, replace by objectclass
@@ -480,8 +480,8 @@ class Regul_del2(object):
         # Regul.__init__(self, axes)
         self.axes = axes
         self.amplitude = amplitude
-        self.delxy = None        
-        
+        self.delxy = None
+
     def grad(self, x):
         """
         Compute and return the regularizer gradient given the array x.
@@ -496,7 +496,7 @@ class Regul_del2(object):
         self.g = 2. * self.amplitude*(del_xb + del_yb - del_xf - del_yf)
 
         return self.g
-        
+
     def poly_line_coeffs(self, h, x=None):
         ax0, ax1 = self.axes
         if x is None:
@@ -506,12 +506,12 @@ class Regul_del2(object):
             del_yf = u.delxf(x, axis=ax1)
             del_xb = u.delxb(x, axis=ax0)
             del_yb = u.delxb(x, axis=ax1)
-            
+
         hdel_xf = u.delxf(h, axis=ax0)
         hdel_yf = u.delxf(h, axis=ax1)
         hdel_xb = u.delxb(h, axis=ax0)
         hdel_yb = u.delxb(h, axis=ax1)
-        
+
         c0 = self.amplitude * (u.norm2(del_xf)
                                + u.norm2(del_yf)
                                + u.norm2(del_xb)
@@ -526,7 +526,7 @@ class Regul_del2(object):
                                + u.norm2(hdel_yf)
                                + u.norm2(hdel_xb)
                                + u.norm2(hdel_yb))
-        
+
         self.coeff = np.array([c0, c1, c2])
         return self.coeff
 

--- a/ptypy/engines/ML_old.py
+++ b/ptypy/engines/ML_old.py
@@ -43,7 +43,7 @@ DEFAULT = u.Param(
 
 
 class ML(BaseEngine):# pragma: no cover
-    
+
     DEFAULT = DEFAULT
 
     def __init__(self, ptycho_parent, pars=None):
@@ -53,7 +53,7 @@ class ML(BaseEngine):# pragma: no cover
         if pars is None:
             pars = DEFAULT.copy()
         super(ML, self).__init__(ptycho_parent, pars)
-        
+
     def engine_initialize(self):
         """
         Prepare for ML reconstruction.
@@ -68,7 +68,7 @@ class ML(BaseEngine):# pragma: no cover
         # Probe gradient
         self.pr_grad = self.pr.copy(self.pr.ID+'_grad',fill=0.) # Probe gradient
         self.pr_h = self.pr.copy(self.pr.ID+'_h',fill=0.) # Probe minimization direction
-   
+
         # Create noise model
         if self.p.ML_type.lower() == "gaussian":
             self.ML_model = ML_Gaussian(self)
@@ -78,20 +78,20 @@ class ML(BaseEngine):# pragma: no cover
             self.ML_model = ML_Gaussian(self)
         else:
             raise RuntimeError("Unsupported ML_type: '%s'" % self.p.ML_type)
-            
+
         # Other options
         self.smooth_gradient = prepare_smoothing_preconditioner(self.p.smooth_gradient)
 
     def engine_prepare(self):
         """
         last minute initialization, everything, that needs to be recalculated, when new data arrives
-        """     
+        """
         #- # fill object with coverage of views
         #- for name,s in self.ob_viewcover.S.iteritems():
         #-    s.fill(s.get_view_coverage())
         pass
-        
-        
+
+
     def engine_iterate(self, num=1):
         """
         Compute `num` iterations.
@@ -100,30 +100,30 @@ class ML(BaseEngine):# pragma: no cover
         # Compute new gradient
         ########################
         for it in range(num):
-            new_ob_grad, new_pr_grad, error_dct = self.ML_model.new_grad() 
-    
+            new_ob_grad, new_pr_grad, error_dct = self.ML_model.new_grad()
+
             if (self.p.probe_update_start <= self.curiter):
                 # Apply probe support if needed
                 for name,s in new_pr_grad.S.iteritems():
                     support = self.probe_support.get(name)
-                    if support is not None: 
+                    if support is not None:
                         s.data *= support
             else:
                 new_pr_grad.fill(0.)
-    
+
             # Smoothing preconditioner
             # !!! Lets make this consistent with the smoothing already done in DM
             #if self.smooth_gradient:
             #    for name,s in new_ob_grad.S.iteritems()
             #    s.data[:] = self.smooth_gradient(s.data)
-    
+
             # probe/object rescaling
             if self.p.scale_precond:
                 scale_p_o = self.p.scale_probe_object * Cnorm2(new_ob_grad) / Cnorm2(new_pr_grad)
                 logger.debug('Scale P/O: %6.3g' % scale_p_o)
             else:
                 scale_p_o = self.p.scale_probe_object
-    
+
             ############################
             # Compute next conjugate
             ############################
@@ -131,61 +131,61 @@ class ML(BaseEngine):# pragma: no cover
                 bt = 0.
             else:
                 bt_num = scale_p_o * ( Cnorm2(new_pr_grad) - np.real(Cdot(new_pr_grad, self.pr_grad))) +\
-                                     ( Cnorm2(new_ob_grad) - np.real(Cdot(new_ob_grad, self.ob_grad))) 
-                bt_denom = scale_p_o * Cnorm2(self.pr_grad) + Cnorm2(self.ob_grad) 
-    
+                                     ( Cnorm2(new_ob_grad) - np.real(Cdot(new_ob_grad, self.ob_grad)))
+                bt_denom = scale_p_o * Cnorm2(self.pr_grad) + Cnorm2(self.ob_grad)
+
                 bt = max(0,bt_num/bt_denom)
-    
+
             #verbose(3,'Polak-Ribiere coefficient: %f ' % bt)
-    
+
             # It would be nice to have something more elegant than the following
             for name,s in self.ob_grad.S.iteritems():
                 s.data[:] = new_ob_grad.S[name].data
             for name,s in self.pr_grad.S.iteritems():
                 s.data[:] = new_pr_grad.S[name].data
-            
+
             # 3. Next conjugate
             for name,s in self.ob_h.S.iteritems():
                 s.data *= bt
                 s.data -= self.ob_grad.S[name].data
-                
+
             for name,s in self.pr_h.S.iteritems():
                 s.data *= bt
                 s.data -= scale_p_o * self.pr_grad.S[name].data
-                
+
             # 3. Next conjugate
             #ob_h = self.ob_h
             #ob_h *= bt
-            
+
             # Smoothing preconditioner not implemented.
             #if self.smooth_gradient:
             #    ob_h -= object_smooth_filter(grad_obj)
             #else:
             #    ob_h -= ob_grad
-            
+
             #ob_h -= ob_grad
             #pr_h *= bt
             #pr_h -= scale_p_o * pr_grad
-            
+
             # Minimize - for now always use quadratic approximation (i.e. single Newton-Raphson step)
             # In principle, the way things are now programmed this part could be iterated over in
             # a real NR style.
             B = self.ML_model.poly_line_coeffs(self.ob_h, self.pr_h)
-    
+
             if np.isinf(B).any() or np.isnan(B).any():
                 print 'Warning! inf or nan found! Trying to continue...'
                 B[np.isinf(B)] = 0.
                 B[np.isnan(B)] = 0.
-                
+
             tmin = -.5*B[1]/B[2]
-    
+
             for name,s in self.ob.S.iteritems():
                 s.data += tmin*self.ob_h.S[name].data
             for name,s in self.pr.S.iteritems():
                 s.data += tmin*self.pr_h.S[name].data
             # Newton-Raphson loop would end here
 
-        return error_dct  #np.array([[self.ML_model.LL[0]] * 3]) 
+        return error_dct  #np.array([[self.ML_model.LL[0]] * 3])
 
     def engine_finalize(self):
         """
@@ -199,14 +199,14 @@ class ML(BaseEngine):# pragma: no cover
         del self.pr_grad
         del self.ptycho.containers[self.pr_h.ID]
         del self.pr_h
-               
+
 class ML_Gaussian(object):
     """
     """
-        
+
     def __init__(self, MLengine):
         """
-        Core functions for ML computation using a Gaussian model. 
+        Core functions for ML computation using a Gaussian model.
         """
         self.engine = MLengine
 
@@ -235,7 +235,7 @@ class ML_Gaussian(object):
         if self.p.reg_del2:
             obj_Npix = self.ob.size
             expected_obj_var = obj_Npix / self.tot_power  # Poisson
-            reg_rescale  = self.tot_measpts / (8. * obj_Npix * expected_obj_var) 
+            reg_rescale  = self.tot_measpts / (8. * obj_Npix * expected_obj_var)
             logger.debug('Rescaling regularization amplitude using the Poisson distribution assumption.')
             logger.debug('Factor: %8.5g' % reg_rescale)
             reg_del2_amplitude = self.p.reg_del2_amplitude * reg_rescale
@@ -254,7 +254,7 @@ class ML_Gaussian(object):
         del self.ob_grad
         del self.engine.ptycho.containers[self.pr_grad.ID]
         del self.pr_grad
-        
+
         # Remove working attributes
         for name,diff_view in self.di.V.iteritems():
             if not diff_view.active: continue
@@ -275,32 +275,32 @@ class ML_Gaussian(object):
         pr_grad = self.pr_grad
         ob_grad.fill(0.)
         pr_grad.fill(0.)
-        
+
         LL = np.array([0.]) # We need an array for MPI
         error_dct={}
 
         # Outer loop: through diffraction patterns
         for dname,diff_view in self.di.V.iteritems():
             if not diff_view.active: continue
-            
+
             # Weights and intensities for this view
             w = self.weights[diff_view]
             I = diff_view.data
-            
+
             Imodel = np.zeros_like(I)
             f = {}
-            
+
             # First pod loop: compute total intensity
             for name,pod in diff_view.pods.iteritems():
                 if not pod.active: continue
                 f[name] = pod.fw(pod.probe*pod.object)
                 Imodel += u.abs2(f[name])
-        
+
             # Floating intensity option
             if self.p.floating_intensities:
                 diff_view.float_intens_coeff = (w * Imodel * I).sum() / (w * Imodel**2).sum()
-                Imodel *= diff_view.float_intens_coeff 
-            
+                Imodel *= diff_view.float_intens_coeff
+
             DI = Imodel - I
 
             # Second pod loop: gradients computation
@@ -315,7 +315,7 @@ class ML_Gaussian(object):
                 # Negative log-likelihood term
                 #LLL += (w * DI**2).sum()
 
-            #LLL 
+            #LLL
             diff_view.error = LLL
             error_dct[dname]= np.array([0,LLL / np.prod(DI.shape),0])
             LL += LLL
@@ -326,14 +326,14 @@ class ML_Gaussian(object):
         for name,s in pr_grad.S.iteritems():
             parallel.allreduce(s.data)
         parallel.allreduce(LL)
-        
+
         # Object regularizer
         if self.regularizer:
             for name,s in self.ob.S.iteritems():
                 ob_grad.S[name].data += self.regularizer.grad(s.data)
 
         self.LL = LL / self.tot_measpts
-        
+
         return ob_grad, pr_grad, error_dct
 
     def poly_line_coeffs(self, ob_h, pr_h):
@@ -341,14 +341,14 @@ class ML_Gaussian(object):
         Compute the coefficients of the polynomial for line minimization
         in direction h
         """
-        
+
         B = np.zeros((3,))
         Brenorm = 1./ self.LL[0]**2
-        
+
         # Outer loop: through diffraction patterns
         for dname,diff_view in self.di.V.iteritems():
             if not diff_view.active: continue
-            
+
             # Weights and intensities for this view
             w = self.weights[diff_view]
             I = diff_view.data
@@ -356,14 +356,14 @@ class ML_Gaussian(object):
             A0 = None
             A1 = None
             A2 = None
-            
+
             for name,pod in diff_view.pods.iteritems():
                 if not pod.active: continue
                 f = pod.fw(pod.probe*pod.object)
                 a = pod.fw(pod.probe * ob_h[pod.ob_view] + pr_h[pod.pr_view] * pod.object)
                 b = pod.fw(pr_h[pod.pr_view] * ob_h[pod.ob_view])
-    
-                if A0 is None: 
+
+                if A0 is None:
                     A0 = u.abs2(f)
                     A1 = 2*np.real(f*a.conj())
                     A2 = 2*np.real(f*b.conj()) + u.abs2(a)
@@ -371,17 +371,17 @@ class ML_Gaussian(object):
                     A0 += u.abs2(f)
                     A1 += 2*np.real(f*a.conj())
                     A2 += 2*np.real(f*b.conj()) + u.abs2(a)
-                    
+
             if self.p.floating_intensities:
                 A0 *= diff_view.float_intens_coeff
                 A1 *= diff_view.float_intens_coeff
                 A2 *= diff_view.float_intens_coeff
             A0 -= I
-    
+
             B[0] += np.dot(w.flat,(A0**2).flat) * Brenorm
             B[1] += np.dot(w.flat,(2*A0*A1).flat) * Brenorm
             B[2] += np.dot(w.flat,(A1**2 + 2*A0*A2).flat) * Brenorm
- 
+
         parallel.allreduce(B)
 
         # Object regularizer
@@ -390,7 +390,7 @@ class ML_Gaussian(object):
                 B += Brenorm * self.regularizer.poly_line_coeffs(ob_h.S[name].data, s.data)
 
         self.B = B
-        
+
         return B
 
 # Regul class does not exist, replace by objectclass
@@ -404,8 +404,8 @@ class Regul_del2(object):
         #Regul.__init__(self, axes)
         self.axes = axes
         self.amplitude = amplitude
-        self.delxy = None        
-        
+        self.delxy = None
+
     def grad(self, x):
         """
         Compute and return the regularizer gradient given the array x.
@@ -420,7 +420,7 @@ class Regul_del2(object):
         self.g = 2. * self.amplitude*(del_xb + del_yb - del_xf - del_yf)
 
         return self.g
-        
+
     def poly_line_coeffs(self, h, x=None):
         ax0,ax1 = self.axes
         if x is None:
@@ -430,20 +430,20 @@ class Regul_del2(object):
             del_yf = u.delxf(x,axis=ax1)
             del_xb = u.delxb(x,axis=ax0)
             del_yb = u.delxb(x,axis=ax1)
-            
+
         hdel_xf = u.delxf(h,axis=ax0)
         hdel_yf = u.delxf(h,axis=ax1)
         hdel_xb = u.delxb(h,axis=ax0)
         hdel_yb = u.delxb(h,axis=ax1)
-        
+
         c0 = self.amplitude * (u.norm2(del_xf) + u.norm2(del_yf) + u.norm2(del_xb) + u.norm2(del_yb))
         c1 = 2 * self.amplitude * np.real(np.vdot(del_xf, hdel_xf) + np.vdot(del_yf, hdel_yf) +\
                                           np.vdot(del_xb, hdel_xb) + np.vdot(del_yb, hdel_yb))
         c2 = self.amplitude * (u.norm2(hdel_xf) + u.norm2(hdel_yf) + u.norm2(hdel_xb) + u.norm2(hdel_yb))
-        
+
         self.coeff = np.array([c0,c1,c2])
         return self.coeff
-    
+
 def prepare_smoothing_preconditioner(amplitude):
     """\
     Factory for smoothing preconditioner.

--- a/ptypy/engines/base.py
+++ b/ptypy/engines/base.py
@@ -56,26 +56,26 @@ DEFAULT_iter_info = u.Param(
 class BaseEngine(object):
     """
     Base reconstruction engine.
-    
+
     In child classes, overwrite the following methods for custom behavior :
-    
+
     engine_initialize
     engine_prepare
     engine_iterate
     engine_finalize
     """
-    
+
     DEFAULT = DEFAULT.copy()
 
     def __init__(self, ptycho, pars=None):
         """
         Base reconstruction engine.
-        
+
         Parameters
         ----------
-        ptycho : Ptycho 
+        ptycho : Ptycho
             The parent :any:`Ptycho` object.
-            
+
         pars: Param or dict
             Initialization parameters
         """
@@ -117,13 +117,13 @@ class BaseEngine(object):
         logger.info('Parameter set:')
         logger.info(u.verbose.report(self.p, noheader=True).strip())
         logger.info(headerline('', 'l', '='))
-        
+
         self.curiter = 0
         if self.ptycho.runtime.iter_info:
             self.alliter = self.ptycho.runtime.iter_info[-1]['iterations']
         else:
             self.alliter = 0
-        
+
         # Common attributes for all reconstructions
         self.di = self.ptycho.diff
         self.ob = self.ptycho.obj
@@ -135,7 +135,7 @@ class BaseEngine(object):
         self.probe_support = {}
         # Call engine specific initialization
         self.engine_initialize()
-        
+
     def prepare(self):
         """
         Last-minute preparation before iterating.
@@ -151,63 +151,63 @@ class BaseEngine(object):
                 ll, xx, yy = u.grids(sh, FFTlike=False)
                 support = (np.pi * (xx**2 + yy**2) < supp * sh[1] * sh[2])
                 self.probe_support[name] = support
-                
+
         # Call engine specific preparation
         self.engine_prepare()
-            
+
     def iterate(self, num=None):
         """
         Compute one or several iterations.
-        
+
         num : None, int number of iterations.
             If None or num<1, a single iteration is performed.
         """
         # Several iterations
         if self.p.numiter_contiguous is not None:
-            niter_contiguous = self.p.numiter_contiguous 
+            niter_contiguous = self.p.numiter_contiguous
         else:
             niter_contiguous = 1
-        
+
         # Overwrite default parameter
         if num is not None:
             niter_contiguous = num
-        
+
         if self.finished:
             return
 
         # For benchmarking
         self.t = time.time()
-        
+
         it = self.curiter
-        
+
         # Call engine specific iteration routine
-        # and collect the per-view error.      
+        # and collect the per-view error.
         self.error = self.engine_iterate(niter_contiguous)
-        
+
         # Check if engine did things right.
         if it >= self.curiter:
-            
-            logger.warn("""Engine %s did not increase iteration counter 
+
+            logger.warn("""Engine %s did not increase iteration counter
             `self.curiter` internally. Accessing this attribute in that
             engine is inaccurate""" % self.__class__.__name__)
-            
+
             self.curiter += niter_contiguous
-        
+
         elif self.curiter != (niter_contiguous + it):
-            
-            logger.error("""Engine %s increased iteration counter 
-            `self.curiter` by %d instead of %d. This may lead to 
+
+            logger.error("""Engine %s increased iteration counter
+            `self.curiter` by %d instead of %d. This may lead to
             unexpected behaviour""" % (self.__class__.__name__,
             self.curiter-it, niter_contiguous))
-        
+
         else:
             pass
-            
+
         self.alliter += niter_contiguous
-        
+
         if self.curiter >= self.numiter:
             self.finished = True
-        
+
         # Prepare runtime
         self._fill_runtime()
 
@@ -226,17 +226,17 @@ class BaseEngine(object):
             duration=time.time() - self.t,
             error=error
         )
-        
+
         self.ptycho.runtime.iter_info.append(info)
         self.ptycho.runtime.error_local = local_error
-        
+
     def finalize(self):
         """
         Clean up after iterations are done.
         """
         self.engine_finalize()
         pass
-    
+
     def engine_initialize(self):
         """
         Engine-specific initialization.
@@ -244,7 +244,7 @@ class BaseEngine(object):
         Called at the end of self.initialize().
         """
         raise NotImplementedError()
-        
+
     def engine_prepare(self):
         """
         Engine-specific preparation.
@@ -253,7 +253,7 @@ class BaseEngine(object):
         reconstruction. Called at the end of self.prepare()
         """
         raise NotImplementedError()
-    
+
     def engine_iterate(self, num):
         """
         Engine single-step iteration.

--- a/ptypy/engines/dummy.py
+++ b/ptypy/engines/dummy.py
@@ -25,11 +25,11 @@ DEFAULT = u.Param(
 )
 
 class Dummy(BaseEngine):
-    
+
     """
     Minimum implementation of BaseEngine
     """
-    
+
     DEFAULT = DEFAULT
 
     def __init__(self, ptycho_parent, pars=None):
@@ -45,13 +45,13 @@ class Dummy(BaseEngine):
         """
         self.itertime = self.p.itertime / parallel.size
         self.error = np.ones((100,3))*1e6
-        
+
     def engine_prepare(self):
         """
         Last-minute preparation before iterating.
         """
         pass
-            
+
     def engine_iterate(self,numiter):
         """
         Compute one iteration.
@@ -67,14 +67,14 @@ class Dummy(BaseEngine):
             error_dct[dname] = [0., 0.9**self.ntimescalled, 0.]
         self.ntimescalled+=1
         return error_dct
-     
+
     def engine_finalize(self):
         """
         Clean up after iterations are done
         """
         pass
-        
-        
 
 
-        
+
+
+

--- a/ptypy/engines/engine_utils.py
+++ b/ptypy/engines/engine_utils.py
@@ -62,7 +62,7 @@ def basic_fourier_update(diff_view, pbound=None, alpha=1., LL_error=True):
         LL = np.zeros_like(diff_view.data)
         for name, pod in diff_view.pods.iteritems():
             LL += u.abs2(pod.fw(pod.probe * pod.object))
-        err_phot = (np.sum(fmask * np.square(LL - I) / (I + 1.))
+        err_phot = (np.sum(fmask * (LL - I)**2 / (I + 1.))
                     / np.prod(LL.shape))
     else:
         err_phot = 0.

--- a/ptypy/engines/engine_utils.py
+++ b/ptypy/engines/engine_utils.py
@@ -74,7 +74,7 @@ def basic_fourier_update(diff_view, pbound=None, alpha=1., LL_error=True):
         f[name] = pod.fw((1 + alpha) * pod.probe * pod.object
                          - alpha * pod.exit)
 
-        af2 += u.cabs2(f[name]).real
+        af2 += u.abs2(f[name])
 
     fmag = np.sqrt(np.abs(I))
     af = np.sqrt(af2)
@@ -92,7 +92,7 @@ def basic_fourier_update(diff_view, pbound=None, alpha=1., LL_error=True):
                 continue
             df = pod.bw(fm * f[name]) - pod.probe * pod.object
             pod.exit += df
-            err_exit += np.mean(u.cabs2(df).real)
+            err_exit += np.mean(u.abs2(df))
     elif err_fmag > pbound:
         # Power bound is applied
         renorm = np.sqrt(pbound / err_fmag)
@@ -102,7 +102,7 @@ def basic_fourier_update(diff_view, pbound=None, alpha=1., LL_error=True):
                 continue
             df = pod.bw(fm * f[name]) - pod.probe * pod.object
             pod.exit += df
-            err_exit += np.mean(u.cabs2(df).real)
+            err_exit += np.mean(u.abs2(df))
     else:
         # Within power bound so no constraint applied.
         for name, pod in diff_view.pods.iteritems():
@@ -110,7 +110,7 @@ def basic_fourier_update(diff_view, pbound=None, alpha=1., LL_error=True):
                 continue
             df = alpha * (pod.probe * pod.object - pod.exit)
             pod.exit += df
-            err_exit += np.mean(u.cabs2(df).real)
+            err_exit += np.mean(u.abs2(df))
 
     if pbound is not None:
         # rescale the fmagnitude error to some meaning !!!

--- a/ptypy/engines/engine_utils.py
+++ b/ptypy/engines/engine_utils.py
@@ -16,38 +16,38 @@ def basic_fourier_update(diff_view, pbound=None, alpha=1., LL_error=True):
     """\
     Fourier update a single view using its associated pods.
     Updates on all pods' exit waves.
-    
+
     Parameters
     ----------
     diff_view : View
         View to diffraction data
-        
+
     alpha : float, optional
         Mixing between old and new exit wave. Valid interval ``[0, 1]``
-    
+
     pbound : float, optional
         Power bound. Fourier update is bypassed if the quadratic deviation
         between diffraction data and `diff_view` is below this value.
         If ``None``, fourier update always happens.
-        
+
     LL_error : bool
         If ``True``, calculates log-likelihood and puts it in the last entry
         of the returned error vector, else puts in ``0.0``
-    
+
     Returns
     -------
     error : ndarray
-        1d array, ``error = np.array([err_fmag, err_phot, err_exit])``. 
-                
-        - `err_fmag`, Fourier magnitude error; quadratic deviation from 
+        1d array, ``error = np.array([err_fmag, err_phot, err_exit])``.
+
+        - `err_fmag`, Fourier magnitude error; quadratic deviation from
           root of experimental data
         - `err_phot`, quadratic deviation from experimental data (photons)
-        - `err_exit`, quadratic deviation of exit waves before and after 
+        - `err_exit`, quadratic deviation of exit waves before and after
           Fourier iteration
     """
     # Prepare dict for storing propagated waves
     f = {}
-    
+
     # Buffer for accumulated photons
     af2 = np.zeros_like(diff_view.data)
 
@@ -56,7 +56,7 @@ def basic_fourier_update(diff_view, pbound=None, alpha=1., LL_error=True):
 
     # Get the mask
     fmask = diff_view.pod.mask
-        
+
     # For log likelihood error
     if LL_error is True:
         LL = np.zeros_like(diff_view.data)
@@ -66,7 +66,7 @@ def basic_fourier_update(diff_view, pbound=None, alpha=1., LL_error=True):
                     / np.prod(LL.shape))
     else:
         err_phot = 0.
-    
+
     # Propagate the exit waves
     for name, pod in diff_view.pods.iteritems():
         if not pod.active:
@@ -75,7 +75,7 @@ def basic_fourier_update(diff_view, pbound=None, alpha=1., LL_error=True):
                          - alpha * pod.exit)
 
         af2 += u.cabs2(f[name]).real
-    
+
     fmag = np.sqrt(np.abs(I))
     af = np.sqrt(af2)
 
@@ -83,7 +83,7 @@ def basic_fourier_update(diff_view, pbound=None, alpha=1., LL_error=True):
     fdev = af - fmag
     err_fmag = np.sum(fmask * fdev**2) / fmask.sum()
     err_exit = 0.
-    
+
     if pbound is None:
         # No power bound
         fm = (1 - fmask) + fmask * fmag / (af + 1e-10)
@@ -116,17 +116,17 @@ def basic_fourier_update(diff_view, pbound=None, alpha=1., LL_error=True):
         # rescale the fmagnitude error to some meaning !!!
         # PT: I am not sure I agree with this.
         err_fmag /= pbound
-    
+
     return np.array([err_fmag, err_phot, err_exit])
 
 
 def Cnorm2(c):
     """\
     Computes a norm2 on whole container `c`.
-    
+
     :param Container c: Input
     :returns: The norm2 (*scalar*)
-    
+
     See also
     --------
     ptypy.utils.math_utils.norm2
@@ -141,7 +141,7 @@ def Cdot(c1, c2):
     """\
     Compute the dot product on two containers `c1` and `c2`.
     No check is made to ensure they are of the same kind.
-    
+
     :param Container c1, c2: Input
     :returns: The dot product (*scalar*)
     """

--- a/ptypy/experiment/AMO_LCLS.py
+++ b/ptypy/experiment/AMO_LCLS.py
@@ -155,7 +155,7 @@ class AMOScan(core.data.PtyScan):
         frames_accessible = min((frames, npos-start))
         stop = self.frames_accessible + start
         return frames_accessible, (stop >= npos)
-        
+
     def load(self, indices):
         """
         Load frames given by the indices.
@@ -179,7 +179,7 @@ class AMOScan(core.data.PtyScan):
             i+=self.info.recipe.averaging_number
         log(3, 'Data loaded successfully.')
         return raw, pos, weights
-        
+
     def correct(self, raw, weights, common):
         """
         Apply (eventual) corrections to the frames. Convert from "raw" frames to usable data.

--- a/ptypy/experiment/DLS.py
+++ b/ptypy/experiment/DLS.py
@@ -119,7 +119,7 @@ class DlsScan(PtyScan):
         motor_positions = []
         i=0
         mmult = u.expect2(self.info.recipe.motors_multiplier)
-        
+
         for k in NEXUS_PATHS.motors:
             if not self.info.recipe.israster:
                 motor_positions.append(instrument[k]*mmult[i])
@@ -134,7 +134,7 @@ class DlsScan(PtyScan):
         """
         Returns the number of frames available from starting index `start`, and whether the end of the scan
         was reached.
-  
+
         :param frames: Number of frames to load
         :param start: starting point
         :return: (frames_available, end_of_scan)
@@ -175,7 +175,7 @@ class DlsScan(PtyScan):
                     data = io.h5read(self.data_file, key, slice=j)[key].astype(np.float32)
                     raw[j] = data
                 else:
-                    
+
                     #print "frame number "+str(j)
                     dset= h5.File(self.data_file, 'r', libver='latest', swmr=True)[key]
                     dset.id.refresh()

--- a/ptypy/experiment/DLS_mapping.py
+++ b/ptypy/experiment/DLS_mapping.py
@@ -118,7 +118,7 @@ class DlsScan(PtyScan):
         motor_positions = []
         i=0
         mmult = u.expect2(self.info.recipe.motors_multiplier)
-        
+
         for k in NEXUS_PATHS.motors:
             if not self.info.recipe.israster:
                 motor_positions.append(instrument[k]*mmult[i])
@@ -133,7 +133,7 @@ class DlsScan(PtyScan):
         """
         Returns the number of frames available from starting index `start`, and whether the end of the scan
         was reached.
-  
+
         :param frames: Number of frames to load
         :param start: starting point
         :return: (frames_available, end_of_scan)
@@ -180,11 +180,11 @@ class DlsScan(PtyScan):
                     data = dataset[j]
                     raw[j] = data.astype(np.float32) * (float(ic[j])/float(ic[0]))
                 else:
-                    
+
                     #print "frame number "+str(j)
                     dset= h5.File(self.data_file, 'r', libver='latest', swmr=True)[key]
                     dset.id.refresh()
-                    
+
                     try:
                         ic =  h5.File(self.data_file)['entry1/merlin_sw_hdf/ionc_photonflux']
                     except KeyError:
@@ -196,7 +196,7 @@ class DlsScan(PtyScan):
         else:
             if not self.info.recipe.is_swmr:
                 data = h5.File(self.data_file)[key]
-                
+
                 sh = data.shape
                 for j in indices:
                     raw[j]=data[j % sh[0], j // sh[1]] # or the other way round???

--- a/ptypy/experiment/I08.py
+++ b/ptypy/experiment/I08.py
@@ -52,7 +52,7 @@ RECIPE.dark_value = 200.   # Used if dark_number is None
 RECIPE.detector_flat_file = None
 RECIPE.nxs_file_pattern = '%(base_path)s/nexus/i08-%(scan_number)s.nxs'
 RECIPE.dark_nxs_file_pattern = '%(base_path)s/nexus/i08-%(dark_number)s.nxs'
-RECIPE.date = None 
+RECIPE.date = None
 RECIPE.stxm_file_pattern = '%(base_path)s/%(date)s/discard/Sample_Image_%(date)s_%(scan_number_stxm)s.hdf5'
 
 
@@ -72,7 +72,7 @@ I08DEFAULT.auto_center = False
 
 class I08Scan(ptypy.core.data.PtyScan):
     DEFAULT = I08DEFAULT
-    
+
     def __init__(self, pars=None, **kwargs):
         """
         I08 (Diamond Light Source) data preparation class.
@@ -82,7 +82,7 @@ class I08Scan(ptypy.core.data.PtyScan):
         RDEFAULT = RECIPE.copy()
         RDEFAULT.update(pars.recipe)
         pars.recipe.update(RDEFAULT)
-        
+
         super(I08Scan, self).__init__(pars, **kwargs)
 
         # Try to extract base_path to access data files
@@ -105,12 +105,12 @@ class I08Scan(ptypy.core.data.PtyScan):
         if self.info.recipe.date is None:
             raise RuntimeError('recipe.date has to be specified to find the STXM file name.')
         else:
-            try: 
-                time.strptime(self.info.recipe.date, '%Y-%m-%d') 
+            try:
+                time.strptime(self.info.recipe.date, '%Y-%m-%d')
             except ValueError:
                 print('The date should be in format "YYYY-MM-DD"')
                 raise
-        
+
         # Construct the file names
         self.nxs_filename = self.info.recipe.nxs_file_pattern % self.info.recipe
         self.stxm_filename = self.info.recipe.stxm_file_pattern % self.info.recipe
@@ -142,20 +142,20 @@ class I08Scan(ptypy.core.data.PtyScan):
                 dark = np.median(dark, axis=0)
         else:
             dark = self.info.recipe.dark_value
-        
+
         if self.info.recipe.detector_flat_file is not None:
             flat = io.h5read(self.info.recipe.detector_flat_file,FLAT_PATHS.key)[FLAT_PATHS.key]
 
         else:
             flat = 1.
-        
+
         scan_dimensions = io.h5read(self.nxs_filename,key)[key].shape[0],io.h5read(self.nxs_filename,key)[key].shape[1]
 
         common.dark = dark
         common.flat = flat
         common.scan_dimensions = scan_dimensions
         return common._to_dict()
-                
+
     def load_positions(self):
      	"""
         Load the positions and return as an (N,2) array
@@ -188,9 +188,9 @@ class I08Scan(ptypy.core.data.PtyScan):
         pos = {}  # Container for the positions. Left empty here because positions are provided by self.load_positions
         weights = {}  # Container for the weights
         key = NXS_PATHS.frame_pattern
-        ix = np.zeros(len(indices))        
+        ix = np.zeros(len(indices))
         iy = np.zeros(len(indices))
-        
+
         # data from I08 comes in as a [npts_x,npts_y,framesize_x,framesize_y]
         for i in range(len(indices)):
             ix[i] = int(np.mod(indices[i], self.common.scan_dimensions[1]))  # find the remainder - works out the column

--- a/ptypy/experiment/I13DLS_legacy.py
+++ b/ptypy/experiment/I13DLS_legacy.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """\
-Tools specific to the I13 beamline, Diamond. 
+Tools specific to the I13 beamline, Diamond.
 
-TODO: 
+TODO:
     * smarter way to guess parameters.
 
 This file is part of the PTYPY package.
@@ -20,7 +20,7 @@ import glob
 import os
 import fnmatch
 import time
-import re   
+import re
 
 from ptypy.utils.scripts import expect2, mass_center
 from ptypy.utils.verbose import logger
@@ -80,12 +80,12 @@ def load(filename,name=None):
     """\
     Helper function to read mask, flat and dark.
     """
-    
+
     #try:
     #    a = io.h5read(filename)
     #except:
     #    a = io.loadmat(filename)
-    
+
     if name is not None:
         return io.h5read(filename,name)[name]
     else:
@@ -100,14 +100,14 @@ class DataReader(object):
     def __init__(self, pars=None):#base_path, experimentID=None, mask=None, flat=None, dark=None):
         """\
         I13 DLS data reading class. The only mandatory argument for this constructor are 'base_path' and 'user'.
-        
+
         Mask, flat or dark should be either None, scan numbers (integer) or file paths
         """
         # Semi-smart base path detection: we are looking for a "raw" directory
         p = u.Param(DEFAULT)
         if pars is not None:
             p.update(pars)
-    
+
         try:
             verbose_level = p.verbose_level
             verbose.set_level(verbose_level)
@@ -116,7 +116,7 @@ class DataReader(object):
         self.p=p
         base_path = p.base_path if p.base_path.endswith('/') else p.base_path + '/'
         experimentID = p.experimentID
-        
+
         if base_path is None:
             d = os.getcwd()
             while True:
@@ -128,11 +128,11 @@ class DataReader(object):
                     break
             if base_path is None:
                 raise RuntimeError('Could not figure out base_path')
-            logger.debug( 'base_path: "%s" (automatically set).' % base_path)          
+            logger.debug( 'base_path: "%s" (automatically set).' % base_path)
         else:
-            logger.debug( 'base_path: "%s".' % base_path)          
+            logger.debug( 'base_path: "%s".' % base_path)
         self.base_path = base_path
-        
+
         self.nxs = u.Param()
         self.nxs.frame = FRAME_IN_NEXUS_FILE.format(**p)
         self.nxs.exp = EXPOSURE_IN_NEXUS_FILE.format(**p)
@@ -141,7 +141,7 @@ class DataReader(object):
         self.nxs.experiment = EXPERIMENT_IN_NEXUS_FILE.format(**p)
         self.nxs.label = LABEL_IN_NEXUS_FILE.format(**p)
         # Load mask, flat and dark
-        
+
         try:
             self.mask = load(self.get_nexus_file(p.mask),self.nxs.frame)
         except:
@@ -153,23 +153,23 @@ class DataReader(object):
         except:
             self.dark = p.dark
             #assert self.dark.shape[-2:] == sh
-            
+
         try:
             self.flat = load(self.get_nexus_file(p.flat),self.nxs.frame)
         except:
             self.flat = p.flat
             #assert self.flat.shape[-2:] == sh
-            
- 
+
+
     def read(self, scan=None, **kwargs):
         """\
         Read in the data
-        TODO: (maybe?) MPI to avoid loading all data in a single process for large scans. 
+        TODO: (maybe?) MPI to avoid loading all data in a single process for large scans.
         """
-        
+
         scan=scan if scan is not None else self.p.scan
         logger.info( 'Processing scan number %s' % str(scan))
- 
+
         self.scan = self.get_nexus_file(scan)
         logger.debug( 'Data will be read from path: %s' % self.scan)
 
@@ -189,7 +189,7 @@ class DataReader(object):
             except:
                 logger.debug('Could not find experiment ID from nexus file %s.' % self.scan)
                 experimentID = os.path.split(base_path[:-1])[1]
-            logger.debug( 'experimentID: "%s" (automatically set).' % experimentID)          
+            logger.debug( 'experimentID: "%s" (automatically set).' % experimentID)
         else:
             logger.debug( 'experimentID: "%s".' % self.p.experimentID)
             self.experimentID = self.p.experimentID
@@ -198,7 +198,7 @@ class DataReader(object):
 
         dpsize = self.p.dpsize
         ctr =  self.p.ctr
-        
+
         sh = self.data.shape[-2:]
         fullframe = False
         if dpsize is None:
@@ -206,7 +206,7 @@ class DataReader(object):
             logger.debug( 'Full frames (%d x %d) will be saved (so no recentering).' % (sh))
             fullframe = True
         self.p.dpsize = expect2(dpsize)
- 
+
         #data_filename = self.get_save_filename(scan_number, dpsize)
         #logger.info( 'Data will be saved to %s' % data_filename)
         f = self.data
@@ -236,7 +236,7 @@ class DataReader(object):
 
             else:
                 logger.debug( 'Using center: (%d, %d) - I would have guessed it is (%d, %d)' % (ctr[0], ctr[1], ctr_auto[0], ctr_auto[1]))
-    
+
             self.dpsize = dpsize
             self.ctr = np.array(ctr)
             lim_inf = -np.ceil(ctr - dpsize/2.).astype(int)
@@ -245,28 +245,28 @@ class DataReader(object):
             logger.debug( 'Going from %s to %s (hplane_list = %s)' % (str(sh), str(dpsize), str(hplane_list)))
             if self.mask is not None: self.mask = u.crop_pad(self.mask, hplane_list).astype(bool)
             if self.flat is not None: self.flat = u.crop_pad(self.flat, hplane_list,fillpar=1.)
-            if self.dark is not None: self.dark = u.crop_pad(self.dark, hplane_list)            
+            if self.dark is not None: self.dark = u.crop_pad(self.dark, hplane_list)
             if self.data is not None: self.data = u.crop_pad(self.data, hplane_list)
         # obsolete
 
         #return data, self.mask, self.flat, self.dark
 
     def prepare(self,scan=None,filename=None,dtype=np.uint32,**kwargs):
-        
+
         self.p.update(kwargs) #rebin = rebin if rebin is not None else self.p.rebin
-        
+
         scan = scan if scan is not None else self.p.scan
-        
+
         self.read( scan, **kwargs)
         DS = u.Param()
-        
+
         dark = self.dark
         data = self.data
         if dark is not None:
             if dark.ndim == 3:
                 dark = dark.mean(0)
             dark = np.resize(dark,data.shape)
-            
+
         flat = self.flat
         if flat is not None:
             if flat.ndim == 3:
@@ -293,62 +293,62 @@ class DataReader(object):
         #DS.flat = self.flat
         #DS.dark = self.dark
         DS.scan_info = u.Param()
-        s = DS.scan_info     
+        s = DS.scan_info
         p = self.p
         #s.scan_number = p.scan_number
         s.scan_label = 'S'+self.label #'S%05d' % p.scan_number
         s.data_filename = self.scan #scandict['data_filename']
-        s.wavelength = u.keV2m( p.energy )    
+        s.wavelength = u.keV2m( p.energy )
         s.energy = p.energy
         rebin = self.p.rebin
         s.detector_pixel_size = p.detector_pixel_size * rebin if p.detector_pixel_size is not None else None
-        p.dpsize = p.dpsize / rebin 
+        p.dpsize = p.dpsize / rebin
         s.detector_distance = p.detector_distance
         s.initial_ctr = self.ctr / rebin
         if rebin!=1:
             sh = data.shape
             data = u.rebin(data,sh[0],sh[1]/rebin,sh[2]/rebin)
             mask = u.rebin(mask.astype(int),sh[0],sh[1]/rebin,sh[2]/rebin).astype(bool)
-            
+
         data = flip(data,self.p.flip)
         mask = flip(mask,self.p.flip)
-        
+
         DS.data = data.astype(dtype)
         DS.mask = mask
         DS.data[np.invert(DS.mask)]=0
         #s.date_collected = scandict['date']
         s.date_processed = time.asctime()
         s.exposure_time = self.exp
-    
+
         #if meta is not None: s.raw_filenames = meta['filename']
         s.preparation_basepath = self.base_path
         s.preparation_other = {}
         s.shape = DS.data.shape
-    
+
         s.positions_theory = None
-    
+
         s.scan_command = self.command
-    
+
         motors = p.motors
         if self.motors is not None:
             Nmotors = len(motors)
             logger.debug( 'Motors are : %s' % str(p.motors))
             mmult = u.expect2(p.motors_multiplier)
-    
+
             pos_list = [mmult[i]*np.array(self.motors[motors[i]]) for i in range(Nmotors)]
             s.positions = np.array(pos_list).T
         else:
             s.positions = None
-                
+
         self.p.scan_label = s.scan_label
         if filename is None:
             p.write_path = WRITE_PATH_PATTERN.format(**p)
-            filename = SAVE_FILENAME_PATTERN.format(**p) 
-        
+            filename = SAVE_FILENAME_PATTERN.format(**p)
+
         s.data_filename = u.clean_path(filename)
         io.h5write(filename,DS)
         return DS
-        
+
     def get_nexus_file(self, number):
         if str(number)==number or number is None:
             # ok this is not a number but a filename

--- a/ptypy/experiment/ID16Anfp.py
+++ b/ptypy/experiment/ID16Anfp.py
@@ -34,7 +34,7 @@ H5_PATHS.command = '{entry}/scan_type'
 H5_PATHS.label = '{entry}/title'
 H5_PATHS.experiment = '{entry}/experiment_identifier'
 
-# These two entries are added to the structure post-measurement. 
+# These two entries are added to the structure post-measurement.
 H5_PATHS.frames = '{entry}/ptycho/data'
 H5_PATHS.motors = '{entry}/ptycho/motors'
 
@@ -56,7 +56,7 @@ RECIPE.use_h5 = False               # Load data from prepared h5 file
 RECIPE.flat_division = False        # Switch for flat division
 RECIPE.dark_subtraction = False     # Switch for dark subtraction
 
-# These are home-made wrapped data 
+# These are home-made wrapped data
 RECIPE.data_file_pattern = '{[base_path]}/{[sample_name]}/{[scan_label]}_data.h5'
 RECIPE.flat_file_pattern = '{[base_path]}/{[sample_name]}/{[flat_label]}_flat.h5'
 RECIPE.dark_file_pattern = '{[base_path]}/{[sample_name]}/{[dark_label]}_dark.h5'
@@ -98,11 +98,11 @@ class ID16AScan(PtyScan):
         # Apply beamline-specific generic defaults
         #pars = PREP_DEFAULT.copy().update(pars)
         #pars.update(**kwargs)
-        
+
         # Apply beamline parameters ("recipe")
         #rinfo = DEFAULT.copy()
         #rinfo.update(pars.recipe)
-        
+
         # Initialise parent class with input parameters
         #super(self.__class__, self).__init__(pars)
 
@@ -115,7 +115,7 @@ class ID16AScan(PtyScan):
         #        'Incompatible scan labels')
         #self.info.label = rinfo.scan_label
         #logger.info('Scan label: %s' % rinfo.scan_label)
-        
+
         # Default flat and dark labels.
         #if rinfo.flat_label is None:
         #    rinfo.flat_label = rinfo.scan_label
@@ -164,7 +164,7 @@ class ID16AScan(PtyScan):
         #h = io.h5read(rinfo.data_file)
         #entry = h.keys()[0]
         #rinfo.entry = entry
-        
+
         # Energy
         #k = H5_PATHS.energy.format(rinfo)
         #energy = float(io.h5read(rinfo.data_file, k)[k])
@@ -180,7 +180,7 @@ class ID16AScan(PtyScan):
         #        rinfo.base_path[:-1])[0])[1]
         #    logger.info('experiment ID: %s' % experimentID)
         #    rinfo.experimentID = experimentID
-        
+
         # Effective pixel size
 
         # Data file names
@@ -255,7 +255,7 @@ class ID16AScan(PtyScan):
 
         #h = io.h5read(self.rinfo.data_file)
         #entry = h.keys()[0]
-        
+
         # Get positions
         #motor_positions = io.h5read(self.rinfo.data_file,
         #                            H5_PATHS.motors)[H5_PATHS.motors]
@@ -272,10 +272,10 @@ class ID16AScan(PtyScan):
         #    common.dark = darks
         #else:
         #    common.dark = darks.median(axis=0)
-        
+
         # Load white field
         #common.white = io.edfread(self.rinfo.whitefield_file)[0]
-        
+
         # Load distortion files
         #dh = io.edfread(self.rinfo.distortion_h_file)[0]
         #dv = io.edfread(self.rinfo.distortion_v_file)[0]
@@ -352,7 +352,7 @@ class ID16AScan(PtyScan):
         frames_accessible = min((frames, npos - start))
         stop = self.frames_accessible + start
         return frames_accessible, (stop >= npos)
-        
+
     def load(self, indices):
         """
         Load frames given by the indices.
@@ -386,7 +386,7 @@ class ID16AScan(PtyScan):
                 raw[j] = data.astype(np.float32)
 
         return raw, pos, weights
-        
+
     def correct(self, raw, weights, common):
         """
         Apply (eventual) corrections to the raw frames. Convert from "raw"
@@ -399,7 +399,7 @@ class ID16AScan(PtyScan):
         # Sanity check
         #assert (raw.shape == (2048,2048)), (
         #    'Wrong frame dimension! Is this a Frelon camera?')
-        
+
         # Whitefield correction
         #raw_wf = raw / common.white
 
@@ -408,10 +408,10 @@ class ID16AScan(PtyScan):
         #raw_wf_ml[1024:,:] = raw_wf[1023:-1,1]
         #raw_wf_ml[1023,:] += raw_wf[1024,:]
         #raw_wf_ml[1023,:] *= .5
-        
+
         # Undistort
         #raw_wl_ml_ud = undistort(raw_wf_ml, common.distortion)
-        
+
         #data = raw_wl_ml_ud
 
         # Apply flat and dark, only dark, or no correction
@@ -439,14 +439,14 @@ def undistort(frame, delta):
     Frame distortion correction (linear interpolation)
     Any value outside the frame is replaced with a constant value (mean of
     the complete frame)
-    
+
     Parameters
     ----------
     frame: ndarray
         the input frame data
-    delta: 2-tuple 
+    delta: 2-tuple
         containing the horizontal and vertical displacements respectively.
-    
+
     Returns
     -------
     ndarray
@@ -463,7 +463,7 @@ def undistort(frame, delta):
 
     ny = (y-deltav).flatten()
     nx = (x-deltah).flatten()
-    
+
     nyf = np.floor(ny).astype(int)
     nyc = nyf+1
     nxf = np.floor(nx).astype(int)
@@ -484,7 +484,7 @@ def undistort(frame, delta):
     #nxc = np.clip(nxc, 0, sh[1]-1)
     #nyf = np.clip(nyf, 0, sh[0]-1)
     #nyc = np.clip(nyc, 0, sh[0]-1)
-   
+
     fa = frame[ nyf, nxf ]
     fb = frame[ nyc, nxf ]
     fc = frame[ nyf, nxc ]

--- a/ptypy/experiment/optiklabor.py
+++ b/ptypy/experiment/optiklabor.py
@@ -22,12 +22,12 @@ DEFAULT.base_path = '/data/CDI/opticslab_sxdm_2013/'
 DEFAULT.scan_number = 74 #35          # scan number
 DEFAULT.dark_number = 72
 #DEFAULT.scan_label = 'S%05d' % p.scan_number
-DEFAULT.exp_string='exp_time'  
+DEFAULT.exp_string='exp_time'
 DEFAULT.hdr_thresholds = [500,50000]
 DEFAULT.lam = 650e-9
 
 DEFAULT.energy = 1.2398e-9 /DEFAULT.lam
-DEFAULT.z = 0.158                                          # Distance from object to screen 
+DEFAULT.z = 0.158                                          # Distance from object to screen
 DEFAULT.psize_det = 24e-6    # Camera pixel size
 DEFAULT.center = 'auto'
 DEFAULT.orientation = (True,True,False)
@@ -39,7 +39,7 @@ DEFAULT.scan_dir = 'ccdfli/S00000-00999/'
 #DEFAULT.log_file_pattern = '%(base_path)s' + '/spec/dat-files/spec_started_2014_07_28_2158.dat'        # log file
 DEFAULT.log_file_pattern = '%(base_path)s' + 'spec/dat-files/spec_started_2013_11_21_1659.dat'        # log file
 DEFAULT.data_dir_pattern = '%(base_path)s'+'%(scan_dir)s'+ 'S%(scan_number)05d/'
-DEFAULT.dark_dir_pattern = '%(base_path)s'+'%(scan_dir)s'+ 'S%(dark_number)05d/' 
+DEFAULT.dark_dir_pattern = '%(base_path)s'+'%(scan_dir)s'+ 'S%(dark_number)05d/'
 
 pp = u.Param()
 pp.filename = './foo.ptyd'
@@ -48,7 +48,7 @@ pp.num_frames = 50
 pp.save = 'extlink'
 
 class FliSpecScanMultexp(PtyScan):
-    
+
     def __init__(self,pars=None,**kwargs):
         p= DEFAULT.copy()
         if pars is not None:
@@ -60,7 +60,7 @@ class FliSpecScanMultexp(PtyScan):
         self.info.dark_dir = self.info.dark_dir_pattern % self.info
         self.info.data_dir = self.info.data_dir_pattern % self.info
         self.nexp = len(glob.glob(self.info.dark_dir + '/ccd*_00000_??.raw'))
-        
+
     def load_common(self):
         # Load 'spec' file
         self.specinfo = spec.SpecInfo(self.info.log_file)
@@ -70,7 +70,7 @@ class FliSpecScanMultexp(PtyScan):
             self.scaninfo = self.specinfo.scans[self.info.scan_number]
         except:
             self.scaninfo = None
-            
+
         common = u.Param()
         dark_imgs = []
         exposures =[]
@@ -78,7 +78,7 @@ class FliSpecScanMultexp(PtyScan):
             darks,meta = u.image_read(self.info.dark_dir + '/ccd*_%02d.raw' % j)
             dark_imgs.append(np.array(darks,dtype=np.float).mean(0))
             exposures.append(meta[0][self.exp_string])
-        
+
         # save in common dict/Param
         common.darks = np.asarray(dark_imgs)
         common.exposures = np.asarray(exposures)
@@ -89,11 +89,11 @@ class FliSpecScanMultexp(PtyScan):
             common.positions_scan = motor_mult * np.array([x, y]).T
         else:
             common.positions_scan = None
-        
+
         return common._to_dict()
-        
+
     def check(self,frames_requested, start=0):
-        
+
         npos = len(glob.glob(self.info.data_dir + '/ccd*_%02d.raw' % (self.nexp-1)))
         # essential!
         frames_accessible = min((frames_requested,npos-start))
@@ -103,7 +103,7 @@ class FliSpecScanMultexp(PtyScan):
         #print frames_accessible
         return frames_accessible,(stop >= self.num_frames)
 
-        
+
     def load(self,indices):
         raw = u.Param()
         raw = {}
@@ -112,9 +112,9 @@ class FliSpecScanMultexp(PtyScan):
         for j in indices:
             data,meta = u.image_read(self.info.data_dir + '/ccd*_%05d_??.raw' % j)
             raw[j] = np.asarray(data)
-            
+
         return raw, pos, weights
-        
+
     def correct(self, raw, weights, common):
         #chunk = u.Param()
         data = {}
@@ -125,7 +125,7 @@ class FliSpecScanMultexp(PtyScan):
             data_hdr,lmask=u.hdr_image(rr, expos, thresholds=self.hdr_thresholds, dark_list=darks, avg_type='highest')
             data[j] = data_hdr
             weights[j] = lmask[-1]
-        
+
         return data, weights
 
 if __name__ == '__main__':
@@ -142,7 +142,7 @@ if __name__ == '__main__':
         msg = RS.auto(10)
         logger.info(u.verbose.report(msg), extra={'allprocesses': True})
         u.parallel.barrier()
-    
+
     #RS.report()
     #%RS.load_raw([0,1,2])
     #RS.prepare()

--- a/ptypy/experiment/spec.py
+++ b/ptypy/experiment/spec.py
@@ -17,7 +17,7 @@ lastSpecInfo = None
 def verbose(n,s):
     """
     This function should be replaced by the real verbose class after import.
-    It is here for convenience since this module has no other external dependencies. 
+    It is here for convenience since this module has no other external dependencies.
     """
     print s
 
@@ -32,7 +32,7 @@ class SpecInfo(object):
         self.parse()
         global lastSpecInfo
         lastSpecInfo = self
-        
+
     def parse(self, rehash=False):
         """\
         Parse the spec dat-file and extract information.
@@ -42,10 +42,10 @@ class SpecInfo(object):
 
         # Initialize
         motordefs = []
-        motors = [] 
+        motors = []
         scans = {}
 
-        # A while loop offers more flexibility        
+        # A while loop offers more flexibility
         lnum = -1
         continue_reading = True
         while continue_reading:
@@ -72,7 +72,7 @@ class SpecInfo(object):
                     #print('Skipping known scan #S %d' % scannr)
                     continue
                 #print line.strip()
-                
+
                 # Create the structure
                 scan = SpecScan()
                 scan.command = scancmd
@@ -85,8 +85,8 @@ class SpecInfo(object):
 
                 # Keep reading file until empty line
                 while line.strip():
-                    # Get a new line, exit everything if we are 
-                    # at the end of a file 
+                    # Get a new line, exit everything if we are
+                    # at the end of a file
                     try:
                         line = f.next(); lnum += 1
                     except StopIteration:
@@ -105,7 +105,7 @@ class SpecInfo(object):
                         # This is data for the current section ("label")
                         # We will end up here if an error message is printed in
                         # the spec file. Trying to be smart about this here.
-                        # It looks like all lines that do not start with "#" in 
+                        # It looks like all lines that do not start with "#" in
                         # a spec file contain only numbers. So we simply check
                         # if the current line can be converted to numbers
                         try:
@@ -116,13 +116,13 @@ class SpecInfo(object):
                         except ValueError:
                             verbose(1,'Ignoring bad line (number %d) in spec file' % lnum)
                             verbose(1,line.strip())
-                                                    
+
                 # Aborted scan?
                 scan.aborted = False
                 comments = scanstr.get('C', [])
                 if any(c.lower().find('aborted')>0 for c in comments):
                     scan.aborted = True
-                
+
                 good_scan = True
                 # Get date
                 try:
@@ -151,7 +151,7 @@ class SpecInfo(object):
                     good_scan = False
                     verbose(1, 'Error extracting counter names for scan number %d.' % scannr)
                     verbose(1, e.message)
-                
+
                 # Data
                 try:
                     data = zip(*[[float(x) for x in Lline.split()] for Lline in scanstr['L'][1:]])
@@ -164,19 +164,19 @@ class SpecInfo(object):
 		scan.valid = good_scan
                 scans[scannr] = scan
         self.scans = scans
-        
+
 """
         assert scannr > 0
         assert burst > 0
         assert multexp > 0
         scanpos = self.scans.get(scannr, None)
         if scanpos is None:
-            print 'Scan not found. parsing the file again...' 
+            print 'Scan not found. parsing the file again...'
             self.parse()
             scanpos = self.scans.get(scannr, None)
             if scanpos is None:
                 raise RuntimeError('Scan %d not found.' % scannr)
-        
+
         cmd, lineno, fstart, fend = scanpos
 
         # Create the structure
@@ -185,11 +185,11 @@ class SpecInfo(object):
         scan.S = cmd
         scan.lineno = lineno
         scan.filepos = (fstart, fend)
-        
+
         # Read text block
         self.spec_file.seek(fstart)
         scanlines = self.spec_file.read(fend-fstart).split('/n')
-        
+
         # temporary structure
         scanstr = {}
         lastlabel = ''
@@ -202,18 +202,18 @@ class SpecInfo(object):
             else:
                 entry = scanstr.get(lastlabel,[])
                 entry.append(line)
-    
+
         # Get date
         scan.date = dateutil.parser.parse(scanstr['D'][0])
         scan.D = scan.date
-                
+
         # Get motor info
-        
-        
-        
-        
-  
-% here the default parameters  
+
+
+
+
+
+% here the default parameters
   scannr     = -1;
   output_arg = {'meta','motor','counter'};
   unhandled_par_error = 1;
@@ -221,7 +221,7 @@ class SpecInfo(object):
 % other parameters
   burstn0 = 1;
   mexpn0  = 1;
-  
+
       case 'OutPut'
         output_arg = set_TextFlag(output_arg,value);
       case 'PilatusMask'
@@ -239,19 +239,19 @@ class SpecInfo(object):
         vararg{end+1} = value;                                  %#ok<AGROW>
     end
   end
-    
+
   specDatFile = find_specDatFile(specDatFile);
-  
+
   % reading the spec file for the scans
   [scans,scanline] = spec_readscan(specDatFile, scannr);
-  
+
   % reading the spec file for configuration information
   [motorc,motorline] = spec_readconfig(specDatFile);
   motorn = cell(size(scannr));
   for jj=1:numel(scans)
     motorn{jj} = motorc{find(motorline<scanline(1),1,'last')};
   end
-  
+
   varargout{1} = cell(size(scans));
   % copying vararg in order to keep its content for each iteration
   vararg_1 = vararg;
@@ -261,7 +261,7 @@ class SpecInfo(object):
     scanstr = scans{jj}';
     arrout = regexp(scanstr{1},' +','split');
     scannr(jj) = str2double(arrout{2});
-    
+
     % get the motors
     line = ~cellfun(@isempty,regexp(scanstr,'^#P'));
     arrout = reshape(transpose(strvcat((scanstr(line)))),1,[]);
@@ -277,7 +277,7 @@ class SpecInfo(object):
     line  = ~cellfun(@isempty,regexp(scanstr,'^[0-9+-]'));
     data = cellfun(@str2num,scanstr(line),'UniformOutput',false);
     data = cell2mat(data(:));
-    
+
     % get Pilatus information if required
     if (exist('pilatusMask','var'))
       if (exist('pilatusDir0','var'))
@@ -288,14 +288,14 @@ class SpecInfo(object):
 
       [pilatusDir, pilatusName, vararg] = ...
         find_files(strcat(pilatusDir,pilatusMask), vararg_1);
-      
+
       pilatusInd = zeros(numel(pilatusName),2);
       for ii=1:numel(pilatusName)
         arrout = regexp(pilatusName(ii).name,'[_\.]','split');
         pilatusInd(ii,:) = str2double(arrout(end-2:end-1));
       end
     end
-    
+
     % make a structure
     scan_structure = struct;
     if (any(strcmp(output_arg,'meta')))
@@ -310,14 +310,14 @@ class SpecInfo(object):
         datestr{6}, ...
         datestr{5});
     end
-    
+
     if (any(strcmp(output_arg,'motor')) || ...
         any(strcmp(output_arg,'motors')))
       for ii=1:numel(motorn{jj})
         scan_structure.(motorn{jj}{ii}) = motorv(ii);
       end
     end
-    
+
     if (any(strcmp(output_arg,'counter')) || ...
         any(strcmp(output_arg,'counters')))
       if (numel(data)>0)
@@ -326,7 +326,7 @@ class SpecInfo(object):
         end
       end
     end
-    
+
     if (any(strcmp(output_arg,'pilatus')))
       if (burstn0>1)
         burstn = burstn0;
@@ -342,7 +342,7 @@ class SpecInfo(object):
       else
         mexpn = mexpn0;
       end
-      
+
       if (numel(burstn)==1 && numel(mexpn)==1)
         % these pseudo motors shouldn't be scanned and are
         %   therefore presumably constant
@@ -370,7 +370,7 @@ class SpecInfo(object):
       scan_structure.Pilatus = Pilatus;
       scan_structure.PilatusDir = pilatusDir;
     end
-    
+
     varargout{1}{jj} = scan_structure;
   end
   if ((unhandled_par_error) && (~isempty(vararg)))
@@ -387,18 +387,18 @@ end
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function [varargout] = spec_readscan(specDatFile, scannr)
 % check minimum number of input arguments
-  if (nargin<2) 
+  if (nargin<2)
     spec_read_help(mfilename);
     error('usage ''spec_readscan(specDatFile, scannr)''');
   end
-  
+
   cmd = sprintf('grep -n ''#S '' %s', specDatFile);
   [~,sysout] = system(cmd);
   arrout = regexp(sysout,'[:\n]','split');
   arrout = arrout(~cellfun(@isempty,arrout));
   arrout = transpose(reshape(arrout,2,[]));
   [s1,~] = size(arrout);
-  
+
   if (any(scannr>0))
     tmp = regexp(arrout(:,2),' +','split');
     scanID = zeros(size(tmp));
@@ -406,7 +406,7 @@ function [varargout] = spec_readscan(specDatFile, scannr)
       scanID(ii) = str2double(tmp{ii}{2});
     end
   end
-  
+
 % creating a look up table where the scans begin and end
   lineI = zeros(size(scannr));
   scans = cell(size(scannr));
@@ -467,7 +467,7 @@ function [motors,linenr] = spec_readconfig(specDatFile)
   arrout = arrout(~cellfun(@isempty,arrout));
   arrout = transpose(reshape(arrout,2,[]));
   [s1,~] = size(arrout);
-  
+
   % devide this collection of configuration information into single chuncks
   linenr = '';
   motors = cell(0);
@@ -503,7 +503,7 @@ function specDatFile = find_specDatFile(specDatFile)
       if (specDatFile(end) ~= '/')
         specDatFile = strcat(specDatFile,'/');
       end
-      
+
       for ii=1:numel(fname)
         if (regexp(fname(ii).name,'.dat$'))
           specDatFile = strcat(specDatFile,'*.dat');
@@ -556,7 +556,7 @@ function pilatusDir = find_pilatusDir(pilatusDir,scannr)
       if (pilatusDir(end) ~= '/')
         pilatusDir = strcat(pilatusDir,'/');
       end
-      
+
       for ii=1:numel(fname)
         if (strcmp(fname(ii).name,sprintf('S%02d000-%02d999',floor(scannr/1e3),floor(scannr/1e3))) || ...
             strcmp(fname(ii).name,sprintf('S%05d',scannr)))

--- a/ptypy/io/edfIO.py
+++ b/ptypy/io/edfIO.py
@@ -7,7 +7,7 @@ translated to python: April 2010, Dieter Hahn
 
 Among other, contains the functions
     readData
-    writeData WHICH IS NOT YET IMPLEMENTED    
+    writeData WHICH IS NOT YET IMPLEMENTED
 """
 import numpy as np
 import os
@@ -45,7 +45,7 @@ def edfread(filename, doglob=None, roi=None):
             ignores wildcards
 
         ... = edfread(filename, doglob=None) [default]
-            behaves like doglob=True, except that it returns a list only if filename contains wildcards, 
+            behaves like doglob=True, except that it returns a list only if filename contains wildcards,
             while doglob=True always returns a list, even if there is only one match.
 
         ... = edfread(filename, roi=(RowFrom, RowTo, ColumnFrom, ColumnTo))
@@ -75,11 +75,11 @@ def edfread(filename, doglob=None, roi=None):
         lmeta.append(meta)
         if meta["DataType"]=="Float" or meta["DataType"]=="FloatValue":
             if meta["ByteOrder"]=="HighByteFirst":
-                logger.debug("EDF File ByteOrder = HighByteFirst. Converting array to Big Endian")                
+                logger.debug("EDF File ByteOrder = HighByteFirst. Converting array to Big Endian")
                 dat=dat.newbyteorder("B")
             else:
                 dat=dat.newbyteorder("L")
-                logger.debug("EDF File ByteOrder = Not HighByteFirst. Converting array to Little Endian")                
+                logger.debug("EDF File ByteOrder = Not HighByteFirst. Converting array to Little Endian")
 
         if roi is not None:
             ldat.append(dat[roi[0]:roi[1],roi[2]:roi[3]].copy())
@@ -94,29 +94,29 @@ def edfread(filename, doglob=None, roi=None):
 def readData(filenameprefix,imgstart=0,imgnumber = 1,xi = 0, xf = 0, bin_fact = 1,rowFrom = 0, rowTo = 0,multiple = 1):
     """\
         Reads image data from .edf file.
-        
+
         [dat, meta] = readData(path+filename, imgstart=0,imgnumber = 1,xi = 0, xf = 0, bin = 1,rowFrom = 0, rowTo = 0,multiple = 1)
-        
+
         with multiple = 1 (default, corresponds to ESRF id19 file format):
             Reads in 'imgnumber' image files beginning from 'imgstart' and stores the data in a
             list of numpy.array(ydim,xdim). Stores metadata in dictionaries which are themselves
             stored in a list.
-        
+
         with multiple = 0
             Reads filenameprefix.edf
 
         returns: [dat, meta]:
                                 datm = list of 2d arrays containing image data
                                 meta = list of dictionaries containing metadata for each image
-        
-        
+
+
         example:
         [dat, meta] = readData('some_prefix',imgstart=4,imgnumber = 3, multiple = 1) reads 3 images:
-        some_prefix_0004_0000.edf 
-        some_prefix_0004_0001.edf 
+        some_prefix_0004_0000.edf
+        some_prefix_0004_0001.edf
         some_prefix_0004_0002.edf
         and stores their respective data and headers in dat and meta
-        
+
         [dat, meta] = readData('other_prefix', multiple = 0) reads
         other_prefix.edf
     """
@@ -227,7 +227,7 @@ def readHeader(filename, headerlength=None):
     # add local filename in meta-data
     hdict["local_filename"] = filename
     return hdict
-    
+
 def convertStr(s):
     try:
         ret = int(s)

--- a/ptypy/io/h5rw.py
+++ b/ptypy/io/h5rw.py
@@ -30,7 +30,7 @@ SLASH_ESCAPE = '_SLASH_')
 STR_CONVERT = [type]
 
 def sdebug(f):
-    """ 
+    """
     debugging decorator for _store functions
     """
     def newf(*args, **kwds):
@@ -52,7 +52,7 @@ def _h5write(filename, mode, *args, **kwargs):
     _h5write(filename, mode, {'var1'=..., 'var2'=..., ...})
     _h5write(filename, mode, var1=..., var2=..., ...)
     _h5write(filename, mode, dict, var1=..., var2=...)
-    
+
     Writes variables var1, var2, ... to file filename. The file mode
     can be chosen according to the h5py documentation. The key-value
     arguments have precedence on the provided dictionnary.
@@ -66,8 +66,8 @@ def _h5write(filename, mode, *args, **kwargs):
 
     (if the option UNSUPPORTED is equal to 'pickle', any other type
     is pickled and saved. UNSUPPORTED = 'ignore' silently eliminates
-    unsupported types. Default is 'fail', which raises an error.) 
-    
+    unsupported types. Default is 'fail', which raises an error.)
+
     The file mode can be chosen according to the h5py documentation.
     It defaults to overwriting an existing file.
     """
@@ -86,7 +86,7 @@ def _h5write(filename, mode, *args, **kwargs):
 
     # List of object ids to make sure we are not saving something twice.
     ids = []
-    
+
     # This is needed to store strings
     dt = h5py.new_vlen(str)
 
@@ -121,7 +121,7 @@ def _h5write(filename, mode, *args, **kwargs):
         return dset
 
 
-    #@sdebug    
+    #@sdebug
     def _store_list(group, l, name):
         check_id(id(l))
         arrayOK = len(set([type(x) for x in l])) == 1
@@ -151,7 +151,7 @@ def _h5write(filename, mode, *args, **kwargs):
         dset_type = dset.attrs['type']
         dset.attrs['type'] = 'arraytuple' if dset_type == 'arraylist' else 'tuple'
         return dset
-    
+
     #@sdebug
     def _store_dict(group, d, name):
         check_id(id(d))
@@ -176,7 +176,7 @@ def _h5write(filename, mode, *args, **kwargs):
         dset = _store_dict(group,d._to_dict(),name)
         dset.attrs['type'] = 'param'
         return dset
-        
+
     def _store_dict_new(group, d, name):
         check_id(id(d))
         dset = group.create_group(name)
@@ -185,20 +185,20 @@ def _h5write(filename, mode, *args, **kwargs):
             _store(dset, kv, '%05d' % i)
         pop_id(id(d))
         return dset
-    
+
     #@sdebug
     def _store_None(group, a, name):
         dset = group.create_dataset(name, data = np.zeros((1,)))
-        dset.attrs['type'] = 'None' 
+        dset.attrs['type'] = 'None'
         return dset
-        
+
     #@sdebug
     def _store_pickle(group, a, name):
         apic = cPickle.dumps(a)
         dset = group.create_dataset(name, data=np.asarray(apic), dtype=dt)
         dset.attrs['type'] = 'pickle'
         return dset
-    
+
     #@sdebug
     def _store(group, a, name):
         if type(a) is str:
@@ -228,9 +228,9 @@ def _h5write(filename, mode, *args, **kwargs):
             elif h5options['UNSUPPORTED']=='pickle':
                 dset = _store_pickle(group,a,name)
             else:
-                dset = None 
+                dset = None
         return dset
- 
+
     # generate all parent directories
     base= os.path.split(filename)[0]
     if not os.path.exists(base):
@@ -250,13 +250,13 @@ def _h5write(filename, mode, *args, **kwargs):
                 del f[k]
             _store(f,v,k)
     return
-    
+
 def h5write(filename, *args, **kwargs):
     """\
     h5write(filename, {'var1'=..., 'var2'=..., ...})
     h5write(filename, var1=..., var2=..., ...)
     h5write(filename, dict, var1=..., var2=...)
-    
+
     Writes variables var1, var2, ... to file filename. The key-value
     arguments have precedence on the provided dictionnary.
 
@@ -269,8 +269,8 @@ def h5write(filename, *args, **kwargs):
 
     (if the option UNSUPPORTED is equal to 'pickle', any other type
     is pickled and saved. UNSUPPORTED = 'ignore' silently eliminates
-    unsupported types. Default is 'fail', which raises an error.) 
-    
+    unsupported types. Default is 'fail', which raises an error.)
+
     The file mode can be chosen according to the h5py documentation.
     It defaults to overwriting an existing file.
     """
@@ -283,8 +283,8 @@ def h5append(filename, *args, **kwargs):
     h5append(filename, {'var1'=..., 'var2'=..., ...})
     h5append(filename, var1=..., var2=..., ...)
     h5append(filename, dict, var1=..., var2=...)
-    
-    Appends variables var1, var2, ... to file filename. The 
+
+    Appends variables var1, var2, ... to file filename. The
     key-value arguments have precedence on the provided dictionnary.
 
     supported variable types are:
@@ -296,8 +296,8 @@ def h5append(filename, *args, **kwargs):
 
     (if the option UNSUPPORTED is equal to 'pickle', any other type
     is pickled and saved. UNSUPPORTED = 'ignore' silently eliminates
-    unsupported types. Default is 'fail', which raises an error.) 
-    
+    unsupported types. Default is 'fail', which raises an error.)
+
     The file mode can be chosen according to the h5py documentation.
     It defaults to overwriting an existing file.
     """
@@ -310,19 +310,19 @@ def h5read(filename, *args, **kwargs):
     h5read(filename)
     h5read(filename, s1, s2, ...)
     h5read(filename, (s1,s2, ...))
-    
-    Read variables from a hdf5 file created with h5write and returns them as 
+
+    Read variables from a hdf5 file created with h5write and returns them as
     a dictionary.
-    
+
     If specified, only variable named s1, s2, ... are loaded.
-    
-    Variable names support slicing and group access. For instance, provided 
-    that the file contains the appropriate objects, the following syntax is 
+
+    Variable names support slicing and group access. For instance, provided
+    that the file contains the appropriate objects, the following syntax is
     valid:
-        
+
     a = h5read('file.h5', 'myarray[2:4]')
     a = h5read('file.h5', 'adict.thekeyIwant')
-    
+
     Another way of slicing, is with the slice keyword argument, which will take
     the provided slice object and apply it on the last variable name:
 
@@ -330,13 +330,13 @@ def h5read(filename, *args, **kwargs):
     # Will read array2[1:2]
 
     h5read(filename_with_wildcard, ... , doglob=True)
-    Reads sequentially all globbed filenames. 
- 
+    Reads sequentially all globbed filenames.
+
     """
     doglob = kwargs.pop('doglob', None)
     depth = kwargs.pop('depth',None)
     depth = 99 if depth is None else depth+1
-    
+
     # Used if we read a list of files
     fnames = []
     if not isinstance(filename, str):
@@ -350,7 +350,7 @@ def h5read(filename, *args, **kwargs):
             fnames = sorted(glob.glob(filename))
             if not fnames:
                 raise IOError('%s : no match.' % filename)
-      
+
     if fnames:
         # We are here only if globbing was allowed.
         dl = []
@@ -358,9 +358,9 @@ def h5read(filename, *args, **kwargs):
         for f in fnames:
             # Call again, but this time without globbing.
             d = h5read(f, *args, doglob=False, **kwargs)
-            dl.append(d) 
+            dl.append(d)
         return dl
-    
+
     # We are here only if there was no globbing (fnames is empty)
     filename = os.path.abspath(os.path.expanduser(filename))
 
@@ -382,7 +382,7 @@ def h5read(filename, *args, **kwargs):
                     k = k.replace(h5options['SLASH_ESCAPE'], '/')
                 d[k] = _load(v,depth-1)
         return d
-        
+
     def _load_list(dset,depth):
         l = []
         if depth>0:
@@ -391,34 +391,34 @@ def h5read(filename, *args, **kwargs):
             for k in keys:
                 l.append(_load(dset[k],depth-1))
         return l
-    
+
     def _load_numpy(dset,sl=None):
         if sl is not None:
             return dset[sl]
         else:
             return dset[...]
-        
+
     def _load_scalar(dset):
         try:
             return dset[...].item()
         except:
             return dset[...]
-       
+
     def _load_str(dset):
         return dset.value
 
     def _load_unicode(dset):
         return dset.value.decode('utf8')
-        
+
     def _load_pickle(dset):
         return cPickle.loads(dset[...])
 
     def _load(dset, depth,sl=None):
         dset_type = dset.attrs.get('type',None)
-      
+
         # Treat groups as dicts
         if (dset_type is None) and (type(dset) is h5py.Group):
-            dset_type = 'dict'    
+            dset_type = 'dict'
 
         if dset_type == 'dict' or dset_type =='param':
             if sl is not None:
@@ -502,7 +502,7 @@ def h5read(filename, *args, **kwargs):
 
             last_k = key_list[-1]
             for k in key_list:
-                if k == last_k and slice is not None: 
+                if k == last_k and slice is not None:
                     sl = slice
                 else:
                     # detect slicing
@@ -512,7 +512,7 @@ def h5read(filename, *args, **kwargs):
                         sl = str_to_slice('[' + slice_string + ']')
                     else:
                         sl = None
-                
+
                 # detect group access
                 if '.' in k:
                     glist = k.split('.')
@@ -523,10 +523,10 @@ def h5read(filename, *args, **kwargs):
                     outdict[k] = _load(gr[k],depth,sl=sl)
                 else:
                     outdict[k] = _load(f[k],depth,sl=sl)
-      
-    return outdict      
 
-    
+    return outdict
+
+
 
 def h5info(filename, path='', output=None, depth=8):
     """\
@@ -539,18 +539,18 @@ def h5info(filename, path='', output=None, depth=8):
     filename = os.path.abspath(os.path.expanduser(filename))
 
     def _format_dict(d,key, dset, isParam=False):
-        ss='Param' if isParam else 'dict' 
+        ss='Param' if isParam else 'dict'
         stringout = ' '*key[0] + ' * %s [%s %d]:\n' % (key[1],ss,len(dset))
-        if d>0: 
+        if d>0:
             for k,v in dset.items():
                 if v is not None and v.attrs.get('escaped', None) is not None:
                     k = k.replace(h5options['SLASH_ESCAPE'], '/')
                 stringout += _format(d-1,(key[0]+indent, k), v)
         return stringout
-    
+
     def _format_list(d,key, dset):
         stringout = ' '*key[0] + ' * %s [list %d]:\n' % (key[1],len(dset))
-        if d>0: 
+        if d>0:
             keys = dset.keys()
             keys.sort()
             for k in keys:
@@ -559,7 +559,7 @@ def h5info(filename, path='', output=None, depth=8):
 
     def _format_tuple(key, dset):
         stringout = ' '*key[0] + ' * %s [tuple]:\n' % key[1]
-        if d>0: 
+        if d>0:
             keys = dset.keys()
             keys.sort()
             for k in keys:
@@ -589,7 +589,7 @@ def h5info(filename, path='', output=None, depth=8):
             except ValueError:
                 stringout = ' '*key[0] + ' * ' + key[1] + ' [list = [%d x %s objects]]\n' % (a.size, str(a.dtype))
         return stringout
-    
+
     def _format_numpy(key, dset):
         a = dset[...]
         if len(a) < 5 and a.ndim == 1:
@@ -597,11 +597,11 @@ def h5info(filename, path='', output=None, depth=8):
         else:
             stringout = ' '*key[0] + ' * ' + key[1] + ' [' + (('%dx'*(a.ndim-1) + '%d') % a.shape) + ' ' + str(a.dtype) + ' array]\n'
         return stringout
-        
+
     def _format_scalar(key, dset):
         stringout = ' '*key[0] + ' * ' + key[1] + ' [scalar = ' + str(dset[...]) + ']\n'
         return stringout
-       
+
     def _format_str(key, dset):
         s = str(dset[...])
         if len(s) > 40:
@@ -615,7 +615,7 @@ def h5info(filename, path='', output=None, depth=8):
             s = s[:40] + '...'
         stringout = ' '*key[0] + ' * ' + key[1] + ' [unicode = "' + s + '"]\n'
         return stringout
-       
+
     def _format_pickle(key, dset):
         stringout = ' '*key[0] + ' * ' + key[1] + ' [pickled object]\n'
         return stringout
@@ -630,7 +630,7 @@ def h5info(filename, path='', output=None, depth=8):
 
     def _format(d,key, dset):
         dset_type = 'None' if dset is None else dset.attrs.get('type',None)
-      
+
         # Treat groups as dicts
         if (dset_type is None) and (type(dset) is h5py.Group):
             dset_type = 'dict'
@@ -664,7 +664,7 @@ def h5info(filename, path='', output=None, depth=8):
         else:
             stringout = _format_unknown(key, dset)
         return stringout
-        
+
     with h5py.File(filename,'r') as f:
         # h5rw_version = f.attrs.get('h5rw_version',None)
         # if h5rw_version is None:
@@ -677,10 +677,10 @@ def h5info(filename, path='', output=None, depth=8):
         outstring = ''
         for k in key_list:
             outstring += _format(depth,(0,k),f[path+k])
-    
+
     print outstring
-    
+
     # return string if output variable passed as option
     if output != None:
         return outstring
-    
+

--- a/ptypy/io/imageIO.py
+++ b/ptypy/io/imageIO.py
@@ -9,7 +9,7 @@ import PIL.Image as PIL
 from .. import utils
 from .. import verbose
 
-# Tentative support for 12-bit tiff. Requires libtiff library 
+# Tentative support for 12-bit tiff. Requires libtiff library
 try:
     import libtiff12bit
 except:
@@ -30,7 +30,7 @@ def imread(filename, doglob=None, roi=None):
             ignores wildcards
 
         ... = imread(filename, doglob=None) [default]
-            behaves like doglob=True, except that it returns a list only if filename contains wildcards, 
+            behaves like doglob=True, except that it returns a list only if filename contains wildcards,
             while doglob=True always returns a list, even if there is only one match.
 
         ... = imread(filename, roi=(RowFrom, RowTo, ColumnFrom, ColumnTo))

--- a/ptypy/io/image_read.py
+++ b/ptypy/io/image_read.py
@@ -24,7 +24,7 @@ def image_read(filename, *args, **kwargs):
             ext = subset.pop()
             use_imread = False
             filename = os.path.splitext(filename)[0] + ext
-    else:    
+    else:
         ext = os.path.splitext(filename)[1].lower()
         if ext in special_format:
             use_imread = False
@@ -38,7 +38,7 @@ def image_read(filename, *args, **kwargs):
         h5_image = h5read(filename, *args, **kwargs)
         def look_for_ndarray(d):
             for k,v in d.iteritems():
-                if type(v) is np.ndarray: 
+                if type(v) is np.ndarray:
                     return k,v
                 elif type(v) is type({}):
                     out = look_for_ndarray(v)
@@ -48,7 +48,7 @@ def image_read(filename, *args, **kwargs):
         if isinstance(h5_image, list):
             h5_arrays = []
             h5_metas = []
-            for h5s in h5_image: 
+            for h5s in h5_image:
                 h5a = look_for_ndarray(h5s)
                 h5_arrays.append(h5a[-1])
                 h5_metas.append({'filename':filename, 'path': '/'.join(h5a[0:-1])})

--- a/ptypy/io/interaction.py
+++ b/ptypy/io/interaction.py
@@ -76,26 +76,26 @@ class NumpyEncoder(json.JSONEncoder):
     Custom JSON Encoder class that take out numpy arrays from a structure
     and replace them with a code string.
     """
-    def encode(self, obj):  
+    def encode(self, obj):
         # Prepare the array list
         self.npy_arrays = []
-        
+
         # Encode as usual
         s = json.JSONEncoder.encode(self, obj)
-        
+
         # Return the list along with the encoded object
         npy_arrays = self.npy_arrays
-        del self.npy_arrays 
+        del self.npy_arrays
         return s, npy_arrays
 
-    def default(self, obj):    
+    def default(self, obj):
         if hasattr(obj, '__array_interface__'):
             # obj is "array-like". Add it to the list
             self.npy_arrays.append(obj)
-            
+
             # Replace obj by a key string giving the index of obj in the list
             return u'NPYARRAY[%03d]' % (len(self.npy_arrays)-1)
-            
+
         return json.JSONEncoder.default(self, obj)
 
 NE = NumpyEncoder()
@@ -122,7 +122,7 @@ def numpy_replace(obj, arraylist):
     elif isinstance(obj, list):
         return [numpy_replace(x, arraylist) for x in obj]
     else:
-        return obj        
+        return obj
 
 
 def numpy_zmq_send(out_socket, obj):
@@ -132,22 +132,22 @@ def numpy_zmq_send(out_socket, obj):
 
     # Encode the object
     s, npy_arrays = NE.encode(obj)
-    
+
     # (re-decode the string that does not contain numpy arrays anymore)
     s = json.loads(s)
-        
+
     if not npy_arrays:
         # Simple case, just send the object as-is
         out = {'hasarray': False, 'message': obj}
         out_socket.send_json(out)
         return
-        
-    # Make sure arrays to be sent have contiguous buffers 
+
+    # Make sure arrays to be sent have contiguous buffers
     npy_arrays = [a if a.flags.contiguous else a.copy() for a in npy_arrays]
-    
-    # Prepare the shape and datatype information for each array 
+
+    # Prepare the shape and datatype information for each array
     arrayprops = [{'dtype': a.dtype.str, 'shape': a.shape} for a in npy_arrays]
-    
+
     # Send the header
     out_socket.send_json({'hasarray': True, 'message': s, 'arraylist': arrayprops}, flags=zmq.SNDMORE)
 
@@ -156,7 +156,7 @@ def numpy_zmq_send(out_socket, obj):
         out_socket.send(a, copy=False, track=True, flags=zmq.SNDMORE)
     out_socket.send(npy_arrays[-1], copy=False, track=True)
     return
-  
+
 
 def numpy_zmq_recv(in_socket):
     """\
@@ -181,36 +181,36 @@ class Server(object):
     """\
     Main server class.
     """
-    
+
     #: Default parameters, see also :py:data:`.io.interaction`
     DEFAULT = Server_DEFAULT
-    
+
     def __init__(self, pars=None, **kwargs):
         """
         Interaction server, meant to run asynchronously with process 0 to manage client requests.
-        
+
         Parameters
         ----------
         pars : dict or Param
-            Parameter set for the server. 
-            
+            Parameter set for the server.
+
         Keyword Arguments
         -----------------
-        address : str 
+        address : str
             Primary address
-        
+
         port : int
             Primary port
-            
+
         connections : int
             number of ports to open on demand *behind* the primary port.
-            
+
         poll_timeout : float
             Network polling interval (in milliseconds!).
-                         
+
         pinginterval : float
             Interval to check pings (in seconds).
-                         
+
         pingtimeout : float
             Ping time out: client disconnected after this period (in seconds).
 
@@ -222,43 +222,43 @@ class Server(object):
         p.update(pars)
         p.update(kwargs)
         self.p = p
-        
-        
+
+
         # sanity check for port range:
         #if str(p.port_range)==p.port_range:
         #    from ptypy.utils import str2range
         #    p.port_range = str2range(p.port_range)
-        
+
         self.address = p.address
         self.port = p.port
-        
+
         self.poll_timeout = p.poll_timeout
         self.pinginterval = p.pinginterval
         self.pingtimeout = p.pingtimeout
 
         # Object list, from which data can be transferred
         self.objects = dict()
-        
+
         # Client names (might not be unique, but can be informative)
         self.names = {}
-        
+
         # Ping times for all connected Clients
         self.pings = {}
-        
-        # Last time a ping check was done 
+
+        # Last time a ping check was done
         self.pingtime = time.time()
-    
+
         # Command queue
         self.queue = Queue.Queue()
-        
-        # Initialize flags to communicate state between threads. 
+
+        # Initialize flags to communicate state between threads.
         self._need_process = False
         self._can_process = False
-        
+
         self._thread = None
         self._stopping = False
         self._activated = False
-        
+
         # Bind command names to methods
         self.cmds = {'CONNECT':self._cmd_connect,         # Initial connection from client
                      'DISCONNECT': self._cmd_disconnect,  # Disconnect from client
@@ -271,10 +271,10 @@ class Server(object):
                      'SHUTDOWN': self._cmd_shutdown}      # Shut down the server
 
         self.make_ID_pool()
-        
+
     def make_ID_pool(self):
-        
-        port_range = range(self.port+1,self.port+self.p.connections+1) 
+
+        port_range = range(self.port+1,self.port+self.p.connections+1)
         # Initial ID pool
         IDlist = []
         # This loop ensures all IDs are unique
@@ -303,7 +303,7 @@ class Server(object):
             time.sleep(0.05)
 
         return port
-        
+
     def send_warning(self, warning_message):
         """
         Queue a warning message for all connected clients.
@@ -326,7 +326,7 @@ class Server(object):
 
     def _run(self):
         """
-        Prepare the server and start listening for connections. 
+        Prepare the server and start listening for connections.
         (runs on the separate thread)
         """
 
@@ -345,12 +345,12 @@ class Server(object):
                 continue
             if success:
                 break
-        
+
         if self.port != port:
             # not thread safe
             self.port = port
             self.make_ID_pool()
-            
+
         print("Server listens on %s, port %s" % (str(self.address), str(self.port)))
 
         # Initialize list of requests
@@ -359,7 +359,7 @@ class Server(object):
         # Initialize poller
         self.poller = zmq.Poller()
         self.poller.register(self.in_socket, zmq.POLLIN)
-             
+
         self._activated = True
         # Start the main loop with a little bit naive protection for
         # rogue threads that block ports. Only works if thread raised
@@ -370,7 +370,7 @@ class Server(object):
             print("stop listening on %s, port %s" % (str(self.address), str(self.port)))
             self.in_socket.unbind(fulladdress)
             self.in_socket.close()
-            
+
     def _listen(self):
         """
         Listen for connections and process requests when given permission
@@ -384,27 +384,27 @@ class Server(object):
                 self._need_process = False
                 self._can_process = False
                 self._process()
-                
+
             # Check for new requests
             if self.poller.poll(self.poll_timeout):
 
                 # Get new command
                 message = self._recv(self.in_socket)
-                
+
                 # Parse it
                 reply = self._parse_message(message)
-                
+
                 # Send reply to client
                 self._send(self.in_socket, reply)
-                
+
             # Regular client ping
             self._checkping()
-                
+
     def _parse_message(self, message):
         """\
         Parse the message sent by the bound client and queue the corresponding
         command if needed.
-        
+
         message is {'ID':ID, 'cmd':command, 'args':kwargs}
         """
 
@@ -439,7 +439,7 @@ class Server(object):
         except IndexError:
             # No more connections are allowed
             return {'ID': None, 'status': 'Error: no more connection allowed'}
-            
+
         # New connection socket for the client (PUB means one way)
         out_socket = self.context.socket(zmq.PUB)
         fulladdress = self.address + ':' + str(newport)
@@ -471,7 +471,7 @@ class Server(object):
 
         # Place this back in the pool
         self.ID_pool.append(IDtuple)
-        
+
         return{'status': 'ok'}
 
     def _cmd_shutdown(self, ID, args):
@@ -481,7 +481,7 @@ class Server(object):
         self._stopping = True
         self._can_process = True
         return {'status': 'ok'}
-        
+
     def _cmd_avail(self, ID, args):
         """\
         Process and AVAIL command
@@ -489,7 +489,7 @@ class Server(object):
         """
         DEBUG('Processing an AVAIL command')
         return {'status': 'ok', 'avail': self.objects.keys()}
-        
+
     def _cmd_ping(self, ID, args):
         """\
         Process a PING command
@@ -525,7 +525,7 @@ class Server(object):
         self.queue.put({'ID': ID, 'cmd': 'SET', 'ticket': args['ticket'], 'str': args['str'], 'val': args['val']})
         self._need_process = True
         return {'status': 'ok'}
-        
+
     def _cmd_get_now(self, ID, args):
         """\
         Return the requested object to be sent immediately as a reply.
@@ -540,7 +540,7 @@ class Server(object):
             out = None
 
         return {'status': status, 'out': out}
-            
+
     def _send(self, out_socket, obj):
         """\
         Send the given object using JSON, taking care of numpy arrays.
@@ -556,15 +556,15 @@ class Server(object):
         Receive a JSON object, taking care of numpy arrays
         """
         return numpy_zmq_recv(in_socket)
-      
+
     def _process(self):
-        """\                
+        """\
         Loop through the queued commands and execute them. Normally access to any object
         is safe since the other thread is waiting for this function to complete.
         """
         DEBUG('Executing queued commands')
         t0 = None
-        
+
         # Loop until the queue is empty
         while True:
             try:
@@ -581,11 +581,11 @@ class Server(object):
                 self.queue.task_done()
                 logger.debug('Client %s disconnected. Skipping.' % q['ID'])
                 continue
-                
+
             # Measure how long a transfer takes
             if t0 is None:
                 t0 = time.time()
-            
+
             status = 'ok'
 
             # Process the command
@@ -611,25 +611,25 @@ class Server(object):
                     out = None
             elif q['cmd'] in ['WARN', 'ERROR']:
                 out = q['str']
-                
+
             # This is the socket to send data to
             out_socket = self.out_sockets[q['ID']][0]
-            
+
             # Send the data
             try:
                 self._send(out_socket, {'ticket': ticket, 'status': status, 'out': out})
             except TypeError:
                 # We have tried to send something that JSON doesn't support.
                 self._send(out_socket, {'ticket': ticket, 'status': 'TypeError', 'out': None})
-            
+
             # Task completed!
             self.queue.task_done()
-            
+
         # We get here only once the queue is empty.
         if t0 is not None:
             logger.debug('Time spent : %f' % (time.time() - t0))
         return
-        
+
     def register(self, obj, name):
         """\
         Exposes the content of an object for transmission and interaction.
@@ -648,7 +648,7 @@ class Server(object):
         if self._need_process:
             # Set flag to allow sending objects
             self._can_process = True
-            
+
             # Wait until the command queue is empty
             self.queue.join()
 
@@ -661,47 +661,47 @@ class Server(object):
 
 class Client(object):
     """
-    Basic but complete client to interact with the server. 
+    Basic but complete client to interact with the server.
     """
-    
+
     #: Default parameters, see also :py:data:`.io.interaction`
     DEFAULT = Client_DEFAULT
-    
+
     def __init__(self, pars=None, **kwargs):
         """
         Parameters
         ----------
         pars : dict or Param
-            Parameter set for the client, see :py:attr:`DEFAULT` 
-            
+            Parameter set for the client, see :py:attr:`DEFAULT`
+
         Keyword Arguments
         -----------------
-        address : str 
+        address : str
             Primary address of the remote server.
-        
+
         port : int
             Primary port of the remote server.
-            
+
         poll_timeout : float
             Network polling interval (in milliseconds!).
-                         
+
         pinginterval : float
             Interval to check pings (in seconds).
-                         
+
         """
-        
+
         p = u.Param(self.DEFAULT)
         p.update(pars)
         p.update(kwargs)
         self.p = p
-        
+
         """
         # sanity check for port range:
         if str(p.port_range)==p.port_range:
             from ptypy.utils import str2range
             p.port_range = str2range(p.port_range)
         """
-        
+
         self.req_address = p.address
         self.req_port = p.port
         self.poll_timeout = p.poll_timeout
@@ -710,28 +710,28 @@ class Client(object):
 
         # Initially not connected
         self.connected = False
-        
+
         # A name for us.
         self.name = self.__class__.__name__
 
         # Command queue
         self.cmds = []
-        
+
         # Data container
         self.data = {}
-        
+
         # Status container
         self.status = {}
 
         # ticket counter
         self.masterticket = 0
-        
+
         # ticket status
         self.tickets = {}
-        
+
         # list of pending transactions
         self.pending = []
-        
+
         # list of completed transactions
         self.completed = []
 
@@ -764,7 +764,7 @@ class Client(object):
         self.req_socket = self.context.socket(zmq.REQ)
         fulladdress = self.req_address + ':' + str(self.req_port)
         self.req_socket.connect(fulladdress)
-        
+
         # Establish connection with the interactor by sending a "CONNECT" command
         self._send(self.req_socket, {'ID': None, 'cmd': 'CONNECT', 'args': {'name':self.name}})
         reply = self._recv(self.req_socket)
@@ -787,7 +787,7 @@ class Client(object):
         self.req_poller = zmq.Poller()
         self.req_poller.register(self.req_socket, zmq.POLLIN)
         self.connected = True
-        
+
         # Create "Event" flags for calls that require synchronization.
         self.getnow_flag = Event()
         self.getnow_flag.clear()
@@ -840,7 +840,7 @@ class Client(object):
             self._ping()
 
         self.connected = False
-                
+
     def _ping(self):
         """\
         Send a ping
@@ -862,16 +862,16 @@ class Client(object):
         Receive a JSON object, taking care of numpy arrays
         """
         return numpy_zmq_recv(in_socket)
-    
+
     def _read_message(self):
         """\
         Read the message sent by the server and store the accompanying data
         if needed.
         """
-        
+
         message = self._recv(self.bind_socket)
         ticket = message['ticket']
-        
+
         # Store data
         self.data[ticket] = message['out']
         self.status[ticket] = message['status']
@@ -900,7 +900,7 @@ class Client(object):
         self.data = {}
         self.status = {}
         self.datatag = {}
-        
+
     def poll(self, ticket=None, tag=None):
         """\
         Returns true if the transaction for a given ticket is completed.
@@ -942,13 +942,13 @@ class Client(object):
         Meant to be replaced, e.g. to send signals to a GUI.
         """
         pass
-    
+
     def unexpected_ticket(self, ticket):
         """\
         Used to deal with warnings sent by the server.
         """
         logger.debug(str(ticket) + ': ' + str(self.data[ticket]))
-    
+
     def stop_server(self):
         """
         Send a SHUTDOWN command - is this a good idea?
@@ -957,7 +957,7 @@ class Client(object):
         self.shutdown_flag.clear()
         self.shutdown_flag.wait()
         return self.last_reply
-        
+
     def stop(self):
         if not self._stopping:
             logger.debug("Stopping.")
@@ -973,12 +973,12 @@ class Client(object):
         self.avail_flag.clear()
         self.avail_flag.wait()
         return self.last_reply
-        
+
     def do(self, execstr, timeout=0, tag=None):
         """\
         Modify and object using an exec string.
-        This function returns the "ticket number" which identifies the object once 
-        it will have been transmitted. If timeout > 0 and the requested object has 
+        This function returns the "ticket number" which identifies the object once
+        it will have been transmitted. If timeout > 0 and the requested object has
         been transmitted within timeout seconds, return a tuple (ticket, data).
         """
         ticket = self.masterticket + 1
@@ -993,12 +993,12 @@ class Client(object):
             if self.wait(ticket, timeout):
                 return ticket, self.data[ticket]
         return ticket
-        
+
     def get(self, evalstr, timeout=0, tag=None):
         """\
         Requests an object (or part of it) using an eval string.
-        This function returns the "ticket number" which identifies the object once 
-        it will have been transmitted. If timeout > 0 and the requested object has 
+        This function returns the "ticket number" which identifies the object once
+        it will have been transmitted. If timeout > 0 and the requested object has
         been transmitted within timeout seconds, return a tuple (ticket, data).
         """
         ticket = self.masterticket + 1
@@ -1016,7 +1016,7 @@ class Client(object):
 
     def set(self, varname, varvalue, timeout=0, tag=None):
         """\
-        Sets an object named varname to the value varvalue. 
+        Sets an object named varname to the value varvalue.
         """
         ticket = self.masterticket + 1
         self.masterticket += 1

--- a/ptypy/io/rawIO.py
+++ b/ptypy/io/rawIO.py
@@ -1,6 +1,6 @@
 #-*- coding: utf-8 -*-
 """
-read .raw images from FLI camera 
+read .raw images from FLI camera
 Created in Nov 2013
 TODO: add masking function to mask out hot/dead pixels of detector
 @author: Bjoern Enders
@@ -40,7 +40,7 @@ def rawread(filename, doglob=None, roi=None):
             ignores wildcards
 
         ... = rawread(filename, doglob=None) [default]
-            behaves like doglob=True, except that it returns a list only if filename contains wildcards, 
+            behaves like doglob=True, except that it returns a list only if filename contains wildcards,
             while doglob=True always returns a list, even if there is only one match.
 
         ... = rawread(filename, roi=(RowFrom, RowTo, ColumnFrom, ColumnTo))
@@ -65,7 +65,7 @@ def rawread(filename, doglob=None, roi=None):
     for f in fnames:
         log(3, 'Reading "%s"' % f)
         dat,meta = _read(f,np.uint16)
-        meta['filename'] = f       
+        meta['filename'] = f
         lmeta.append(meta)
         if roi is not None:
             ldat.append(dat[roi[0]:roi[1],roi[2]:roi[3]].copy())
@@ -80,21 +80,21 @@ def _read(filename,dtype):
     f=file(filename)
     header = []
     header.append(f.readline())
-    
+
     while 'EOH' not in header[-1]:
         header.append(f.readline())
-        
+
     meta = _interpret_header(header)
     rows = meta['rows']
     cols = meta['cols']
     f.seek(-rows*cols*2,2)
     data = np.fromfile(f,dtype)
     data = data.reshape((rows,cols))
-    
+
     return data,meta
 
 def _interpret_header(header):
-    """ 
+    """
     This is special for FLI server I guess.
     """
     #print header
@@ -116,4 +116,4 @@ def _interpret_header(header):
     raw_header = header
     )
     return meta
-    
+

--- a/ptypy/resources/__init__.py
+++ b/ptypy/resources/__init__.py
@@ -15,7 +15,7 @@ def flower_obj(shape=None):
         ish = np.array(im.shape[:2])
         d = sh-ish
         im = u.crop_pad(im,d,axes=[0,1],cen=None,fillpar=0.0,filltype='mirror')
-        
+
     return im
 
 def tree_obj(shape=None):
@@ -29,7 +29,7 @@ def tree_obj(shape=None):
         ish = np.array(im.shape[:2])
         d = sh-ish
         im = u.crop_pad(im,d,axes=[0,1],cen=None,fillpar=0.0,filltype='mirror')
-        
+
     return im
 
 def moon_pr(shape=None):
@@ -42,7 +42,7 @@ def moon_pr(shape=None):
         sh = u.expect2(shape)
         ish = np.array(im.shape[:2]).astype(float)
         im = u.zoom(im,sh/ish)
-        
+
     return im
 
 

--- a/ptypy/simulations/__init__.py
+++ b/ptypy/simulations/__init__.py
@@ -9,6 +9,6 @@ This file is part of the PTYPY package.
 """
 from ptysim_utils import *
 #from ptysim import *
-import detector 
-#import cxro 
+import detector
+#import cxro
 from simscan import SimScan

--- a/ptypy/simulations/detector.py
+++ b/ptypy/simulations/detector.py
@@ -10,7 +10,7 @@ in your acquisition.
 This file is part of the PTYPY package.
 
     :copyright: Copyright 2014 by the PTYPY team, see AUTHORS.
-    :license: GPLv2, see LICENSE for details.    
+    :license: GPLv2, see LICENSE for details.
 """
 import numpy as np
 from scipy import ndimage as ndi
@@ -18,7 +18,7 @@ from scipy import ndimage as ndi
 __all__=['shot','Detector','conv','fill2D']
 
 DEFAULTS= dict(
-    sci_psf = None,     # (None or float, 2-tuple, array) Parameters for gaussian convolution or convolution kernel after exposure of scintillator 
+    sci_psf = None,     # (None or float, 2-tuple, array) Parameters for gaussian convolution or convolution kernel after exposure of scintillator
     sci_qe = 1,         # (float) how many optical photons per x-ray photon
     psf = None,         # (None or float, 2-tuple, array) Parameters for gaussian convolution or convolution kernel after exposure
     qe = 1.,            # (float) detector quantum efficiency for converting a photon to a well count
@@ -30,12 +30,12 @@ DEFAULTS= dict(
     modules = (1,1),    # (tuple) number of modules for each dimension
     center = 1024,      # (int,tuple) frame center of the exposure within the first module
     dtype = np.uint16,  # (numpy integer dtype) data type for storing (can also be the type char)
-    on_limit = 'clip',  # 
+    on_limit = 'clip',  #
     psize = 10e-6,      # pixel size (for documentation only)
     #beamstop = None,    # (None,'rect','circ') beamstop
-    #bs_size = 0.0,      # (float, tuple) beamstop size in  
+    #bs_size = 0.0,      # (float, tuple) beamstop size in
     #bs_trans = 0.0,     #
-    #bs_edgewith = 0.5,   
+    #bs_edgewith = 0.5,
 )
 
 TEMPLATES = {}
@@ -51,7 +51,7 @@ TEMPLATES['FLI_PL1001'] = dict(
     shot_noise = 9,
     adu = 10,
     center = 512,
-    psize = 24e-6 
+    psize = 24e-6
 )
 
 TEMPLATES['FRELON_TAPER'] = dict(
@@ -89,7 +89,7 @@ TEMPLATES['PILATUS_300K']['modules'] = (3,1)
 
 
 class Detector(object):
-    
+
     def __init__(self,pars=None):
         self._update(DEFAULTS)
         if str(pars)==pars:
@@ -102,11 +102,11 @@ class Detector(object):
         self._make_mask()
         if self.center is None:
             self.center = expect2(self._mask.shape)/2
-            
+
     def _update(self,pars=None):
         if pars is not None:
             self.__dict__.update(pars)
-            
+
     def _make_mask(self):
         gaps = expect2(self.gaps)
         module = np.ones(self.shape).astype(np.bool)
@@ -119,28 +119,28 @@ class Detector(object):
             gap = np.zeros((module.shape[0],gaps[1])).astype(np.bool)
             start = np.concatenate([start,np.concatenate([gap,module],axis=1)],axis=1)
         self._mask = start
-        
+
     def _get_mask(self,sh):
         msh =  expect2(sh[-2:])
         mask = np.zeros(msh).astype(np.bool)
         offset = msh//2 - expect2(self.center)
         mask = fill2D(mask,self._mask,-offset)
         return np.resize(mask,sh)
-        
+
     def filter(self,intensity_stack,convert_dtype=False):
         I= intensity_stack
-        I_dtype = I.dtype if not convert_dtype else self.dtype 
+        I_dtype = I.dtype if not convert_dtype else self.dtype
 
         mask = self._get_mask(I.shape)
-        
+
         I = np.abs(np.array(I).astype(float))
         if self.sci_psf is not None:
             I = self.sci_qe*conv(np.random.poisson(I).astype(float),self.sci_psf)
         if self.psf is not None:
             I = conv(I,self.psf)
-        
+
         # convert to well counts
-        Iel = np.random.poisson(I* self.qe).astype(float) 
+        Iel = np.random.poisson(I* self.qe).astype(float)
         # add shot noise
         Iel += np.abs(np.random.standard_normal(I.shape)*self.shot_noise)
         overexposed = Iel>=self.full_well
@@ -151,12 +151,12 @@ class Detector(object):
         if self.on_limit=='clip':
             mx = np.iinfo(dt).max
             DU[DU>mx]=mx
-        
+
         DU[np.invert(mask)]=0.0
         mask &= np.invert(overexposed)
-        
+
         return DU.astype(I_dtype), mask
-        
+
 def conv(A,inp,**kwargs):
     dims = A.ndim
     assert dims in [2,3], "Filtered array has to be 2D or 3D."
@@ -164,7 +164,7 @@ def conv(A,inp,**kwargs):
         return A
     elif np.size(inp)<=2:
         inp = expect2(inp)
-        if dims==3: 
+        if dims==3:
             inp=[0,inp[0],inp[1]]
         return ndi.gaussian_filter(A,inp,**kwargs)
     else:
@@ -173,10 +173,10 @@ def conv(A,inp,**kwargs):
         if dims ==3:
             inp = inp.reshape((1,inp.shape[0],inp.shape[1]))
         return ndi.convolve(A,inp,**kwargs)
-        
+
 def shot(I,exp=0.1,flux=1e5,sensitivity=1.0,dark_c=None,io_noise=0.,full_well=2**10-1,el_per_ADU=1.0,offset=50.):
     """\
-    I : intensity distribution  
+    I : intensity distribution
     flux : overall photon photons per seconds coming in
     exp : exposition time in sec
     io_noise : readout noise rms
@@ -184,18 +184,18 @@ def shot(I,exp=0.1,flux=1e5,sensitivity=1.0,dark_c=None,io_noise=0.,full_well=2*
     el_per_ADU : conversion effficiency of electrons to digitally counted units
     dark_curr : electrons per second per pixel on average
     """
-    
+
     I=np.asarray(I).astype(float)
-    
+
     if I.sum() != 0. :
         I=I/I.sum()
-    
+
     photo_el = np.floor(sensitivity*np.random.poisson(exp*flux*I))
     if dark_c is not None:
         therm_el = np.floor(np.random.poisson(dark_c*exp*np.ones_like(I)))
     else:
         therm_el = np.zeros_like(I)
-    
+
     el = photo_el + therm_el
     el[el > full_well] = full_well
     out = offset + io_noise*np.random.standard_normal(I.shape)+ el / el_per_ADU
@@ -218,26 +218,26 @@ def fill2D(imA,imB,offset):
     maxA=vmin([shA,vmax([shB-offset,expect2(0)])])
     minB=vmax([expect2(0),vmin([+offset,shB])])
     maxB=vmin([shB,vmax([shA+offset,expect2(0)])])
-    #print minA,maxA,minB,maxB 
+    #print minA,maxA,minB,maxB
     imA[...,minA[0]:maxA[0],minA[1]:maxA[1]] = imB[...,minB[0]:maxB[0],minB[1]:maxB[1]]
     return imA
-    
+
 def expect2(a):
     """\
-    generates 1d numpy array with 2 entries generated from multiple inputs 
+    generates 1d numpy array with 2 entries generated from multiple inputs
     (tuples, arrays, scalars). main puprose of this function is to circumvent
     debugging of input.
-    
+
     expect2( 3.0 ) -> np.array([3.0,3.0])
     expect2( (3.0,4.0) ) -> np.array([3.0,4.0])
-    
+
     even higher order inputs possible, though not tested much
-    """ 
+    """
     a=np.atleast_1d(a)
     if len(a)==1:
         b=np.array([a.flat[0],a.flat[0]])
     else: #len(psize)!=2:
-        b=np.array([a.flat[0],a.flat[1]])        
+        b=np.array([a.flat[0],a.flat[1]])
     return b
 
 def smooth_step(x,mfs):
@@ -249,7 +249,7 @@ if __name__ == "__main__":
     from scipy.misc import lena
     from scipy.ndimage import gaussian_filter as gf
     from matplotlib import pyplot as plt
-    from scipy.special import erf 
+    from scipy.special import erf
     if len(sys.argv) > 1:
         det = sys.argv[1]
     else:

--- a/ptypy/simulations/ptysim.py
+++ b/ptypy/simulations/ptysim.py
@@ -25,10 +25,10 @@ else:
     from ptysim_utils import *
     from ..core.data import PtyScan
     from ..core.ptycho import Ptycho
-    
+
 DEFAULT = u.Param(
     pos_noise = 1e-10,  # (float) unformly distributed noise in xy experimental positions
-    pos_scale = 0,      # (float, list) amplifier for noise. Will be extended to match number of positions. Maybe used to only put nois on individual points  
+    pos_scale = 0,      # (float, list) amplifier for noise. Will be extended to match number of positions. Maybe used to only put nois on individual points
     pos_drift = 0,      # (float, list) drift or offset paramter. Noise independent drift. Will be extended like pos_scale.
     detector = 'PILATUS_300K',
     frame_size = None ,   # (None, or float, 2-tuple) final frame size when saving if None, no cropping/padding happens
@@ -42,7 +42,7 @@ warnings.simplefilter('always', DeprecationWarning)
 def simulate_basic_with_pods(ptypy_pars_tree=None,sim_pars=None,save=False):# pragma: no cover
     """
     Basic Simulation
-    
+
     DEPRECATED - cannot produce the right .ptyd format
     """
     warnings.warn('This function is deprecated and will be removed from the package on 30/11/16',DeprecationWarning)
@@ -52,21 +52,21 @@ def simulate_basic_with_pods(ptypy_pars_tree=None,sim_pars=None,save=False):# pr
         p.update(ppt.get('simulation'))
     if sim_pars is not None:
         p.update(sim_pars)
-        
+
     P = Ptycho(ppt,level=1)
 
     # make a data source that has is basicaly empty
     P.datasource = make_sim_datasource(P.modelm,p.pos_drift,p.pos_scale,p.pos_noise)
-    
+
     P.modelm.new_data()
     u.parallel.barrier()
     P.print_stats()
-    
+
     # Propagate and apply psf for simulationg partial coherence (if not done so with modes)
     for name,pod in P.pods.iteritems():
         if not pod.active: continue
         pod.diff += conv(u.abs2(pod.fw(pod.exit)),p.psf)
-    
+
     # Filter storage data similar to a detector.
     if p.detector is not None:
         Det = Detector(p.detector)
@@ -80,16 +80,16 @@ def simulate_basic_with_pods(ptypy_pars_tree=None,sim_pars=None,save=False):# pr
                 dat = u.crop_pad(dat,hplanes,axes=[-2,-1]).astype(dat.dtype)
                 mask = u.crop_pad(mask,hplanes,axes=[-2,-1]).astype(mask.dtype)
             Sdiff.fill(dat)
-            Smask.fill(mask) 
+            Smask.fill(mask)
     else:
-        save_dtype = None        
-    
+        save_dtype = None
+
     if save:
         P.modelm.collect_diff_mask_meta(save=save,dtype=save_dtype)
-           
+
     u.parallel.barrier()
     return P
-    
+
 
 
 class SimScan(data.PtyScan):
@@ -97,62 +97,62 @@ class SimScan(data.PtyScan):
     Test Ptyscan class producing a romantic ptychographic dataset of a moon
     illuminating flowers.
     """
-    
+
     def __init__(self, pars = None,scan_pars=None,**kwargs):
 
         # Initialize parent class
         super(SimScan, self).__init__(pars, **kwargs)
-        
-       
+
+
         # we will use ptypy to figure out everything
         pp = u.Param()
-        
+
         # we don't want a server
         pp.interaction = None
-        
+
         # be as silent as possible
         pp.verbose_level = 2
-       
+
         # get scan parameters
         if scan_pars is None:
             pp.model = scan_DEFAULT.copy()
         else:
             pp.model = scan_pars.copy()
-            
+
         # note that shape cannot be None
         if self.info.shape is None:
             self.info.shape = pp.model.geometry.shape
-        
+
         rinfo = DEFAULT.copy()
         rinfo.update(self.info.recipe)
         self.rinfo = rinfo
         self.info.recipe = rinfo
-        
+
         # update changes specified in recipe
         pp.model.update(rinfo)
 
         # Create a Scan that will deliver empty diffraction patterns
         # FIXME: This may be obsolete if the dry_run switch works.
-        
+
         pp.scans=u.Param()
         pp.scans.sim = u.Param()
         pp.scans.sim.data=u.Param()
         pp.scans.sim.data.source ='empty'
         pp.scans.sim.data.shape = pp.model.geometry.shape
         pp.scans.sim.data.auto_center = False
-        
+
         # Now we let Ptycho sort out things
         P=Ptycho(pp,level=2)
         P.modelm.new_data()
-        
+
         u.parallel.barrier()
-        
+
         #############################################################
         # Place here additional manipulation on position and sample #
-        
+
         P = self.manipulate_ptycho(P)
-        #############################################################        
-        
+        #############################################################
+
         # Simulate diffraction signal
         for name,pod in P.pods.iteritems():
             if not pod.active: continue
@@ -166,17 +166,17 @@ class SimScan(data.PtyScan):
         else:
             save_dtype = None
             acquire = lambda x: x
-                    
+
         # create dictionaries for 'raw' data
         self.diff = {}
         self.mask = {}
         self.pos = {}
-        
-        
+
+
         ID,Sdiff = P.diff.S.items()[0]
         for view in Sdiff.views:
             ind = view.layer
-            dat, mask = acquire(view.data) 
+            dat, mask = acquire(view.data)
             view.data = dat
             view.mask = mask
             pos = view.pod.ob_view.physcoord
@@ -186,23 +186,23 @@ class SimScan(data.PtyScan):
             self.pos[ind] = pos
 
         self.P=P
-        
+
         # Create 'raw' ressource buffers. We will let the master node keep them
         # as memary may be short (Not that this is the most efficient type)
         self.diff = u.parallel.gather_dict(self.diff)
         self.mask = u.parallel.gather_dict(self.mask)
         self.pos = u.parallel.gather_dict(self.pos)
-        
+
         # we have to avoid loading in parallel now
         self.load_in_parallel = False
-        
+
         # Fix the number of available frames
         self.num_frames = np.min(len(self.diff),self.num_frames)
-        
+
         # RESET THE loadmanager
         u.parallel.loadmanager.reset()
-        
-    
+
+
     def load(self,indices):
         """
         Load data, weights and positions from internal dictionarys
@@ -215,21 +215,21 @@ class SimScan(data.PtyScan):
             pos[ind] = self.pos[ind]
             weight[ind] = self.mask[ind]
         return raw, pos, weight
-      
+
     def manipulate_ptycho(self, ptycho):
         """
-        Overwrite in child class for inline manipulation 
+        Overwrite in child class for inline manipulation
         of the ptycho instance that is created by the Simulation
         """
         ptycho.print_stats()
-        
+
         return ptycho
-    
+
 if __name__ == "__main__":
     s = scan_DEFAULT.copy()
     s.xy.scan_type = "round_roi"                # (25) None,'round', 'raster', 'round_roi','custom'
     s.xy.dr = 1e-6                             # (26) round,round_roi :width of shell
-    s.xy.nr = 10                                # (27) round : number of intervals (# of shells - 1) 
+    s.xy.nr = 10                                # (27) round : number of intervals (# of shells - 1)
     s.xy.lx = 5e-6                            # (29) round_roi: Width of ROI
     s.xy.ly = 5e-6                            # (30) round_roi: Height of ROI
     shape = 256

--- a/ptypy/simulations/ptysim_utils.py
+++ b/ptypy/simulations/ptysim_utils.py
@@ -29,14 +29,14 @@ def exp_positions(positions, drift=0.0,scale= 0.0,noise=0.0):
     offset = augment_to_coordlist(drift,len(pos))
     scale = augment_to_coordlist(scale,len(pos))
     point_distance = u.norm(pos[1]-pos[0])
-    
+
     if noise is not None:
         pos += offset + scale*np.random.normal(0,noise*point_distance,pos.shape)
-    else: 
+    else:
         pos += np.zeros(pos.shape)
-                
+
     return pos
-    
+
 def make_sim_datasource(model_inst,drift=0.0,scale= 0.0,noise=0.0):
 
     labels=[]
@@ -56,35 +56,35 @@ def make_sim_datasource(model_inst,drift=0.0,scale= 0.0,noise=0.0):
         N = u.expect2(scan.pars.geometry.N)
         scan_info.shape = (len(pos),np.int(N[0]),np.int(N[1]))
         scan_info.scan_label = label
-        scan_info.data_filename = source 
-        
+        scan_info.data_filename = source
+
         pars.append(scan_info)
 
     return data.StaticDataSource(sources,pars,labels)
-    
 
-    
+
+
 def framepositions(pos_pixel,probe_shape,frame_overhead=(10,10)):
     pos_pixel -= pos_pixel.min(axis=0)
     pos_pixel = np.round(pos_pixel)
     shape = pos_pixel.max(axis=0)+w.expect2(probe_shape)+w.expect2(frame_overhead)
     pos_pixel += np.round(w.expect2(frame_overhead) /2)
     positions = [(p[0],p[0]+probe_shape[0],p[1],p[1]+probe_shape[1]) for p in pos_pixel]
-    
+
     return shape,positions
- 
-    
+
+
 def augment_to_coordlist(a,Npos):
     if np.isscalar(a):
         a=u.expect2(a)
-        
+
     a = np.asarray(a)
     if a.size % 2 == 0:
         a=a.reshape(a.size//2,2)
-    
+
     if a.shape[0] < Npos:
         b=np.concatenate((1+Npos//a.shape[0])*[a],axis=0)
     else:
         b=a
-    
+
     return b[:Npos,:2]

--- a/ptypy/test/core_tests/__init__.py
+++ b/ptypy/test/core_tests/__init__.py
@@ -1,4 +1,4 @@
 '''
-This section provides some really basic tests of the underlying classes and parameters used in the code. 
+This section provides some really basic tests of the underlying classes and parameters used in the code.
 Things like instanciating classes and geometry tests for the propagators. Checks we don't slip up anywhere.
 '''

--- a/ptypy/test/core_tests/base_test.py
+++ b/ptypy/test/core_tests/base_test.py
@@ -9,6 +9,6 @@ from ptypy.core import Base
 class BaseTest(unittest.TestCase):
     def test_base(self):
         a = Base()
-        
+
 if __name__ == '__main__':
     unittest.main()

--- a/ptypy/test/core_tests/container_test.py
+++ b/ptypy/test/core_tests/container_test.py
@@ -9,6 +9,6 @@ from ptypy.core import Container
 class ContainerTest(unittest.TestCase):
     def test_container(self):
         a = Container()
-        
+
 if __name__ == '__main__':
     unittest.main()

--- a/ptypy/test/core_tests/core_test.py
+++ b/ptypy/test/core_tests/core_test.py
@@ -1,7 +1,7 @@
 '''
 A test for the Base
 '''
- 
+
 import unittest
 import numpy as np
 import ptypy
@@ -9,7 +9,7 @@ from ptypy import utils as u
 from ptypy.core import View, Container, Storage, Base
 from ptypy.core.classes import DEFAULT_ACCESSRULE
 
- 
+
 class CoreTest(unittest.TestCase):
     C1 = Container(data_type='real')
     S1 = C1.new_storage(shape=(1, 7, 7))
@@ -32,27 +32,27 @@ class CoreTest(unittest.TestCase):
     mn = S1[V1].mean()
     S1.fill_value = mn
     S1.reformat()
-     
+
     ar2 = ar.copy()
     ar2.coord = (-0.82, -0.82)
     V2 = View(C1, ID=None, accessrule=ar2)
     S1.fill_value = 0.
     S1.reformat()
-     
+
     for i in range(1, 11):
         ar2 = ar.copy()
         ar2.coord = (-0.82+i*0.1, -0.82+i*0.1)
         View(C1, ID=None, accessrule=ar2)
-     
+
     S1.data[:] = S1.get_view_coverage()
-     
+
     ar = DEFAULT_ACCESSRULE.copy()
     ar.shape = 200
     ar.coord = 0.
     ar.storageID = 'S100'
     ar.psize = 1.0
     V3=View(C1, ID=None, accessrule=ar)
- 
- 
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/ptypy/test/core_tests/geometry_test.py
+++ b/ptypy/test/core_tests/geometry_test.py
@@ -49,11 +49,11 @@ class GeometryTest(unittest.TestCase):
 
     def test_geometry_near_field_init(self):
         G = self.set_up_nearfield()
-        
+
     def test_geometry_nearfield_resolution(self):
         G = self.set_up_nearfield()
         assert (np.round(G.resolution*1e7) == [1.00, 1.00]).all(), "geometry resolution incorrect for the nearfield"
-        
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/ptypy/test/core_tests/pod_test.py
+++ b/ptypy/test/core_tests/pod_test.py
@@ -1,7 +1,7 @@
 # '''
 # A test for the Base
 # '''
-# 
+#
 # import unittest
 # import numpy as np
 # import ptypy
@@ -13,7 +13,7 @@
 # ar.coord = 0.      # ar.coord = (0.,0.) would have been accepted, too.
 # ar.storageID = S1.ID
 # ar.psize = None
-# 
+#
 # class PodTest(unittest.TestCase):
 # # C1 = Container(data_type='real')
 # S1 = C1.new_storage(shape=(1, 7, 7))
@@ -31,32 +31,32 @@
 # mn = S1[V1].mean()
 # S1.fill_value = mn
 # S1.reformat()
-# 
+#
 # ar2 = ar.copy()
 # ar2.coord = (-0.82, -0.82)
 # V2 = View(C1, ID=None, accessrule=ar2)
 # S1.fill_value = 0.
 # S1.reformat()
-# 
+#
 # >>> for i in range(1, 11):
 # >>>     ar2 = ar.copy()
 # >>>     ar2.coord = (-0.82+i*0.1, -0.82+i*0.1)
 # >>>     View(C1, ID=None, accessrule=ar2)
-# 
+#
 # >>> S1.data[:] = S1.get_view_coverage()
-# 
+#
 # >>> ar = DEFAULT_ACCESSRULE.copy()
 # >>> ar.shape = 200
 # >>> ar.coord = 0.
 # >>> ar.storageID = 'S100'
 # >>> ar.psize = 1.0
 # >>> V3=View(C1, ID=None, accessrule=ar)
-# 
-# 
-# 
-# 
+#
+#
+#
+#
 # V2.data = V1.data.copy()
-# 
-# 
+#
+#
 # if __name__ == '__main__':
 #     unittest.main()

--- a/ptypy/test/core_tests/probe_test.py
+++ b/ptypy/test/core_tests/probe_test.py
@@ -59,5 +59,5 @@ class ProbeTest(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-    
-    
+
+

--- a/ptypy/test/core_tests/storage_test.py
+++ b/ptypy/test/core_tests/storage_test.py
@@ -10,6 +10,6 @@ class StorageTest(unittest.TestCase):
     def test_storage(self):
         cont = Container()
         a = Storage(cont)
-        
+
 if __name__ == '__main__':
     unittest.main()

--- a/ptypy/test/core_tests/view_test.py
+++ b/ptypy/test/core_tests/view_test.py
@@ -10,6 +10,6 @@ class ViewTest(unittest.TestCase):
     def test_storage(self):
         cont = Container()
         a = View(cont)
-        
+
 if __name__ == '__main__':
     unittest.main()

--- a/ptypy/test/engine_tests/DM_simple_test.py
+++ b/ptypy/test/engine_tests/DM_simple_test.py
@@ -7,7 +7,7 @@ This file is part of the PTYPY package.
 """
 
 import unittest
-from ptypy.test import test_utils as tu 
+from ptypy.test import test_utils as tu
 from ptypy import utils as u
 
 

--- a/ptypy/test/engine_tests/DM_test.py
+++ b/ptypy/test/engine_tests/DM_test.py
@@ -7,7 +7,7 @@ This file is part of the PTYPY package.
 """
 
 import unittest
-from ptypy.test import test_utils as tu 
+from ptypy.test import test_utils as tu
 from ptypy import utils as u
 
 class DMTest(unittest.TestCase):

--- a/ptypy/test/engine_tests/ML_new_test.py
+++ b/ptypy/test/engine_tests/ML_new_test.py
@@ -7,7 +7,7 @@ This file is part of the PTYPY package.
 """
 
 import unittest
-from ptypy.test import test_utils as tu 
+from ptypy.test import test_utils as tu
 from ptypy import utils as u
 
 class MLNewTest(unittest.TestCase):
@@ -24,7 +24,7 @@ class MLNewTest(unittest.TestCase):
         engine_params.scale_precond = False
         engine_params.scale_probe_object = 1.
         tu.EngineTestRunner(engine_params)
-    
+
     @unittest.skip('skip this because it is not supported')
     def test_ML_nearfield(self):
         engine_params = u.Param()
@@ -37,7 +37,7 @@ class MLNewTest(unittest.TestCase):
         engine_params.smooth_gradient = 0
         engine_params.scale_precond = False
         engine_params.scale_probe_object = 1.
-        
+
         tu.EngineTestRunner(engine_params,propagator='nearfield')
 
 if __name__ == "__main__":

--- a/ptypy/test/engine_tests/ML_test.py
+++ b/ptypy/test/engine_tests/ML_test.py
@@ -7,7 +7,7 @@ This file is part of the PTYPY package.
 """
 
 import unittest
-from ptypy.test import test_utils as tu 
+from ptypy.test import test_utils as tu
 from ptypy import utils as u
 
 class MLTest(unittest.TestCase):
@@ -25,7 +25,7 @@ class MLTest(unittest.TestCase):
         engine_params.probe_update_start = 0
         tu.EngineTestRunner(engine_params)
 
-        
+
     def test_ML_nearfield(self):
         engine_params = u.Param()
         engine_params.name = 'ML'
@@ -38,7 +38,7 @@ class MLTest(unittest.TestCase):
         engine_params.smooth_gradient = 0.0
         engine_params.scale_precond =False
         engine_params.probe_update_start = 0
-        
+
         tu.EngineTestRunner(engine_params,propagator='nearfield')
 
 if __name__ == "__main__":

--- a/ptypy/test/engine_tests/dummy_test.py
+++ b/ptypy/test/engine_tests/dummy_test.py
@@ -7,7 +7,7 @@ This file is part of the PTYPY package.
 """
 
 import unittest
-from ptypy.test import test_utils as tu 
+from ptypy.test import test_utils as tu
 from ptypy import utils as u
 
 class DummyTest(unittest.TestCase):

--- a/ptypy/test/engine_tests/engine_tests/DM_simple_test.py
+++ b/ptypy/test/engine_tests/engine_tests/DM_simple_test.py
@@ -7,7 +7,7 @@ This file is part of the PTYPY package.
 """
 
 import unittest
-from ptypy.test import test_utils as tu 
+from ptypy.test import test_utils as tu
 from ptypy import utils as u
 
 

--- a/ptypy/test/engine_tests/engine_tests/DM_test.py
+++ b/ptypy/test/engine_tests/engine_tests/DM_test.py
@@ -7,7 +7,7 @@ This file is part of the PTYPY package.
 """
 
 import unittest
-from ptypy.test import test_utils as tu 
+from ptypy.test import test_utils as tu
 from ptypy import utils as u
 
 class DMTest(unittest.TestCase):
@@ -24,7 +24,7 @@ class DMTest(unittest.TestCase):
         engine_params.fourier_relax_factor = 0.01
         engine_params.obj_smooth_std = 20
         tu.EngineTestRunner(engine_params)
-        
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ptypy/test/engine_tests/engine_tests/ML_old_test.py
+++ b/ptypy/test/engine_tests/engine_tests/ML_old_test.py
@@ -7,7 +7,7 @@ This file is part of the PTYPY package.
 """
 
 import unittest
-from ptypy.test import test_utils as tu 
+from ptypy.test import test_utils as tu
 from ptypy import utils as u
 
 class MLOldTest(unittest.TestCase):

--- a/ptypy/test/engine_tests/engine_tests/ML_test.py
+++ b/ptypy/test/engine_tests/engine_tests/ML_test.py
@@ -7,7 +7,7 @@ This file is part of the PTYPY package.
 """
 
 import unittest
-from ptypy.test import test_utils as tu 
+from ptypy.test import test_utils as tu
 from ptypy import utils as u
 
 class MLTest(unittest.TestCase):

--- a/ptypy/test/engine_tests/engine_tests/dummy_test.py
+++ b/ptypy/test/engine_tests/engine_tests/dummy_test.py
@@ -7,7 +7,7 @@ This file is part of the PTYPY package.
 """
 
 import unittest
-from ptypy.test import test_utils as tu 
+from ptypy.test import test_utils as tu
 from ptypy import utils as u
 
 class DummyTest(unittest.TestCase):

--- a/ptypy/test/ptyscan_tests/dls_test.py
+++ b/ptypy/test/ptyscan_tests/dls_test.py
@@ -7,7 +7,7 @@ This file is part of the PTYPY package.
 """
 
 import unittest
-from ptypy.test import test_utils as tu 
+from ptypy.test import test_utils as tu
 from ptypy.experiment.DLS import DlsScan
 from ptypy import utils as u
 
@@ -16,10 +16,10 @@ class DlsTest(unittest.TestCase):
     @unittest.skip("this won't work unless we figure out how to treat the data")
     def test_dls(self):
         r = u.Param()
-        r.experimentID = None 
-        r.scan_number = 68862 
+        r.experimentID = None
+        r.scan_number = 68862
         r.energy = None
-        r.z = None 
+        r.z = None
         r.detector_name = 'merlin_sw_hdf'
         r.base_path = tu.get_test_data_path('dls')
         r.mask_file = '%s/processing/mask2.hdf' % r.base_path

--- a/ptypy/test/ptyscan_tests/i08_test.py
+++ b/ptypy/test/ptyscan_tests/i08_test.py
@@ -7,7 +7,7 @@ This file is part of the PTYPY package.
 """
 
 import unittest
-from ptypy.test import test_utils as tu 
+from ptypy.test import test_utils as tu
 from ptypy.experiment.I08 import I08Scan
 from ptypy import utils as u
 
@@ -22,7 +22,7 @@ class I08Test(unittest.TestCase):
         r.dark_number = '2536'
         r.dark_number_stxm = '011'
         r.detector_flat_file = "%s/processing/flat2_xflipped.h5" % r.base_path
-        r.date = '2016-03-04' 
+        r.date = '2016-03-04'
         tu.PtyscanTestRunner(I08Scan,r)
 
 if __name__ == "__main__":

--- a/ptypy/test/ptyscan_tests/minimal_load_and_run_test.py
+++ b/ptypy/test/ptyscan_tests/minimal_load_and_run_test.py
@@ -1,74 +1,74 @@
 """
-This script is a test for ptychographic reconstruction after an 
+This script is a test for ptychographic reconstruction after an
 experiment has been carried out and the data is available in ptypy's
 data file format in "/tmp/ptypy/sample.ptyd"
 """
 import ptypy
 from ptypy.core import Ptycho
 from ptypy import utils as u
-from ptypy.test import test_utils as tu 
+from ptypy.test import test_utils as tu
 import unittest
 import tempfile
 
 class MinimalLoadAndRunTest(unittest.TestCase):
-    @unittest.skip("this won't work unless we figure out how to treat the data")    
+    @unittest.skip("this won't work unless we figure out how to treat the data")
     def test_load_and_run(self):
         p = u.Param()
         p.verbose_level = 3
         p.io = u.Param()
         p.io.home = tempfile.mkdtemp()
         p.autosave = None
-        
+
         p.scans = u.Param()
         p.scans.MF = u.Param()
         p.scans.MF.data= u.Param()
         p.scans.MF.data.source = 'file'
         p.scans.MF.data.dfile = tu.get_test_data_path('ptyd')+'test.ptyd'#'sample.ptyd'
-        
+
         p.engine = u.Param()
-        
+
         ## Common defaults for all engines
         p.engine.common = u.Param()
         # Total number of iterations
         p.engine.common.numiter = 5
         # Number of iterations to be executed in one go
-        p.engine.common.numiter_contiguous = 1           
+        p.engine.common.numiter_contiguous = 1
         # Fraction of valid probe area (circular) in probe frame
-        p.engine.common.probe_support = None  
+        p.engine.common.probe_support = None
         # Number of iterations before probe update starts
         p.engine.common.probe_update_start = 2
         # Clip object amplitude into this intrervall
         p.engine.common.clip_object = None   # [0,1]
-        
+
         ## DM default parameters
         p.engine.DM = u.Param()
-        p.engine.DM.name = "DM"   
+        p.engine.DM.name = "DM"
         # HIO parameter
-        p.engine.DM.alpha = 1                            
+        p.engine.DM.alpha = 1
         # Probe fraction kept from iteration to iteration
-        p.engine.DM.probe_inertia = 0.01             
+        p.engine.DM.probe_inertia = 0.01
         # Object fraction kept from iteration to iteration
-        p.engine.DM.object_inertia = 0.1             
+        p.engine.DM.object_inertia = 0.1
         # If False: update object before probe
-        p.engine.DM.update_object_first = True     
+        p.engine.DM.update_object_first = True
         # Gaussian smoothing (FWHM, pixel units) of object
         p.engine.DM.obj_smooth_std = 10
         # Loop the overlap constraint until probe changes lesser than this fraction
-        p.engine.DM.overlap_converge_factor = 0.5  
+        p.engine.DM.overlap_converge_factor = 0.5
         # Maximum iterations to be spent inoverlap constraint
-        p.engine.DM.overlap_max_iterations = 100  
-        # If rms of model vs diffraction data is smaller than this fraction, 
+        p.engine.DM.overlap_max_iterations = 100
+        # If rms of model vs diffraction data is smaller than this fraction,
         # Fourier constraint is considered fullfilled
-        p.engine.DM.fourier_relax_factor = 0.05    
-        
-        p.engines = u.Param()              
+        p.engine.DM.fourier_relax_factor = 0.05
+
+        p.engines = u.Param()
         p.engines.engine00 = u.Param()
         p.engines.engine00.name = 'DM'
         p.engines.engine00.numiter = 2
         p.engines.engine01 = u.Param()
         p.engines.engine01.name = 'ML'
         p.engines.engine01.numiter = 3
-        
+
         P = Ptycho(p,level=5)
 
 

--- a/ptypy/test/ptyscan_tests/on_the_fly_ptyd_test.py
+++ b/ptypy/test/ptyscan_tests/on_the_fly_ptyd_test.py
@@ -31,76 +31,76 @@ class MakeSamplePtydTest(unittest.TestCase):
         rebin = None,
         orientation = None,
     )
-    
+
     def setUp(self):
         # for verbose output
         u.verbose.set_level(3)
-        
+
         data = self.DATA.copy()
         data.save = 'link'
-        
+
         # This scan prepares the data and fills a '.ptyd' container
         if u.parallel.master:
             self.S1 = ptypy.core.data.MoonFlowerScan(data)
             self.S1.initialize()
         else:
             self.S1 = None
-            
+
         # wait until master process complete
         u.parallel.barrier()
-        
+
     def tearDown(self):
         import os
-        for entry in os.listdir(TEMPDIR): 
+        for entry in os.listdir(TEMPDIR):
             os.remove(TEMPDIR + '/' + entry)
         os.rmdir(TEMPDIR)
-        
+
     def _create_PtydScan(self, save = 'append', **kwargs):
-        # the second process will aggregate the linked container to a 
-        # a new .ptyd file holding all data. 
+        # the second process will aggregate the linked container to a
+        # a new .ptyd file holding all data.
         # This may be done in parallel
         data = self.DATA.copy()
         dfile = str(data.dfile)
-        
+
         # Base parameters
         from ptypy.core.data import GENERIC
         data = GENERIC.copy()
         data.dfile = dfile.replace('.ptyd','_aggregated.ptyd')
         data.save = save # maybe replace with merge in future
         data.update(**kwargs)
-        
+
         return ptypy.core.data.PtydScan(data, source = dfile)
-        
+
     def test_non_exisiting_chunk(self):
         try:
             S2 = self._create_PtydScan(save = None)
         except IOError:
             # expected behavior is an IOError if *.ptyd contains no data.
             pass
-    
+
     def test_incomplete_scan(self):
         if u.parallel.master: msg = self.S1.auto(30)
         u.parallel.barrier()
-        
+
         S2 = self._create_PtydScan(save = None)
         S2.initialize()
         msg2 = S2.auto(10)
-        self.assertEqual(10,len(msg2['iterable']), 
+        self.assertEqual(10,len(msg2['iterable']),
             'There should be 10 frames available in Source ptyd')
-            
+
         msg3 = S2.auto(30)
-        self.assertEqual(20,len(msg3['iterable']), 
+        self.assertEqual(20,len(msg3['iterable']),
             'There should be 20 frames available in Source ptyd')
-            
+
         msg4 = S2.auto(30)
         #print(u.verbose.report(msg4))
         from ptypy.core.data import WAIT
-        self.assertEqual(msg4, WAIT, 
+        self.assertEqual(msg4, WAIT,
             "Last auto call should return 'wait' flag (data.WAIT) "
             "but it returned %s." % str(msg4))
-            
+
     def test_completed_scan(self):
-        if u.parallel.master: 
+        if u.parallel.master:
             msgs =[
                 # 30 frames
                 self.S1.auto(30, chunk_form='dp'),
@@ -113,9 +113,9 @@ class MakeSamplePtydTest(unittest.TestCase):
         S2 = self._create_PtydScan(save = 'append')
         S2.initialize()
         msg = S2.auto(100)
-        self.assertEqual(50,len(msg['iterable']), 
+        self.assertEqual(50,len(msg['iterable']),
             'There should be 20 frames available in Source ptyd')
-        
+
     def test_check(self):
         if u.parallel.master: msg = self.S1.auto(30)
         u.parallel.barrier()
@@ -124,7 +124,7 @@ class MakeSamplePtydTest(unittest.TestCase):
         print(S2.num_frames)
         print(S2.info.num_frames)
         print(S2.check(40))
-    
+
 
 
 if __name__ == '__main__':

--- a/ptypy/test/ptyscan_tests/ptyscan_test.py
+++ b/ptypy/test/ptyscan_tests/ptyscan_test.py
@@ -6,7 +6,7 @@ test Scan `ptypy.core.data.MoonFlowerScan`
 from ptypy import utils as u
 from ptypy import io
 from ptypy.core.data import MoonFlowerScan
-from ptypy.test import test_utils as tu 
+from ptypy.test import test_utils as tu
 import unittest
 global DATA
 DATA = u.Param(
@@ -33,50 +33,50 @@ class PtyscanTest(unittest.TestCase):
         check it runs with multiple calls to auto
         '''
         tu.PtyscanTestRunner(MoonFlowerScan, data=DATA, auto_frames=30, ncalls=3)
-    
+
     def test_moonflower_with_three_calls_REGRESSION(self):
         '''
         Same as above, but makes sure the output is sensible
         '''
         out = tu.PtyscanTestRunner(MoonFlowerScan, data=DATA, auto_frames=30, ncalls=3)
-        
-        self.assertEqual(30,len(out['msgs'][0]['iterable']), 
+
+        self.assertEqual(30,len(out['msgs'][0]['iterable']),
             "Scan did not prepare 30 frames as expected")
-            
-        self.assertEqual(20,len(out['msgs'][1]['iterable']), 
+
+        self.assertEqual(20,len(out['msgs'][1]['iterable']),
             "Scan did not prepare 20 frames as expected")
-            
+
         from ptypy.core.data import EOS
-        self.assertEqual(out['msgs'][2], EOS, 
+        self.assertEqual(out['msgs'][2], EOS,
             "Last auto call not identified as End of Scan (data.EOS)")
-    
+
     def test_appended_ptyd(self):
         '''
         technically all of these tests do this, but this is explicit
         '''
         tu.PtyscanTestRunner(MoonFlowerScan,data=DATA, save_type='append')
-        
+
     def test_appended_ptyd_REGRESSION(self):
         '''
         check that we can actually read the result!
         '''
         out = tu.PtyscanTestRunner(MoonFlowerScan,data=DATA, save_type='append', cleanup=False)
         d = io.h5read(out['output_file'])
-        
+
     def test_linked_ptyd(self):
         '''
         test the linking mechanism works
         '''
         tu.PtyscanTestRunner(MoonFlowerScan,data=DATA, save_type='link', cleanup=False)
-    
+
     def test_linked_ptyd_REGRESSION(self):
         '''
         again, can we read it?
         '''
         out = tu.PtyscanTestRunner(MoonFlowerScan,data=DATA, save_type='link', cleanup=False)
         d = io.h5read(out['output_file'])
-    
-    
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/ptypy/test/ptyscan_tests/savu_test.py
+++ b/ptypy/test/ptyscan_tests/savu_test.py
@@ -7,7 +7,7 @@ This file is part of the PTYPY package.
 """
 
 import unittest
-from ptypy.test import test_utils as tu 
+from ptypy.test import test_utils as tu
 from ptypy.experiment.savu import Savu
 from ptypy import utils as u
 import h5py as h5

--- a/ptypy/test/template_tests/ptypy_cSAXS_PseudoBone_6p2keV_test.py
+++ b/ptypy/test/template_tests/ptypy_cSAXS_PseudoBone_6p2keV_test.py
@@ -9,49 +9,49 @@ class PtypycSAXSPseudoBone6p2keVTest(unittest.TestCase):
 #     @unittest.skip('There seems to be a leak of variables between this one and the i13 one')
     def test_csaxs(self):
         p = u.Param()
-        p.verbose_level = 3                  
-        p.data_type = "single"                            
+        p.verbose_level = 3
+        p.data_type = "single"
         p.run = None
         p.io = u.Param()
-        p.io.home = tempfile.mkdtemp()             
+        p.io.home = tempfile.mkdtemp()
         p.io.run = None
         p.io.autosave = None
         p.io.autoplot = False
-        
+
         p.scan = u.Param()
         p.scan.geometry = u.Param()
-        p.scan.geometry.energy = 6.2        
-        p.scan.geometry.lam = None    
-        p.scan.geometry.distance = 7    
-        p.scan.geometry.psize = 172e-6       
-        p.scan.geometry.shape = 256          
-        p.scan.geometry.propagation = "farfield"     
-        
+        p.scan.geometry.energy = 6.2
+        p.scan.geometry.lam = None
+        p.scan.geometry.distance = 7
+        p.scan.geometry.psize = 172e-6
+        p.scan.geometry.shape = 256
+        p.scan.geometry.propagation = "farfield"
+
         p.scan.illumination = u.Param()
         p.scan.illumination.model = None
-        p.scan.illumination.aperture = u.Param() 
-        p.scan.illumination.propagation = None 
-        p.scan.illumination.diversity = None 
-        
+        p.scan.illumination.aperture = u.Param()
+        p.scan.illumination.propagation = None
+        p.scan.illumination.diversity = None
+
         p.scan.sample = u.Param()
         p.scan.sample.model = 'stxm'
         p.scan.sample.process = None
         p.scan.sample.diversity = None
-        
+
         p.scan.coherence = u.Param()
-        p.scan.coherence.Nprobe_modes = 1               
-        p.scan.coherence.Nobject_modes = 1               
-        p.scan.coherence.energies = [1.0]                
+        p.scan.coherence.Nprobe_modes = 1
+        p.scan.coherence.Nobject_modes = 1
+        p.scan.coherence.energies = [1.0]
         sim = u.Param()
         sim.xy = u.Param()
-        sim.xy.model = "round"                
-        sim.xy.spacing = 1e-6                
-        sim.xy.steps = 10        
-        sim.xy.extent = 10e-6      
-        
+        sim.xy.model = "round"
+        sim.xy.spacing = 1e-6
+        sim.xy.steps = 10
+        sim.xy.extent = 10e-6
+
         sim.illumination = u.Param()
         sim.illumination.model = None
-        sim.illumination.photons = 1e8       
+        sim.illumination.photons = 1e8
         sim.illumination.aperture = u.Param()
         sim.illumination.aperture.diffuser = None
         sim.illumination.aperture.form = "circ"
@@ -59,63 +59,63 @@ class PtypycSAXSPseudoBone6p2keVTest(unittest.TestCase):
         sim.illumination.aperture.edge = 1
         sim.illumination.aperture.central_stop = None
         sim.illumination.propagation = u.Param()
-        sim.illumination.propagation.focussed = None 
+        sim.illumination.propagation.focussed = None
         sim.illumination.propagation.parallel = 0.004
         sim.illumination.propagation.spot_size = None
-        
+
         sim.sample = u.Param()
-        sim.sample.model = tree_obj()        
+        sim.sample.model = tree_obj()
         sim.sample.process = u.Param()
-        sim.sample.process.offset = (100,400)                    
-        sim.sample.process.zoom = 1.0                         
-        sim.sample.process.formula = "Ca"                     
-        sim.sample.process.density = 1.5                     
-        sim.sample.process.thickness = 20e-6  
-        sim.sample.process.ref_index = None 
-        sim.sample.process.smoothing = None  
-        sim.sample.fill = 1.0+0.j 
-        
+        sim.sample.process.offset = (100,400)
+        sim.sample.process.zoom = 1.0
+        sim.sample.process.formula = "Ca"
+        sim.sample.process.density = 1.5
+        sim.sample.process.thickness = 20e-6
+        sim.sample.process.ref_index = None
+        sim.sample.process.smoothing = None
+        sim.sample.fill = 1.0+0.j
+
         sim.verbose_level = 1
         sim.plot = False
-        
+
         p.scans = u.Param()
         p.scans.CircSim = u.Param()
         p.scans.CircSim.data=u.Param()
-        p.scans.CircSim.data.source = 'sim' 
+        p.scans.CircSim.data.source = 'sim'
         p.scans.CircSim.data.recipe = sim.copy(depth=4)
         p.scans.CircSim.data.recipe.illumination.aperture.form = "circ"
         p.scans.CircSim.data.save = None
-        
+
         p.scans.RectSim = u.Param()
         p.scans.RectSim.sharing = u.Param()
         p.scans.RectSim.sharing.object_share_with = 'CircSim'
         p.scans.RectSim.data=u.Param()
-        p.scans.RectSim.data.source = 'sim' 
+        p.scans.RectSim.data.source = 'sim'
         p.scans.RectSim.data.recipe = sim.copy(depth=4)
         p.scans.RectSim.data.recipe.illumination.aperture.form = "rect"
         p.scans.RectSim.data.save = None
-        
-        
+
+
         p.engine = u.Param()
         p.engine.common = u.Param()
-        p.engine.common.numiter = 1     
-        p.engine.common.numiter_contiguous = 1  
-        p.engine.common.probe_support = 0.7        
-        p.engine.common.probe_inertia = 0.01   
-        p.engine.common.object_inertia = 0.1     
-        p.engine.common.obj_smooth_std = 20   
-        p.engine.common.clip_object = None    
-        p.engine.common.probe_update_start = 2        
-        
+        p.engine.common.numiter = 1
+        p.engine.common.numiter_contiguous = 1
+        p.engine.common.probe_support = 0.7
+        p.engine.common.probe_inertia = 0.01
+        p.engine.common.object_inertia = 0.1
+        p.engine.common.obj_smooth_std = 20
+        p.engine.common.clip_object = None
+        p.engine.common.probe_update_start = 2
+
         p.engine.DM = u.Param()
-        p.engine.DM.name = "DM"                    
-        p.engine.DM.alpha = 1                       
-        p.engine.DM.update_object_first = True      
-        p.engine.DM.overlap_converge_factor = 0.05      
-        p.engine.DM.overlap_max_iterations = 100    
-        p.engine.DM.fourier_relax_factor = 0.1   
-        
-        p.engines = u.Param()                        
+        p.engine.DM.name = "DM"
+        p.engine.DM.alpha = 1
+        p.engine.DM.update_object_first = True
+        p.engine.DM.overlap_converge_factor = 0.05
+        p.engine.DM.overlap_max_iterations = 100
+        p.engine.DM.fourier_relax_factor = 0.1
+
+        p.engines = u.Param()
         p.engines.engine00 = u.Param()
         p.engines.engine00.name = 'DM'
         p.engines.engine00.numiter = 1
@@ -124,6 +124,6 @@ class PtypycSAXSPseudoBone6p2keVTest(unittest.TestCase):
         p.engines.engine01.name = 'ML'
         p.engines.engine01.numiter = 1
         P = Ptycho(p,level=5)
-        
+
 if __name__ == '__main__':
     unittest.main()

--- a/ptypy/test/template_tests/ptypy_i13_AuStar_nearfield_9p7keV_test.py
+++ b/ptypy/test/template_tests/ptypy_i13_AuStar_nearfield_9p7keV_test.py
@@ -1,6 +1,6 @@
 from ptypy.core import Ptycho
 from ptypy import utils as u
-from ptypy.test import test_utils as tu 
+from ptypy.test import test_utils as tu
 import tempfile
 import unittest
 
@@ -9,8 +9,8 @@ class PtypyI13AuStarNearfield9p7keVTest(unittest.TestCase):
     @unittest.skip('There seems to be a leak of variables between this one and the i13 one')
     def test_i13(self):
         p = u.Param()
-        p.verbose_level = 3   
-        p.data_type = "single"      
+        p.verbose_level = 3
+        p.data_type = "single"
         p.run = None
         p.io = u.Param()
         p.io.home = tempfile.mkdtemp()
@@ -18,48 +18,48 @@ class PtypyI13AuStarNearfield9p7keVTest(unittest.TestCase):
         p.io.autoplot =  u.Param()
         p.io.autoplot.layout ='nearfield'
         p.scan = u.Param()
-        p.scan.source = None           
+        p.scan.source = None
         p.scan.geometry = u.Param()
-        p.scan.geometry.energy = 9.7      
-        p.scan.geometry.lam = None      
-        p.scan.geometry.distance = 8.46e-2    
-        p.scan.geometry.psize = 100e-9         
-        p.scan.geometry.shape = 1024                    
-        p.scan.geometry.propagation = "nearfield"              
+        p.scan.geometry.energy = 9.7
+        p.scan.geometry.lam = None
+        p.scan.geometry.distance = 8.46e-2
+        p.scan.geometry.psize = 100e-9
+        p.scan.geometry.shape = 1024
+        p.scan.geometry.propagation = "nearfield"
         sim = u.Param()
         sim.xy = u.Param()
-        sim.xy.override = u.parallel.MPIrand_uniform(0.0,10e-6,(20,2))          
+        sim.xy.override = u.parallel.MPIrand_uniform(0.0,10e-6,(20,2))
         sim.verbose_level = 1
         sim.illumination = u.Param()
         sim.illumination.model = None
-        sim.illumination.photons = 1e11              
+        sim.illumination.photons = 1e11
         sim.illumination.aperture = u.Param()
         sim.illumination.aperture.diffuser = (8.0, 10.0)
         sim.illumination.aperture.form = "circ"
         sim.illumination.aperture.size = 90e-6
         sim.illumination.aperture.central_stop = 0.15
         sim.illumination.propagation = u.Param()
-        sim.illumination.propagation.focussed = None#0.08 
+        sim.illumination.propagation.focussed = None#0.08
         sim.illumination.propagation.parallel = 0.005
         sim.illumination.propagation.spot_size = None
         sim.sample = u.Param()
         sim.sample.model = u.xradia_star((1200,1200),minfeature=3,contrast=0.8)
         sim.sample.process = u.Param()
-        sim.sample.process.offset = (0,0)        
-        sim.sample.process.zoom = 1.0            
-        sim.sample.process.formula = "Au"              
-        sim.sample.process.density = 19.3                  
-        sim.sample.process.thickness = 700e-9       
-        sim.sample.process.ref_index = None           
-        sim.sample.process.smoothing = None            
-        sim.sample.fill = 1.0+0.j      
-        sim.detector = 'GenericCCD32bit' 
+        sim.sample.process.offset = (0,0)
+        sim.sample.process.zoom = 1.0
+        sim.sample.process.formula = "Au"
+        sim.sample.process.density = 19.3
+        sim.sample.process.thickness = 700e-9
+        sim.sample.process.ref_index = None
+        sim.sample.process.smoothing = None
+        sim.sample.fill = 1.0+0.j
+        sim.detector = 'GenericCCD32bit'
         sim.plot = False
         p.scan.update(sim.copy(depth=4))
         p.scan.coherence = u.Param()
-        p.scan.coherence.Nprobe_modes = 1     
-        p.scan.coherence.Nobject_modes = 1     
-        p.scan.coherence.energies = [1.0]     
+        p.scan.coherence.Nprobe_modes = 1
+        p.scan.coherence.Nobject_modes = 1
+        p.scan.coherence.energies = [1.0]
         p.scan.sample = u.Param()
         p.scan.xy = u.Param()
         p.scan.xy.model=None
@@ -67,35 +67,35 @@ class PtypyI13AuStarNearfield9p7keVTest(unittest.TestCase):
         p.scans = u.Param()
         p.scans.sim = u.Param()
         p.scans.sim.data=u.Param()
-        p.scans.sim.data.source = 'sim' 
-        p.scans.sim.data.recipe = sim.copy(depth=4) 
+        p.scans.sim.data.source = 'sim'
+        p.scans.sim.data.recipe = sim.copy(depth=4)
         p.scans.sim.data.save = None #'append'
         p.scans.sim.data.shape = None
         p.scans.sim.data.num_frames = None
         p.engine = u.Param()
         p.engine.common = u.Param()
-        p.engine.common.numiter = 1           
-        p.engine.common.numiter_contiguous = 1   
-        p.engine.common.probe_support = None          
-        p.engine.common.probe_inertia = 0.001        
-        p.engine.common.object_inertia = 0.1            
-        p.engine.common.obj_smooth_std = 10          
-        p.engine.common.clip_object = None            
+        p.engine.common.numiter = 1
+        p.engine.common.numiter_contiguous = 1
+        p.engine.common.probe_support = None
+        p.engine.common.probe_inertia = 0.001
+        p.engine.common.object_inertia = 0.1
+        p.engine.common.obj_smooth_std = 10
+        p.engine.common.clip_object = None
         p.engine.DM = u.Param()
-        p.engine.DM.name = "DM"                       
-        p.engine.DM.alpha = 1                        
-        p.engine.DM.probe_update_start = 2          
-        p.engine.DM.update_object_first = True       
-        p.engine.DM.overlap_converge_factor = 0.5    
-        p.engine.DM.overlap_max_iterations = 100       
-        p.engine.DM.fourier_relax_factor = 0.05   
+        p.engine.DM.name = "DM"
+        p.engine.DM.alpha = 1
+        p.engine.DM.probe_update_start = 2
+        p.engine.DM.update_object_first = True
+        p.engine.DM.overlap_converge_factor = 0.5
+        p.engine.DM.overlap_max_iterations = 100
+        p.engine.DM.fourier_relax_factor = 0.05
         p.engine.ML = u.Param()
-        p.engines = u.Param()                 
+        p.engines = u.Param()
         p.engines.engine00 = u.Param()
         p.engines.engine00.name = 'DM'
         p.engines.engine00.numiter = 1
         p.engines.engine00.object_inertia = 1.
-        p.engines.engine00.fourier_relax_factor = 0.1       
+        p.engines.engine00.fourier_relax_factor = 0.1
         P = Ptycho(p,level=5)
 
 if __name__ == '__main__':

--- a/ptypy/test/test_utils.py
+++ b/ptypy/test/test_utils.py
@@ -43,12 +43,12 @@ def PtyscanTestRunner(ptyscan_instance,r=u.Param(),data=u.Param(),save_type='app
         return out_dict
 
 def EngineTestRunner(engine_params,propagator='farfield'):
-    
+
     RECIPE = u.Param({'photons': 100000000.0,
                       'psf': 0.0,
                       'density': 0.2})
     p = u.Param()
-    p.verbose_level = 3                              
+    p.verbose_level = 3
     p.io = u.Param()
     p.io.home = './'
     p.io.rfile = False
@@ -66,15 +66,15 @@ def EngineTestRunner(engine_params,propagator='farfield'):
     p.scans.MF.data.precedence =  None
     p.scans.MF.data.num_frames =  100
     p.scans.MF.data.energy =  6.2
-    p.scans.MF.data.shape =  256 
+    p.scans.MF.data.shape =  256
     p.scans.MF.data.chunk_format = '.chunk%02d'
-    p.scans.MF.data.rebin =  None 
-    p.scans.MF.data.experimentID =  None 
-    p.scans.MF.data.label =  None 
-    p.scans.MF.data.version = 0.1 
-    p.scans.MF.data.dfile = None 
-    p.scans.MF.data.lam =  None 
-    p.scans.MF.data.psize =  0.000172 
+    p.scans.MF.data.rebin =  None
+    p.scans.MF.data.experimentID =  None
+    p.scans.MF.data.label =  None
+    p.scans.MF.data.version = 0.1
+    p.scans.MF.data.dfile = None
+    p.scans.MF.data.lam =  None
+    p.scans.MF.data.psize =  0.000172
     p.scans.MF.data.load_parallel =  None
     p.scans.MF.data.misfit =  0
     p.scans.MF.data.origin = 'fftshift'
@@ -84,7 +84,7 @@ def EngineTestRunner(engine_params,propagator='farfield'):
     p.scans.MF.data.propagation = propagator
     p.scans.MF.data.resolution =  None
     p.scans.MF.data.recipe =  RECIPE
-    p.engines = u.Param()                              
+    p.engines = u.Param()
     p.engines.engine00 = engine_params
     P = Ptycho(p,level=5)
     return P

--- a/ptypy/utils/__init__.py
+++ b/ptypy/utils/__init__.py
@@ -27,6 +27,6 @@ if hmpl:# and hpqt4:
 del hmpl
 # del hpqt4
 import validator
-    
+
 import parallel
 

--- a/ptypy/utils/array_utils.py
+++ b/ptypy/utils/array_utils.py
@@ -19,12 +19,12 @@ __all__ = ['grids','switch_orientation','mirror',\
 def switch_orientation(A, orientation, center=None):
     """
     Switches orientation of Array `A` along the last two axes `(-2,-1)`
-    
+
     Parameters
     ----------
     A :  array-like
         input array, must be at least twodimensional
-         
+
     orientation : tuple or int
         3-tuple of booleans (transpose,flipud,fliplr)
         if int: converted according to binary representation:
@@ -36,20 +36,20 @@ def switch_orientation(A, orientation, center=None):
             5: [True, False, True]
             6: [True, True, False]
             7: [True, True, True]
-    
+
     center : tuple, optional
         move this coordinate alomg with the transformations
-        
+
     Returns
     -------
     out : ndarray
         A view of `A` where either rows, columns and axis may be reversed
-    
+
     center : tuple
-        new center        
+        new center
     """
     o = 0 if orientation is None else orientation
-    
+
     if np.isscalar(o):
         o = [i=='1' for i in '%03d' % int(np.base_repr(o))]
 
@@ -68,24 +68,24 @@ def switch_orientation(A, orientation, center=None):
 
     if center is None:
         return A
-    else: 
+    else:
         return A, np.array(center)
 
 
 def rebin_2d(A, rebin=1):
     """
-    Rebins array `A` symmetrically along the last 2 axes 
+    Rebins array `A` symmetrically along the last 2 axes
     with factor `rebin`.
-    
+
     Parameters
     ----------
     A : array-like
         input array, must be at least two-dimensional.
-        
+
     rebin : int
         rebin factor, ``rebin=2`` means that a square of 4 pixels will be
-        binned into one. 
-        
+        binned into one.
+
     Returns
     -------
     out : ndarray
@@ -98,7 +98,7 @@ def rebin_2d(A, rebin=1):
     sh = np.asarray(A.shape[-2:])
     newdim = sh / rebin
     if not (sh % rebin == 0).all():
-        raise ValueError('Last two axes %s of input array `A` cannot be binned by %s' % (str(tuple(sh)),str(rebin))) 
+        raise ValueError('Last two axes %s of input array `A` cannot be binned by %s' % (str(tuple(sh)),str(rebin)))
     else:
         return A.reshape(-1, newdim[0], rebin, newdim[1], rebin).mean(-1).mean(-2)
 
@@ -107,32 +107,32 @@ def crop_pad_symmetric_2d(A, newshape, center=None):
     """
     Crops or pads Array `A` symmetrically along the last two axes `(-2,-1)`
     around center `center` to a new shape `newshape`.
-    
+
     Parameters
     ----------
     A : array-like
         Input array, must be at least two-dimensional.
-        
+
     newshape : tuple, array_like
         New shape (for the last two axes). Must have at least 2 entries.
-        
+
     center : tuple, array_like, optional
         This coordinate tuple marks the center for cropping / padding
         If None, ``np.array(A.shape[-2:]) // 2`` will be the center
-        
+
     Returns
     -------
     out : ndarray
         Cropped or padded array with shape ``A.shape[:-2]+newshape[-2:]``
-    
+
     center : tuple
         Center in returned array, should be in the actual center of array.
-        
+
     See also
     --------
     crop_pad_axis
     crop_pad
-    
+
     """
     osh = np.array(A.shape[-2:])
     c = np.round(center) if center is not None else osh // 2
@@ -150,30 +150,30 @@ def rebin(a, *args,**kwargs):
     """
     Rebin ndarray data into a smaller ndarray of the same rank whose dimensions
     are factors of the original dimensions.
-    
+
     .. note::
         eg. An array with 6 columns and 4 rows
         can be reduced to have 6,3,2 or 1 columns and 4,2 or 1 rows.
-    
+
     Parameters
     ----------
     a : ndarray
         Input array.
-        
+
     axis : int, Default=-1, optional
-        The laplacian is computed along the provided axis or list of axes, 
+        The laplacian is computed along the provided axis or list of axes,
         or all axes if None
-    
+
     Returns
     -------
     out : ndarray
         Rebined array.
-          
+
     Examples
     --------
     >>> import ptypy
     >>> import numpy as np
-    >>> a=np.random.rand(6,4) 
+    >>> a=np.random.rand(6,4)
     >>> b=ptypy.utils.rebin(a,3,2)
     a.reshape(args[0],factor[0],args[1],factor[1],).sum(1).sum(2)*( 1./factor[0]/factor[1])
     >>> a2=np.random.rand(6)
@@ -190,7 +190,7 @@ def rebin(a, *args,**kwargs):
     if kwargs.get('verbose',False):
         print ''.join(evList)
     return eval(''.join(evList))
-           
+
 def _confine(A):
     """\
     Doc TODO.
@@ -198,7 +198,7 @@ def _confine(A):
     sh=np.asarray(A.shape)[1:]
     A=A.astype(float)
     m=np.reshape(sh,(len(sh),) + len(sh)*(1,))
-    return (A+m//2.0) % m - m//2.0  
+    return (A+m//2.0) % m - m//2.0
 
 def _translate_to_pix(sh,center):
     """\
@@ -214,7 +214,7 @@ def _translate_to_pix(sh,center):
     elif center is not None:
         #cen=sh*np.asarray(center) % sh - 0.5
         cen = np.asarray(center) % sh
-        
+
     return cen
 """
 def center_2d(sh,center):
@@ -227,43 +227,43 @@ def grids(sh,psize=None,center='geometric',FFTlike=True):
 
     ``q0,q1,... = grids(sh,psize)``
     gives the coordinates scaled according to the given pixel size psize.
-    
+
     ``q0,q1,... = grids(sh,center='fftshift')``
     gives the coordinates shifted according to fftshift convention for the origin
-    
+
     ``q0,q1,... = grids(sh,psize,center=(c0,c1,c2,...))``
     gives the coordinates according scaled with psize having the origin at (c0,c1,..)
 
-    
+
     Parameters
     ----------
     sh : tuple of int
         The shape of the N-dimensional array
-    
+
     psize : float or tuple of float
         Pixel size in each dimensions
-    
+
     center : tupel of int
         Tuple of pixel, or use ``center='fftshift'`` for fftshift-like grid
         and ``center='geometric'`` for the matrix center as grid origin
-    
+
     FFTlike : bool
         If False, grids ar not bound by the interval [-sh//2:sh//2[
-    
+
     Returns
     -------
     ndarray
         The coordinate grids
     """
     sh=np.asarray(sh)
-    
+
     cen = _translate_to_pix(sh,center)
 
     grid=np.indices(sh).astype(float) - np.reshape(cen,(len(sh),) + len(sh)*(1,))
-        
+
     if FFTlike:
         grid=_confine(grid)
-        
+
     if psize is None:
         return grid
     else:
@@ -279,7 +279,7 @@ def zoom(c,*arg,**kwargs):
     zoom function or the original one. For parameters see :any:`c_zoom`.
     Use this function instead of the aforementioned to profit from a faster
     execution in case of float arrays.
-    
+
     See also
     --------
     c_zoom
@@ -298,29 +298,29 @@ c_affine_transform.__doc__='*complex input*\n\n'+c_affine_transform.__doc__
 def shift_zoom(c,zoom,cen_old,cen_new,**kwargs):
     """\
     Move array from center `cen_old` to `cen_new` and perform a zoom `zoom`.
-    
+
     This function wraps scipy.ndimage.affine_transfrom or the complex
-    overloaded version :any:`c_affine_transform`, which the user is 
+    overloaded version :any:`c_affine_transform`, which the user is
     refered to for keyword args.
-    
+
     Parameters
     ----------
     c : ndarray
         Array to shiftzoom. Can be float or complex
-    
+
     zoom : float
         Zoom factor
-    
+
     cen_old : array_like
         Center in input array `c`
-    
+
     cen_new : array_like
         Desired new center position in shiftzoomed array
-    
+
     See also
     --------
     c_affine_transform
-    
+
     Returns
     -------
     Shifted and zoomed array
@@ -338,7 +338,7 @@ def fill3D(A,B,offset=[0,0,0]):
     Fill 3-dimensional array A with B.
     """
     if A.ndim != 3 or B.ndim!=3:
-        raise ValueError('3D a numpy arrays expected')    
+        raise ValueError('3D a numpy arrays expected')
     Alim=np.array(A.shape)
     Blim=np.array(B.shape)
     off=np.array(offset)
@@ -352,73 +352,73 @@ def fill3D(A,B,offset=[0,0,0]):
         pass
     else:
         A[Ao[0]:min(off[0]+Blim[0],Alim[0]),Ao[1]:min(off[1]+Blim[1],Alim[1]),Ao[2]:min(off[2]+Blim[2],Alim[2])] \
-        =B[Bo[0]:min(Alim[0]-off[0],Blim[0]),Bo[1]:min(Alim[1]-off[1],Blim[1]),Bo[2]:min(Alim[2]-off[2],Blim[2])] 
-        
+        =B[Bo[0]:min(Alim[0]-off[0],Blim[0]),Bo[1]:min(Alim[1]-off[1],Blim[1]),Bo[2]:min(Alim[2]-off[2],Blim[2])]
+
 
 def mirror(A,axis=-1):
     """\
     Mirrors array `A` along one axis `axis`
-    
-    Parameters
-    ----------
-    A : array-like
-        Input array 
-    
-    axis: int, optional
-        Axis along which the array will be mirrored
-    
-    Returns
-    -------
-    array-like
-        A view to the mirrored array.
-    
-    """
-    return np.flipud(np.asarray(A).swapaxes(axis,0)).swapaxes(0,axis)
-    
-def pad_lr(A,axis,l,r,fillpar=0.0, filltype='scalar'):
-    """
-    Pads ndarray `A` orthogonal to `axis` with `l` layers 
-    (pixels,lines,planes,...) on low side an `r` layers on high side.
-    
+
     Parameters
     ----------
     A : array-like
         Input array
-    
+
+    axis: int, optional
+        Axis along which the array will be mirrored
+
+    Returns
+    -------
+    array-like
+        A view to the mirrored array.
+
+    """
+    return np.flipud(np.asarray(A).swapaxes(axis,0)).swapaxes(0,axis)
+
+def pad_lr(A,axis,l,r,fillpar=0.0, filltype='scalar'):
+    """
+    Pads ndarray `A` orthogonal to `axis` with `l` layers
+    (pixels,lines,planes,...) on low side an `r` layers on high side.
+
+    Parameters
+    ----------
+    A : array-like
+        Input array
+
     axis,l,r : int
         Pads orthogonal to `axis` on with `l` layers (pixels,lines,
         planes,...) on low side an `r` layers on high side.
-        
+
     fillpar : scalar
         Scalar fill parameter for ``filltype=scalar`` fill.
-        
+
     filltype : str
             - `'scalar'`, uniformly pad with fillpar
             - `'mirror'`, mirror `A`
             - `'periodic'`, periodic fill
             - `'custom'`, pad according arrays found in `fillpar`
-    
+
     Returns
     -------
     ndarray
         Padded array
-        
+
     See also
     --------
     crop_pad_axis
     crop_pad
     crop_pad_symmetric_2d
-    """ 
+    """
     fsh=np.array(A.shape)
     if l>fsh[axis]: #rare case
         l-=fsh[axis]
         A=pad_lr(A,axis,fsh[axis],0,fillpar, filltype)
         return pad_lr(A,axis,l,r,fillpar, filltype)
-    elif r>fsh[axis]: 
+    elif r>fsh[axis]:
         r-=fsh[axis]
         A=pad_lr(A,axis,0,fsh[axis],fillpar, filltype)
         return pad_lr(A,axis,l,r,fillpar, filltype)
-    elif filltype=='mirror':        
+    elif filltype=='mirror':
         left=mirror(np.split(A,[l],axis)[0],axis)
         right=mirror(np.split(A,[A.shape[axis]-r],axis)[1],axis)
     elif filltype=='periodic':
@@ -428,16 +428,16 @@ def pad_lr(A,axis,l,r,fillpar=0.0, filltype='scalar'):
         fsh[axis]=l
         left=np.ones(fsh,A.dtype)*np.split(A,[1],axis)[0]
         fsh[axis]=r
-        right=np.ones(fsh,A.dtype)*np.split(A,[A.shape[axis]-1],axis)[1] 
+        right=np.ones(fsh,A.dtype)*np.split(A,[A.shape[axis]-1],axis)[1]
     if filltype=='scalar' or l==0:
         fsh[axis]=l
         left=np.ones(fsh,A.dtype)*fillpar
     if filltype=='scalar' or r==0:
         fsh[axis]=r
-        right=np.ones(fsh,A.dtype)*fillpar 
+        right=np.ones(fsh,A.dtype)*fillpar
     if filltype=='custom':
         left=fillpar[0].astype(A.dtype)
-        rigth=fillpar[1].astype(A.dtype)   
+        rigth=fillpar[1].astype(A.dtype)
     return np.concatenate((left,A,right),axis=axis)
 
 
@@ -456,13 +456,13 @@ def _roll_from_pixcenter(sh,center):
             cen=sh*0.0
         elif center is not None:
             cen=sh*np.asarray(center) % sh - 0.5
-            
+
         roll=np.ceil(cen - sh/2.0) % sh
     else:
         roll=np.zeros_like(sh)
     return roll.astype(int)
-       
-    
+
+
 
 def crop_pad_axis(A,hplanes,axis=-1,roll=0,fillpar=0.0, filltype='scalar'):
     """
@@ -473,67 +473,67 @@ def crop_pad_axis(A,hplanes,axis=-1,roll=0,fillpar=0.0, filltype='scalar'):
     ----------
     A : array-like
         Input array, should be at least one-dimensional
-    
+
     hplanes: int or tuple of int
-        Number of hyperplanes to add or remove in total. 
+        Number of hyperplanes to add or remove in total.
         If tuple of 2 ints, this value is interpreted as `(begin, end)`.
         See the ``Note`` for more information.
-        
-    axis: int, optional 
+
+    axis: int, optional
         axis to be used for cropping / padding
-    
-    roll: int, 
-        Roll array backwards by this number prior to padding / cropping. 
+
+    roll: int,
+        Roll array backwards by this number prior to padding / cropping.
         The roll is reversed afterwards
-        
+
     fillpar, filltype
         See :any:`pad_lr` for explqanation
-        
+
     Returns
     -------
     array-like
         Cropped / padded array
-        
+
     See also
     --------
     pad_lr
     crop_pad
-    
+
     Note
     ----
-    - if `hplanes` is scalar and negativ : 
+    - if `hplanes` is scalar and negativ :
         crops symmetrically, low-index end of axis is preferred if hplane is odd,
-    - if `hplanes` is scalar and positiv : 
+    - if `hplanes` is scalar and positiv :
         pads symmetrically with a fill specified with 'fillpar' and 'filltype'
         look at function pad_lr() for detail.
-    - if `hplanes` is tupel : 
+    - if `hplanes` is tupel :
         function pads /crops at (begin, end) according to the tupel.
-    
+
     Examples
     --------
     >>> import numpy as np
     >>> from ptypy.utils import crop_pad_axis
     >>> A=np.ones((8,9))
-    
+
     Add a total of 2 rows, one at top, one at bottom.
-    
+
     >>> B=crop_pad_axis(A,2,0)
-    
+
     That is the same as
-     
+
     >>> B = crop_pad_axis(A,(1,1),0))
-    
+
     Crop 3 columns on the left side and pad 2 columns on the right:
-    
+
     >>> B = crop_pad_axis(A,(-3,2),1)
-    
+
     Crop one plane on low-side and high-side (total of 2) of Volume V:
-    
-    >>> V=np.random.rand(3,5,5)    
-    >>> B=crop_pad_axis(V,-2,0)    
-    
+
+    >>> V=np.random.rand(3,5,5)
+    >>> B=crop_pad_axis(V,-2,0)
+
     Mirror volume 3 planes on low side of row axis, crop 2 planes on high side:
-    
+
     >>> B=crop_pad_axis(V,(3,-2),1,filltype='mirror')
     """
     if np.isscalar(hplanes):
@@ -545,10 +545,10 @@ def crop_pad_axis(A,hplanes,axis=-1,roll=0,fillpar=0.0, filltype='scalar'):
         r=int(hplanes[1])
     else:
         raise RuntimeError('unsupoorted input for \'hplanes\'')
-        
+
     if roll!=0:
         A=np.roll(A,-roll,axis=axis)
-        
+
     if l<=0 and r<=0:
         A=np.split(A,[-l,A.shape[axis]+r],axis)[1]
     elif l>0 and r>0:
@@ -559,78 +559,78 @@ def crop_pad_axis(A,hplanes,axis=-1,roll=0,fillpar=0.0, filltype='scalar'):
     elif l<=0 and r>0:
         A=pad_lr(A,axis,0,r,fillpar,filltype)
         A=np.split(A,[-l,A.shape[axis]],axis)[1]
-        
-        
+
+
     if roll!=0:
         return np.roll(A,roll+r,axis=axis)
     else:
         return A
 
- 
+
 def crop_pad(A,hplane_list,axes=None,cen=None,fillpar=0.0,filltype='scalar'):
     """\
     Crops or pads a volume array `A` with a number of hyperplanes according to parameters in `hplanes`
     Wrapper for crop_pad_axis.
-    
+
     Parameters
     ----------
     A : array-like
         input array of any shape
-        
+
     hplane_list : array-like, list
-        list of scalars or tupels counting the number of hyperplanes to crop / pad 
-        see crop_pad_axis() for detail. If N=len(hplane_list) has less entries than dimensions of A, the last N axes are used 
+        list of scalars or tupels counting the number of hyperplanes to crop / pad
+        see crop_pad_axis() for detail. If N=len(hplane_list) has less entries than dimensions of A, the last N axes are used
 
     axes: tuple, list
         tuple / list of axes to be used for cropping / padding, has to be same length as hplanes
-    
-    cen: 
+
+    cen:
         center of array, padding/cropping occurs at cen + A.shape / 2
-    
+
     Returns
     -------
     array-like
         Cropped or padded array.
-        
+
     See also
     --------
     crop_pad_axis
-    
+
     Examples
     --------
     >>> import numpy as np
     >>> from ptypy.utils import crop_pad
     >>> V=np.random.rand(3,5,5)
-    
-    Pads 4 planes of zeros on the last axis (2 on low side and 2 on high 
-    side) and pads 3 planes of zeros on the second last axis (2 on low 
+
+    Pads 4 planes of zeros on the last axis (2 on low side and 2 on high
+    side) and pads 3 planes of zeros on the second last axis (2 on low
     side and 1 on high side):
-    
+
     >>> B=crop_pad(V,[3,4])
-    
-    Also equivalent: 
-    
+
+    Also equivalent:
+
     >>> B=crop_pad(V,[(2,1),(2,2)])
     >>> B=crop_pad(V,[(2,1),(2,2)], axes=[-2,-1],fillpar=0.0,filltype='scalar')
-    
+
     None-peripheral cropping /padding:
-    
+
     >>> from ptypy.utils import grids
     >>> fftshift_grid = grids((6,4),center = 'fft')
     >>> cropped_grid=crop_pad(V,[-2,4],cen='fft')
-    
+
     Note that cropping/ padding now occurs at the start and end of fourier coordinates
     useful for cropping /padding high frequencies in fourier space.
-    
+
     """
     if axes is None:
         axes=np.arange(len(hplane_list))-len(hplane_list)
     elif not(len(axes)==len(hplane_list)):
         raise RuntimeError('if axes is specified, hplane_list has to be same length as axes')
-    
+
     sh=np.array(A.shape)
     roll = _roll_from_pixcenter(sh,cen)
-        
+
     for ax,cut in zip(axes,hplane_list):
         A=crop_pad_axis(A,cut,ax,roll[ax],fillpar,filltype)
     return A

--- a/ptypy/utils/math_utils.py
+++ b/ptypy/utils/math_utils.py
@@ -10,6 +10,7 @@ This file is part of the PTYPY package.
 
 
 from scipy.special import erf
+from scipy.linalg import eig
 import numpy as np
 from misc import *
 from scipy import ndimage as ndi
@@ -253,7 +254,7 @@ def ortho(modes):
     """
     N = len(modes)
     A = np.array([[np.vdot(p2,p1) for p1 in modes] for p2 in modes])
-    e,v = np.linalg.eig(A)
+    e, v = eig(A)
     ei = (-e).argsort()
     nplist = [sum(modes[i] * v[i,j] for i in range(N)) for j in ei]
     amp = np.array([norm2(npi) for npi in nplist])

--- a/ptypy/utils/math_utils.py
+++ b/ptypy/utils/math_utils.py
@@ -14,8 +14,9 @@ import numpy as np
 from misc import *
 from scipy import ndimage as ndi
 
-__all__ = ['smooth_step','abs2','norm2', 'norm', 'delxb', 'delxc', 'delxf',\
-            'ortho','gauss_fwhm','gaussian','gf','cabs2','gf_2d','c_gf','gaussian2D','rl_deconvolution']
+__all__ = ['smooth_step', 'abs2', 'norm2', 'norm', 'delxb', 'delxc', 'delxf',
+           'ortho', 'gauss_fwhm', 'gaussian', 'gf', 'cabs2', 'gf_2d', 'c_gf',
+           'gaussian2D', 'rl_deconvolution']
 
 def cabs2(A):
     """
@@ -42,19 +43,20 @@ def norm(A):
     """
     return np.sqrt(norm2(A))
 
-def smooth_step(x,mfs):
+def smooth_step(x, mfs):
     """
     Smoothed step function with fwhm `mfs`
     Evaluates the error function `scipy.special.erf`.
     """
-    return 0.5*erf(x*2.35/mfs) +0.5
+    return 0.5 * erf(x * 2.35 / mfs) + 0.5
 
-def gaussian(x,std=1.0,off=0.):
+def gaussian(x, std=1.0, off=0.0):
     """
     Evaluates gaussian standard normal
 
     .. math::
-        g(x)=\\frac{1}{\mathrm{std}\sqrt{2\pi}}\,\exp \\left(-\\frac{(x-\mathrm{off})^2}{2 \mathrm{std}^2 }\\right)
+        g(x)=\\frac{1}{\mathrm{std}\sqrt{2\pi}}\,\exp
+        \\left(-\\frac{(x-\mathrm{off})^2}{2 \mathrm{std}^2 }\\right)
 
     Parameters
     ----------
@@ -72,9 +74,9 @@ def gaussian(x,std=1.0,off=0.):
     gauss_fwhm
     smooth_step
     """
-    return np.exp(-(x-off)**2/(2*std**2)) / (std * np.sqrt(2*np.pi))
+    return np.exp(-(x - off)**2 / (2 * std**2)) / (std * np.sqrt(2 * np.pi))
 
-def gauss_fwhm(x,fwhm=1.0,off=0.):
+def gauss_fwhm(x, fwhm=1.0, off=0.0):
     """
     Evaluates gaussian with full width half maximum
 
@@ -94,12 +96,12 @@ def gauss_fwhm(x,fwhm=1.0,off=0.):
     gaussian
 
     """
-    return gaussian(x,fwhm/2/np.sqrt(2*np.log(2)),off)
+    return gaussian(x, fwhm / 2 / np.sqrt(2 * np.log(2)), off)
 
-def gaussian2D(size, std_x=1.0, std_y=1.0, off_x=0., off_y=0.):
+def gaussian2D(size, std_x=1.0, std_y=1.0, off_x=0.0, off_y=0.0):
     """
-    Evaluates normalized 2D gaussian on array of dimension size. Origin of coordinate
-    system is in the center of the array.
+    Evaluates normalized 2D gaussian on array of dimension size.
+    Origin of coordinate system is in the center of the array.
 
     Parameters
     ----------
@@ -121,12 +123,15 @@ def gaussian2D(size, std_x=1.0, std_y=1.0, off_x=0., off_y=0.):
     """
     if not isinstance(size, int):
         raise RuntimeError('Input size has to be integer.')
-    y, x = np.mgrid[0:size, 0:size]
-    x = x-size/2
-    y = y-size/2
-    return np.exp(-((x-off_x)**2/(2*std_x**2) + (y-off_y)**2/(2*std_y**2))) / (2*np.pi*std_x*std_y)
 
-def delxf(a, axis = -1, out = None):
+    y, x = np.mgrid[0:size, 0:size]
+    x = x - size / 2
+    y = y - size / 2
+    xpart = (x - off_x)**2 / (2 * std_x**2)
+    ypart = (y - off_y)**2 / (2 * std_y**2)
+    return np.exp(-(xpart + ypart)) / (2 * np.pi * std_x * std_y)
+
+def delxf(a, axis=-1, out=None):
     """\
     Forward first order derivative for finite difference calculation.
 
@@ -153,21 +158,23 @@ def delxf(a, axis = -1, out = None):
     nd   = len(a.shape)
     axis = range(nd)[axis]
 
-    slice1 = [ slice(1,  None) if i == axis else slice(None) for i in range(nd) ]
-    slice2 = [ slice(None, -1) if i == axis else slice(None) for i in range(nd) ]
+    slice1 = [slice(1, None) if i == axis else slice(None) for i in range(nd)]
+    slice2 = [slice(None, -1) if i == axis else slice(None) for i in range(nd)]
 
-    if out == None:  out = np.zeros_like(a)
+    if out == None:
+        out = np.zeros_like(a)
 
     out[slice2] = a[slice1] - a[slice2]
 
     if out is a:
         # required for in-place operation
-        slice3 = [ slice(-2, None) if i == axis else slice(None) for i in range(nd) ]
-        out[slice3] = 0.
+        slice3 = [slice(-2, None) if i == axis else slice(None)
+                  for i in range(nd)]
+        out[slice3] = 0.0
 
     return out
 
-def delxb(a,axis=-1):
+def delxb(a, axis=-1):
     """\
     Backward first order derivative for finite difference calculation.
 
@@ -191,8 +198,8 @@ def delxb(a,axis=-1):
 
     nd = len(a.shape)
     axis = range(nd)[axis]
-    slice1 = [slice(1,None) if i==axis else slice(None) for i in range(nd)]
-    slice2 = [slice(None,-1) if i==axis else slice(None) for i in range(nd)]
+    slice1 = [slice(1, None) if i == axis else slice(None) for i in range(nd)]
+    slice2 = [slice(None, -1) if i == axis else slice(None) for i in range(nd)]
     b = np.zeros_like(a)
     b[slice1] = a[slice1] - a[slice2]
     return b
@@ -222,8 +229,8 @@ def delxc(a,axis=-1):
     nd = len(a.shape)
     axis = range(nd)[axis]
     slice_middle = [slice(1,-1) if i==axis else slice(None) for i in range(nd)]
-    b = delxf(a,axis) + delxb(a,axis)
-    b[slice_middle] *= .5
+    b = delxf(a, axis) + delxb(a, axis)
+    b[slice_middle] *= 0.5
     return b
 
 
@@ -258,7 +265,7 @@ c_gf= complex_overload(ndi.gaussian_filter)
 # ndi.gaussian_filter is a little special in the docstring
 c_gf.__doc__='    *complex input*\n\n    '+c_gf.__doc__
 
-def gf(c,*arg,**kwargs):
+def gf(c, *arg, **kwargs):
     """
     Wrapper for scipy.ndimage.gaussian_filter, that determines whether
     original or the complex function shall be used.
@@ -268,11 +275,11 @@ def gf(c,*arg,**kwargs):
     c_gf
     """
     if np.iscomplexobj(c):
-        return c_gf(c,*arg,**kwargs)
+        return c_gf(c, *arg, **kwargs)
     else:
-        return ndi.gaussian_filter(c,*arg,**kwargs)
+        return ndi.gaussian_filter(c, *arg, **kwargs)
 
-def gf_2d(c,sigma,**kwargs):
+def gf_2d(c, sigma, **kwargs):
     """
     Gaussian filter along the last 2 axes
 
@@ -283,9 +290,9 @@ def gf_2d(c,sigma,**kwargs):
     """
     if c.ndim > 2:
         n=c.ndim
-        return gf(c,(0,)*(n-2)+tuple(expect2(sigma)),**kwargs)
+        return gf(c, (0,) * (n - 2) + tuple(expect2(sigma)), **kwargs)
     else:
-        return gf(c,sigma,**kwargs)
+        return gf(c, sigma, **kwargs)
 
 def rl_deconvolution(data, mtf, numiter):
     """
@@ -318,5 +325,5 @@ def rl_deconvolution(data, mtf, numiter):
     convolve = lambda x: np.abs(np.fft.ifft2(np.fft.fft2(x)*mtf)).astype(x.dtype)
     u = data.copy()
     for n in range(numiter):
-        u*=convolve(data/(convolve(u)+1e-6))
+        u *= convolve(data / (convolve(u) + 1e-6))
     return u

--- a/ptypy/utils/math_utils.py
+++ b/ptypy/utils/math_utils.py
@@ -21,16 +21,17 @@ __all__ = ['smooth_step', 'abs2', 'norm2', 'norm', 'delxb', 'delxc', 'delxf',
 
 def cabs2(A):
     """
-    Squared absolute value (for complex array `A`)
+    Squared absolute value for an array `A`.
+    If `A` is complex, the returned value is complex as well, with the
+    imaginary part of zero.
     """
     return A * A.conj()
 
 def abs2(A):
     """
-    Squared absolute value (for real array `A`)
+    Squared absolute value for an array `A`.
     """
-    return np.square(np.abs(A))
-
+    return cabs2(A).real
 
 def norm2(A):
     """

--- a/ptypy/utils/math_utils.py
+++ b/ptypy/utils/math_utils.py
@@ -9,7 +9,7 @@ This file is part of the PTYPY package.
 """
 
 
-from scipy.special import erf 
+from scipy.special import erf
 import numpy as np
 from misc import *
 from scipy import ndimage as ndi
@@ -29,22 +29,22 @@ def abs2(A):
     """
     return np.square(np.abs(A))
 
-    
+
 def norm2(A):
     """
     Squared norm
     """
     return np.sum(abs2(A))
-    
+
 def norm(A):
     """
     Norm.
     """
     return np.sqrt(norm2(A))
-    
+
 def smooth_step(x,mfs):
     """
-    Smoothed step function with fwhm `mfs` 
+    Smoothed step function with fwhm `mfs`
     Evaluates the error function `scipy.special.erf`.
     """
     return 0.5*erf(x*2.35/mfs) +0.5
@@ -52,47 +52,47 @@ def smooth_step(x,mfs):
 def gaussian(x,std=1.0,off=0.):
     """
     Evaluates gaussian standard normal
-    
+
     .. math::
         g(x)=\\frac{1}{\mathrm{std}\sqrt{2\pi}}\,\exp \\left(-\\frac{(x-\mathrm{off})^2}{2 \mathrm{std}^2 }\\right)
-    
+
     Parameters
     ----------
     x : ndarray
         input array
-    
-    std : float,optional 
+
+    std : float,optional
         Standard deviation
-        
+
     off : float, optional
         Offset / shift
-    
+
     See also
     --------
     gauss_fwhm
     smooth_step
     """
     return np.exp(-(x-off)**2/(2*std**2)) / (std * np.sqrt(2*np.pi))
-    
+
 def gauss_fwhm(x,fwhm=1.0,off=0.):
     """
-    Evaluates gaussian with full width half maximum 
-    
+    Evaluates gaussian with full width half maximum
+
     Parameters
     ----------
     x : ndarray
         input array
-    
-    fwhm : float,optional 
+
+    fwhm : float,optional
         Full width at half maximum
-        
+
     off : float, optional
         Offset / shift
-    
+
     See also
     --------
     gaussian
-    
+
     """
     return gaussian(x,fwhm/2/np.sqrt(2*np.log(2)),off)
 
@@ -129,22 +129,22 @@ def gaussian2D(size, std_x=1.0, std_y=1.0, off_x=0., off_y=0.):
 def delxf(a, axis = -1, out = None):
     """\
     Forward first order derivative for finite difference calculation.
-    
+
     .. note::
         The last element along the derivative direction is set to 0.\n
         Pixel units are used (:math:`\\Delta x = \\Delta h = 1`).
-    
+
     Parameters
     ----------
     a : ndarray
         Input array.
-        
+
     axis : int, Default=-1, optional
         Which direction used for the derivative.
-    
+
     out : ndarray, Default=None, optional
         Array in wich the resault is written (same size as ``a``).
-    
+
     Returns
     -------
     out : ndarray
@@ -152,19 +152,19 @@ def delxf(a, axis = -1, out = None):
     """
     nd   = len(a.shape)
     axis = range(nd)[axis]
-    
+
     slice1 = [ slice(1,  None) if i == axis else slice(None) for i in range(nd) ]
     slice2 = [ slice(None, -1) if i == axis else slice(None) for i in range(nd) ]
-    
+
     if out == None:  out = np.zeros_like(a)
-    
+
     out[slice2] = a[slice1] - a[slice2]
-    
+
     if out is a:
         # required for in-place operation
         slice3 = [ slice(-2, None) if i == axis else slice(None) for i in range(nd) ]
         out[slice3] = 0.
-    
+
     return out
 
 def delxb(a,axis=-1):
@@ -174,15 +174,15 @@ def delxb(a,axis=-1):
     .. note::
         The first element along the derivative direction is set to 0.\n
         Pixel units are used (:math:`\\Delta x = \\Delta h = 1`).
-    
+
     Parameters
     ----------
     a : ndarray
         Input array.
-        
+
     axis : int, Default=-1, optional
         Which direction used for the derivative.
-    
+
     Returns
     -------
     out : ndarray
@@ -200,20 +200,20 @@ def delxb(a,axis=-1):
 def delxc(a,axis=-1):
     """\
     Central first order derivative for finite difference calculation.
-    
+
     .. note::
-        Forward and backward derivatives are used for first and last 
+        Forward and backward derivatives are used for first and last
         elements along the derivative direction.\n
         Pixel units are used (:math:`\\Delta x = \\Delta h = 1`).
-    
+
     Parameters
     ----------
     a : nd-numpy-array
         Input array.
-        
+
     axis : int, Default=-1, optional
         Which direction used for the derivative.
-    
+
     Returns
     -------
     out : nd-numpy-array
@@ -225,18 +225,18 @@ def delxc(a,axis=-1):
     b = delxf(a,axis) + delxb(a,axis)
     b[slice_middle] *= .5
     return b
-            
+
 
 def ortho(modes):
     """\
     Orthogonalize the given list of modes or ndarray along first axis.
     **specify procedure**
-    
+
     Parameters
     ----------
     modes : array-like or list
         List equally shaped arrays or array of higher dimension
-        
+
     Returns
     -------
     amp : vector
@@ -257,15 +257,15 @@ def ortho(modes):
 c_gf= complex_overload(ndi.gaussian_filter)
 # ndi.gaussian_filter is a little special in the docstring
 c_gf.__doc__='    *complex input*\n\n    '+c_gf.__doc__
-    
+
 def gf(c,*arg,**kwargs):
     """
     Wrapper for scipy.ndimage.gaussian_filter, that determines whether
     original or the complex function shall be used.
-    
+
     See also
     --------
-    c_gf 
+    c_gf
     """
     if np.iscomplexobj(c):
         return c_gf(c,*arg,**kwargs)
@@ -275,7 +275,7 @@ def gf(c,*arg,**kwargs):
 def gf_2d(c,sigma,**kwargs):
     """
     Gaussian filter along the last 2 axes
-    
+
     See also
     --------
     gf

--- a/ptypy/utils/math_utils.py
+++ b/ptypy/utils/math_utils.py
@@ -155,7 +155,7 @@ def delxf(a, axis=-1, out=None):
     out : ndarray
         Derived array.
     """
-    nd   = len(a.shape)
+    nd = a.ndim
     axis = range(nd)[axis]
 
     slice1 = [slice(1, None) if i == axis else slice(None) for i in range(nd)]
@@ -196,7 +196,7 @@ def delxb(a, axis=-1):
         Derived array.
     """
 
-    nd = len(a.shape)
+    nd = a.ndim
     axis = range(nd)[axis]
     slice1 = [slice(1, None) if i == axis else slice(None) for i in range(nd)]
     slice2 = [slice(None, -1) if i == axis else slice(None) for i in range(nd)]
@@ -226,7 +226,7 @@ def delxc(a,axis=-1):
     out : nd-numpy-array
         Derived array.
     """
-    nd = len(a.shape)
+    nd = a.ndim
     axis = range(nd)[axis]
     slice_middle = [slice(1,-1) if i==axis else slice(None) for i in range(nd)]
     b = delxf(a, axis) + delxb(a, axis)

--- a/ptypy/utils/misc.py
+++ b/ptypy/utils/misc.py
@@ -21,45 +21,45 @@ def str2index(s):
     into an index expression
     """
     return eval("np.index_exp["+s+"]")
-    
+
 def str2range(s):
     """
     Generates an index list from string input `s`
-    
+
     Examples
     --------
     >>> # Same as range(1,4,2)
     >>> str2range('1:4:2')
     >>> # Same as range(1,2)
-    >>> str2range('1') 
+    >>> str2range('1')
     """
     start = 0
     stop = 1
     step = 1
     l=s.split(':')
-    
+
     il = [int(ll) for ll in l]
-    
+
     if len(il)==0:
-        pass    
+        pass
     elif len(il)==1:
         start=il[0]; stop=start+1
     elif len(il)==2:
         start, stop= il
     elif len(il)==3:
         start, stop, step = il
-        
+
     return range(start,stop,step)
 
 def str2int(A):
     """
     Transforms numpy array `A` of strings to ``np.uint8`` and back
-    
+
     Examples
     --------
     >>> from ptypy.utils import str2int
     >>> A=np.array('hallo')
-    >>> A 
+    >>> A
     array('hallo', dtype='|S5')
     >>> str2int(A)
     array([104,  97, 108, 108, 111], dtype=uint8)
@@ -78,43 +78,43 @@ def str2int(A):
         return np.array([s.tostring() for s in np.split(A.astype(np.uint8).ravel(),np.prod(A.shape[:-1]))]).reshape(A.shape[:-1])
     else:
         raise TypeError('Data type `%s` not understood for string - ascii conversion' % dt)
-    
+
 def keV2m(keV):
     """\
     Convert photon energy in keV to wavelength (in vacuum) in meters.
     """
-    wl = 1./(keV*1000)*4.1356e-7*2.9998    
-    
+    wl = 1./(keV*1000)*4.1356e-7*2.9998
+
     return wl
 
 def keV2nm(keV):
     """\
     Convert photon energy in keV to wavelength (in vacuum) in nanometers.
     """
-    nm = 1./(keV*10)*4.1356*2.9998    
-    
+    nm = 1./(keV*10)*4.1356*2.9998
+
     return nm
-    
+
 def nm2keV(nm):
     """\
     Convert wavelength in nanometers to photon energy in keV.
     """
-    keV = keV2nm(1.)/nm    
-    
+    keV = keV2nm(1.)/nm
+
     return keV
 
 def expect2(a):
-    """\ 
-    Generates 1d numpy array with 2 entries generated from multiple inputs 
+    """\
+    Generates 1d numpy array with 2 entries generated from multiple inputs
     (tuples, arrays, scalars). Main puprose of this function is to circumvent
     debugging of input as very often a 2-vector is requred in scripts
-    
+
     Examples
     --------
     >>> from ptypy.utils import expect2
     >>> expect2( 3.0 )
     array([ 3.,  3.])
-    >>> expect2( (3.0,4.0) ) 
+    >>> expect2( (3.0,4.0) )
     array([ 3.,  4.])
     >>> expect2( (1.0, 3.0,4.0) )
     array([ 1.,  3.])
@@ -123,12 +123,12 @@ def expect2(a):
     if len(a)==1:
         b=np.array([a.flat[0],a.flat[0]])
     else: #len(psize)!=2:
-        b=np.array([a.flat[0],a.flat[1]])        
+        b=np.array([a.flat[0],a.flat[1]])
     return b
-    
+
 def expect3(a):
     """\
-    Generates 1d numpy array with 3 entries generated from multiple inputs 
+    Generates 1d numpy array with 3 entries generated from multiple inputs
     (tuples, arrays, scalars). Main puprose of this function is to circumvent
     debugging of input.
 
@@ -137,11 +137,11 @@ def expect3(a):
     >>> from ptypy.utils import expect3
     >>> expect3( 3.0 )
     array([ 3.,  3.,  3.])
-    >>> expect3( (3.0,4.0) ) 
+    >>> expect3( (3.0,4.0) )
     array([ 3.,  4.,  4.])
     >>> expect3( (1.0, 3.0,4.0) )
     array([ 1.,  3.,  4.])
-    
+
     """
     a=np.atleast_1d(a)
     if len(a)==1:
@@ -151,41 +151,41 @@ def expect3(a):
     else:
         b=np.array([a.flat[0],a.flat[1],a.flat[2]])
     return b
- 
+
 def complex_overload(func):
     """\
     Overloads function specified only for floats in the following manner
-    
+
     .. math::
-     
-        \mathrm{complex\_overload}\{f\}(c) = f(\Re(c)) + \mathrm{i} f(\Im(c)) 
+
+        \mathrm{complex\_overload}\{f\}(c) = f(\Re(c)) + \mathrm{i} f(\Im(c))
     """
     @wraps(func)
     def overloaded(c,*args,**kwargs):
         return func(np.real(c),*args,**kwargs) +1j *func(np.imag(c),*args,**kwargs)
-    
+
     return overloaded
-    
+
 
 def unique_path(filename):
     """\
     Makes path absolute and unique
-    
+
     Parameters
     ----------
     filename : str
-                A filename. 
+                A filename.
     """
     return os.path.abspath(os.path.expanduser(filename))
-    
+
 def clean_path(filename):
     """\
     Makes path absolute and create all sub directories if needed.
-    
+
     Parameters
     ----------
     filename : str
-               A filename. 
+               A filename.
     """
     filename = os.path.abspath(os.path.expanduser(filename))
     base = os.path.split(filename)[0]

--- a/ptypy/utils/parameters.py
+++ b/ptypy/utils/parameters.py
@@ -17,25 +17,25 @@ class Param(dict):
     """
     Convenience class: a dictionary that gives access to its keys
     through attributes.
-    
+
     Note: dictionaries stored in this class are also automatically converted
     to Param objects:
     >>> p = Param()
     >>> p.x = {}
     >>> p
     Param({})
-    
+
     While dict(p) returns a dictionary, it is not recursive, so it is better in this case
     to use p.todict(). However, p.todict does not check for infinite recursion. So please
     don't store a dictionary (or a Param) inside itself.
-    
+
     BE: Please note also that the recursive behavior of the update function will create
     new references. This will lead inconsistency if other objects refer to dicts or Params
-    in the updated Param instance. 
+    in the updated Param instance.
     """
     _display_items_as_attributes=True
     _PREFIX = PARAM_PREFIX
-    
+
     def __init__(self,__d__=None,**kwargs):
         """
         A Dictionary that enables access to its keys as attributes.
@@ -58,12 +58,12 @@ class Param(dict):
     def __str__(self):
         from .verbose import report
         return report(self,depth=7,noheader=True)
-        
+
     def __setitem__(self, key, value):
         # BE: original behavior modified as implicit conversion may destroy references
         # Use update(value,Convert=True) instead
         #return super(Param, self).__setitem__(key, Param(value) if type(value) == dict else value)
-        return super(Param, self).__setitem__(key, value) 
+        return super(Param, self).__setitem__(key, value)
 
     def __getitem__(self, name):
         #item = super(Param, self).__getitem__(name)
@@ -75,33 +75,33 @@ class Param(dict):
 
     def __delattr__(self, name):
         return super(Param, self).__delitem__(name)
-        
+
     #__getattr__ = __getitem__
     def __getattr__(self, name):
-        try: 
+        try:
             return self.__getitem__(name)
         except KeyError as ke:
             raise AttributeError(ke)
-            
+
     __setattr__ = __setitem__
 
     def copy(self,depth=0):
         """
-        :returns Param: A (recursive) copy of P with depth `depth` 
+        :returns Param: A (recursive) copy of P with depth `depth`
         """
         d = Param(self)
         if depth>0:
             for k,v in d.iteritems():
                 if isinstance(v,self.__class__): d[k] = v.copy(depth-1)
-        return d     
-     
+        return d
+
 
     def __dir__(self):
         """
         Defined to include the keys when using dir(). Useful for
         tab completion in e.g. ipython.
         If you do not wish the dict key's be displayed as attributes
-        (although they are still accessible as such) set the class 
+        (although they are still accessible as such) set the class
         attribute `_display_items_as_attributes` to False. Default is
         True.
         """
@@ -114,18 +114,18 @@ class Param(dict):
     def update(self, __d__=None, in_place_depth=0, Convert=False, **kwargs):
         """
         Update Param - almost same behavior as dict.update, except
-        that all dictionaries are converted to Param if `Convert` is set 
+        that all dictionaries are converted to Param if `Convert` is set
         to True, and update may occur in-place recursively for other Param
         instances that self refers to.
-        
+
         Parameters
         ----------
-        Convert : bool 
+        Convert : bool
                   If True, convert all dict-like values in self also to Param.
-                  *WARNING* 
+                  *WARNING*
                   This mey result in misdirected references in your environment
-        in_place_depth : int 
-                  Counter for recursive in-place updates 
+        in_place_depth : int
+                  Counter for recursive in-place updates
                   If the counter reaches zero, the Param to a key is
                   replaced instead of updated
         """
@@ -134,7 +134,7 @@ class Param(dict):
             if Convert and hasattr(v, 'keys'):
                 #print 'converting'
                 v = Param(v)
-            # new key 
+            # new key
             if not self.has_key(k):
                 self[k] = v
             # If this key already exists and is already dict-like, update it
@@ -151,23 +151,23 @@ class Param(dict):
             # Otherwise just replace it
             else:
                 self[k] = v
-            
+
         if __d__ is not None:
             if hasattr(__d__, 'keys'):
                 # Iterate through dict-like argument
                 for k,v in __d__.iteritems():
                     _k_v_update(k,v)
-                    
+
             else:
                 # here we assume a (key,value) list.
                 for (k,v) in __d__:
                     _k_v_update(k,v)
-                    
+
         for k,v in kwargs.iteritems():
             _k_v_update(k,v)
-            
+
         return None
-            
+
     def _to_dict(self,Recursive=False):
         """
         Convert to dictionary (recursively if needed).
@@ -179,7 +179,7 @@ class Param(dict):
             for k,v in d.iteritems():
                 if isinstance(v,self.__class__): d[k] = v._to_dict(Recursive)
         return d
-        
+
     @classmethod
     def _from_dict(cls,dct):
         """
@@ -189,7 +189,7 @@ class Param(dict):
         #p=Param()
         #p.update(dct.copy())
         return Param(dct.copy())
-        
+
 def validate_standard_param(sp, p=None, prefix=None):
     """\
     validate_standard_param(sp) checks if sp follows the standard parameter convention.
@@ -210,7 +210,7 @@ def validate_standard_param(sp, p=None, prefix=None):
                     a,b,c = v
                     if prefix is not None:
                         print '    %s.%s = %s' % (prefix, k, str(v))
-                    else:   
+                    else:
                         print '    %s = %s' % (k, str(v))
                 except:
                     good = False
@@ -236,23 +236,23 @@ def format_standard_param(p):
             sublines = format_standard_param(v)
             lines += [k + '.' + s for s in sublines]
         else:
-            lines += ['%s = %s #[%s] %s' % (k, str(v[1]),v[0],v[2])] 
+            lines += ['%s = %s #[%s] %s' % (k, str(v[1]),v[0],v[2])]
     return lines
 
 
 def asParam(obj):
     """
     Convert the input to a Param.
-    
+
     Parameters
     ----------
     a : dict_like
         Input structure, in any format that can be converted to a Param.
-        
+
     Returns:
     out : Param
         The Param structure built from a. No copy is done if the input
-        is already a Param.  
+        is already a Param.
     """
     return obj if isinstance(obj, Param) else Param(obj)
 
@@ -263,7 +263,7 @@ def load(filename):
     # This avoid circular import
     from .. import io
 
-    filename = os.path.abspath(os.path.expanduser(filename)) 
+    filename = os.path.abspath(os.path.expanduser(filename))
     param_dict = io.h5read(filename)
     param = Param(param_dict)
     param.autoviv = False

--- a/ptypy/utils/plot_client.py
+++ b/ptypy/utils/plot_client.py
@@ -14,7 +14,7 @@ from threading import Thread, Lock
 #mpl.rcParams['backend'] = 'Qt4Agg'
 #from matplotlib import gridspec
 #from matplotlib import pyplot as plt
-import os 
+import os
 
 __all__=['MPLClient','MPLplotter','PlotClient','spawn_MPLClient', 'TEMPLATES', 'DEFAULT']
 
@@ -83,11 +83,11 @@ nearfield = DEFAULT.copy(depth=4)
 nearfield.pr.clims=[None, [-np.pi, np.pi]]
 nearfield.pr.cmaps=['gray', 'hsv']
 nearfield.pr.crop=[0.0, 0.0]  # fraction of array to crop for display
-nearfield.pr.rm_pr=False  # 
+nearfield.pr.rm_pr=False  #
 nearfield.ob.clims=[None, None]
 nearfield.ob.cmaps=['gray', 'jet']
 nearfield.ob.crop=[0.0, 0.0]  # fraction of array to crop for display
-nearfield.ob.rm_pr=False # 
+nearfield.ob.rm_pr=False #
 TEMPLATES['nearfield'] = nearfield
 del nearfield
 del bnw
@@ -102,8 +102,8 @@ class PlotClient(object):
 
     This PlotClient doesn't actually plot.
     """
-    
-    ACTIVE = 1 
+
+    ACTIVE = 1
     DATA = 2
     STOPPED = 0
 
@@ -135,13 +135,13 @@ class PlotClient(object):
         self._stopping = False
         self._lock = Lock()
         self._has_stopped = False
-        
+
         # Here you should initialize plotting capabilities.
         self.config = None
-        
+
         # A small flag
         self.is_initialized = False
-        
+
     @property
     def status(self):
         """
@@ -163,7 +163,7 @@ class PlotClient(object):
         self._thread = Thread(target=self._loop)
         self._thread.daemon = True
         self._thread.start()
-    
+
     def stop(self):
         """
         Stop loop plot
@@ -173,7 +173,7 @@ class PlotClient(object):
         pause(0.1)
         self.disconnect()
         self._thread.join(0.2)
-        
+
     def get_data(self):
         """
         Thread-safe way to copy data buffer.
@@ -216,21 +216,21 @@ class PlotClient(object):
         log(self.log_level,'Client requesting configuration parameters')
         autoplot = self.client.get_now("Ptycho.p.io.autoplot")
         if hasattr(autoplot,'items'):
-            self.config = Param(autoplot) 
+            self.config = Param(autoplot)
             self.config.home = self.client.get_now("Ptycho.p.io.home")
         else:
             self.config = autoplot
         log(self.log_level,'Client received the following configuration:')
         log(self.log_level,report(self.config))
-        
+
         # Wait until reconstruction starts.
         log(self.log_level,'Client waiting for reconstruction to start...')
         ready = self.client.get_now("'iter_info' in Ptycho.runtime")
-        
-        # requesting fulll runtime 
+
+        # requesting fulll runtime
         log(self.log_level,'Client requesting runtime container')
         self.runtime = Param(self.client.get_now("Ptycho.runtime"))
-        
+
         while not ready:
             time.sleep(.1)
             ready = self.client.get_now("'start' in Ptycho.runtime")
@@ -266,18 +266,18 @@ class PlotClient(object):
 
         # Get the dump file path
         self.cmd_dct["Ptycho.paths.plot_file(Ptycho.runtime)"] = [None, self.runtime, 'plot_file']
-        
+
         # Get info if it's all over
         self.cmd_dct["Ptycho.runtime.get('allstop') is not None"] = [None, self.__dict__, '_stopping']
-        
-        
+
+
     def _request_data(self):
         """
         Request all data to the server (asynchronous).
         """
         for cmd, item in self.cmd_dct.iteritems():
             item[0] = self.client.get(cmd)
-            
+
     def _store_data(self):
         """
         Transfer all data from the client to local attributes.
@@ -302,13 +302,13 @@ class PlotClient(object):
             # logger.info('New data arrived.')
         self.disconnect()
         self._has_stopped = True
-        
+
 class MPLplotter(object):
     """
     Plotting Client for Ptypy, using matplotlib.
     """
     DEFAULT = DEFAULT
-    
+
     def __init__(self, pars=None, probes = None, objects= None, runtime= None, in_thread=False):
         """
         Create a client and attempt to connect to a running reconstruction server.
@@ -318,14 +318,14 @@ class MPLplotter(object):
         self.pr = probes
         self.ob = objects
         if runtime is None:
-            self.runtime = Param() 
+            self.runtime = Param()
             self.runtime.iter_info = []
         else:
             self.runtime = runtime
         self._set_autolayout(pars)
         self.pr_plot=Param()
         self.ob_plot=Param()
-        
+
     def _set_autolayout(self,pars):
         self.p = self.DEFAULT.copy(depth=4)
         plt.interactive(self.p.interactive)
@@ -335,10 +335,10 @@ class MPLplotter(object):
                     pars = TEMPLATES[pars]
                 except KeyError:
                     log(self.log_level,'Plotting template "\%s" not found, using default settings' % str(pars))
-            
+
             if hasattr(pars,'items'):
                 self.p.update(pars,in_place_depth=4)
-            
+
     def update_plot_layout(self, plot_template=None):
         """
         Generate the plot layout.
@@ -366,7 +366,7 @@ class MPLplotter(object):
                 sh = simplify_aspect_ratios(sh)
             if plot.use_colorbar:
                 sh=(sh[0],int(sh[1]*1.15))
-                
+
             layers = plot.layers
             if layers is None:
                 layers = cont.data.shape[0]
@@ -377,13 +377,13 @@ class MPLplotter(object):
             num_shape = [len(layers)*len(plot.auto_display)+int(plot.local_error), sh]
             num_shape_list.append(num_shape)
             self.ob_plot[key]=plot
-            
+
         # per default we will use the a frame similar to the last object frame for plotting
         if np.array(self.p.plot_error).any():
             self.error_axes_index = len(num_shape_list)-1
             self.error_frame = num_shape_list[-1][0]
             num_shape_list[-1][0] += 1  # add a frame
-        
+
         for key in sorted(self.pr.keys()):
             cont = self.pr[key]
             # attach a plotting dict from above
@@ -395,7 +395,7 @@ class MPLplotter(object):
                 sh = simplify_aspect_ratios(sh)
             if plot.use_colorbar:
                 sh=(sh[0],int(sh[1]*1.2))
-                
+
             layers = plot.layers
             if layers is None:
                 layers = cont.data.shape[0]
@@ -406,7 +406,7 @@ class MPLplotter(object):
             num_shape = [len(layers)*len(plot.auto_display), sh]
             num_shape_list.append(num_shape)
             self.pr_plot[key]=plot
-            
+
         axes_list, plot_fig, gs = self.create_plot_from_tile_list(1, num_shape_list, self.p.figsize)
         sy, sx = gs.get_geometry()
         w, h, l, r, b, t = self.p.gridspecpars
@@ -414,7 +414,7 @@ class MPLplotter(object):
         self.draw()
         plot_fig.hold(False)
         for axes in axes_list:
-            for pl in axes: 
+            for pl in axes:
                 pl.hold(False)
                 plt.setp(pl.get_xticklabels(), fontsize=8)
                 plt.setp(pl.get_yticklabels(), fontsize=8)
@@ -439,7 +439,7 @@ class MPLplotter(object):
                     Horizontal = True
                 else:
                     Horizontal = False
-                     
+
                 if Horizontal:
                     N = N_h
                     a = size[1] % sh[1]
@@ -450,14 +450,14 @@ class MPLplotter(object):
                     a = size[0] % sh[0]
                     coords = [(int(ii*sh[0])+a, size[1]) for ii in range(N)]
                     size[1] += sh[1]
-                    
+
                 num -= N
                 coords_tl += coords
                 coords_tl.sort()
-                
+
             return coords_tl, size
-        
-        
+
+
         allcoords = []
         fig_aspect_ratio = figsize[0]/float(figsize[1])
         size = [0, 0]
@@ -474,21 +474,21 @@ class MPLplotter(object):
                 M=0
                 last_sh = sh
                 allcoords+=coords
-            else:    
+            else:
                 M+=N
                 continue
-        
+
         coords_list =[]
         M=0
         for ii,(N,sh) in enumerate(num_shape_list):
             coords_list.append(allcoords[M:M+N])
             M+=N
-        
+
         from matplotlib import gridspec
         gs = gridspec.GridSpec(size[0], size[1])
         fig = plt.figure(fignum)
         fig.clf()
-        
+
         mag = min(figsize[0]/float(size[1]), figsize[1]/float(size[0]))
         figsize = (size[1]*mag, size[0]*mag)
         fig.set_size_inches(figsize, forward=True)
@@ -497,7 +497,7 @@ class MPLplotter(object):
         axes_list=[]
         for (N, sh), coords in zip(num_shape_list, coords_list):
             axes_list.append([fig.add_subplot(gs[co[0]+frame//2:co[0]+frame//2+sh[0], co[1]+frame//2:co[1]+frame//2+sh[1]]) for co in coords])
-    
+
         return axes_list, fig, gs
 
     def draw(self):
@@ -506,7 +506,7 @@ class MPLplotter(object):
             time.sleep(0.1)
         else:
             plt.show()
-            
+
     def plot_error(self):
         if np.array(self.p.plot_error).any():
             try:
@@ -529,7 +529,7 @@ class MPLplotter(object):
                 plt.setp(axis.get_yticklabels(), fontsize=10)
             except:
                 pass
-            
+
     def plot_storage(self, storage, plot_pars, title="", typ='obj'):
         # get plotting paramters
         pp = plot_pars
@@ -541,14 +541,14 @@ class MPLplotter(object):
             x, y = np.indices(sh)-np.reshape(np.array(sh)//2, (len(sh),)+len(sh)*(1,))
             mask = (np.sqrt(x**2+y**2) < pp.mask*min(sh)/2.)
             pp.mask = mask
-        
+
         # cropping
         crop = np.array(sh)*np.array(pp.crop)//2
         data = storage.data
         #crop = -crop.astype(int)
         #data = crop_pad(storage.data, crop, axes=[-2, -1])
         #plot_mask = crop_pad(mask, crop, axes=[-2, -1])
-        
+
         pty_axes = pp.get('pty_axes',[])
         for layer in pp.layers:
             for ind,channel in enumerate(pp.auto_display):
@@ -568,10 +568,10 @@ class MPLplotter(object):
                     ptya._resize_cid = self.plot_fig.canvas.mpl_connect('resize_event', ptya._after_resize_event)
                     pty_axes.append(ptya)
                 # get the layer
-                ptya.set_data(data[layer])               
+                ptya.set_data(data[layer])
                 ptya.ax.set_ylim(crop[0],sh[0]-crop[0])
                 ptya.ax.set_xlim(crop[1],sh[1]-crop[1])
-                #ptya._update_colorbar() 
+                #ptya._update_colorbar()
                 if channel == 'c':
                     if typ == 'obj':
                         mm = np.mean(np.abs(data[layer]*plot_mask)**2)
@@ -581,13 +581,13 @@ class MPLplotter(object):
                         info = 'P=%1.1e' % mm
                     ttl = '%s#%d (C)\n%s' % (title, layer, info)
                 elif channel == 'a':
-                    ttl = '%s#%d (a)' % (title, layer) 
+                    ttl = '%s#%d (a)' % (title, layer)
                 else:
-                    ttl = '%s#%d (p)' % (title, layer) 
+                    ttl = '%s#%d (p)' % (title, layer)
                 ptya.ax.set_title(ttl, size=12)
-            
+
         pp.pty_axes = pty_axes
-    
+
     def save(self, pattern, count=0):
         try:
             r = self.runtime.copy(depth=1)
@@ -605,7 +605,7 @@ class MPLplotter(object):
         with open(self._framefile,mode) as f:
             f.write(plot_file+'\n')
             f.close()
-        
+
     def plot_all(self, blocking = False):
         for key, storage in self.pr.items():
             #print key
@@ -619,27 +619,27 @@ class MPLplotter(object):
         self.draw()
 
 class MPLClient(MPLplotter):
-    
+
     DEFAULT = DEFAULT
-    
+
     def __init__(self, client_pars=None, autoplot_pars=None,\
                  layout_pars=None, in_thread=False, is_slave=False):
-        
+
         from ptypy.core.ptycho import DEFAULT_autoplot
         self.config = DEFAULT_autoplot.copy(depth=3)
         self.config.update(autoplot_pars)
         # set a home directory
         self.config.home = self.config.get('home',self.DEFAULT.get('home'))
-        
-        layout = self.config.get('layout',layout_pars) 
-        
+
+        layout = self.config.get('layout',layout_pars)
+
         super(MPLClient,self).__init__(pars = layout, in_thread = in_thread)
-            
+
         self.pc = PlotClient(client_pars,in_thread=in_thread)
         self.pc.start()
         self._framefile= None
         self.is_slave = is_slave
-        
+
     def loop_plot(self):
         """
         Plot forever.
@@ -658,7 +658,7 @@ class MPLClient(MPLplotter):
                     self._set_autolayout(self.config.layout)
                     self.update_plot_layout(self.config.layout)
                     initialized=True
-                    
+
                 self.plot_all()
                 self.draw()
                 count+=1
@@ -669,9 +669,9 @@ class MPLClient(MPLplotter):
             elif status == self.pc.STOPPED:
                 break
             pause(.1)
-        
+
         if self.config.get('make_movie'):
-            
+
             from ptypy import utils as u
             u.png2mpg(self._framefile, RemoveImages=True)
 
@@ -688,7 +688,7 @@ def spawn_MPLClient(client_pars, autoplot_pars):
     finally:
         print 'Stopping plot client...'
         mplc.pc.stop()
-        
+
 if __name__ =='__main__':
     from ptypy.resources import moon_pr, flower_obj
     moon = moon_pr(256)

--- a/ptypy/utils/plot_utils.py
+++ b/ptypy/utils/plot_utils.py
@@ -24,8 +24,8 @@ __all__ = ['pause', 'rmphaseramp', 'plot_storage', 'imsave', 'imload',
 NODISPLAY = (os.getenv("DISPLAY") is None)
 if NODISPLAY:
     matplotlib.use('agg')
-    
-                
+
+
 import matplotlib.pyplot as plt
 
 # Improved interactive behavior for old versions of matplotlib
@@ -142,20 +142,20 @@ def complex2hsv(cin, vmin=None, vmax=None):
     Transforms a complex array into an RGB image,
     mapping phase to hue, amplitude to value and
     keeping maximum saturation.
-    
+
     Parameters
     ----------
     cin : ndarray
         Complex input. Must be two-dimensional.
-    
+
     vmin,vmax : float
         Clip amplitude of input into this interval.
-        
+
     Returns
     -------
     rgb : ndarray
-        Three dimensional output.   
-        
+        Three dimensional output.
+
     See also
     --------
     complex2rgb
@@ -173,7 +173,7 @@ def complex2hsv(cin, vmin=None, vmax=None):
         vmax = v.max()
     assert vmin < vmax
     v = (v.clip(vmin, vmax)-vmin)/(vmax-vmin)
-    
+
     return np.asarray((h, s, v))
 
 
@@ -188,7 +188,7 @@ def complex2rgb(cin, **kwargs):
     rgb2complex
     """
     return hsv2rgb(complex2hsv(cin, **kwargs))
-    
+
 
 def hsv2rgb(hsv):
     """\
@@ -199,13 +199,13 @@ def hsv2rgb(hsv):
     hsv : array-like
         Input must be two-dimensional. **First** axis is interpreted
         as hue,saturation,value channels.
-    
+
     Returns
     -------
     rgb : ndarray
         Three dimensional output. **Last** axis is interpreted as
-        red, green, blue channels.  
-        
+        red, green, blue channels.
+
     See also
     --------
     complex2rgb
@@ -233,7 +233,7 @@ def hsv2rgb(hsv):
     rgb[:, :, 2] = 255*(i0*p + i1*p + i2*t + i3*v + i4*v + i5*q)
 
     return rgb
-    
+
 
 def rgb2hsv(rgb):
     """
@@ -249,7 +249,7 @@ def rgb2hsv(rgb):
     rc = (maxc-rgb[:, :, 0]) / (maxc-minc+eps)
     gc = (maxc-rgb[:, :, 1]) / (maxc-minc+eps)
     bc = (maxc-rgb[:, :, 2]) / (maxc-minc+eps)
-    
+
     h = 4.0+gc-rc
     maxgreen = (rgb[:, :, 1] == maxc)
     h[maxgreen] = 2.0+rc[maxgreen]-bc[maxgreen]
@@ -275,8 +275,8 @@ def rgb2complex(rgb):
     """
     return hsv2complex(rgb2hsv(rgb))
 
-HSV_to_RGB = hsv2rgb  
-RGB_to_HSV = rgb2hsv    
+HSV_to_RGB = hsv2rgb
+RGB_to_HSV = rgb2hsv
 P1A_to_HSV = complex2hsv
 HSV_to_P1A = hsv2complex
 
@@ -284,36 +284,36 @@ HSV_to_P1A = hsv2complex
 def imsave(a, filename=None, vmin=None, vmax=None, cmap=None):
     """
     Take array `a` and transform to `PIL.Image` object that may be used
-    by `pyplot.imshow` for example. Also save image buffer directly 
+    by `pyplot.imshow` for example. Also save image buffer directly
     without the sometimes unnecessary Gui-frame and overhead.
-    
+
     Parameters
     ----------
     a : ndarray
         Two dimensional array. Can be complex, in which case the amplitude
-        will be optionally clipped by `vmin` and `vmax` if set. 
-    
+        will be optionally clipped by `vmin` and `vmax` if set.
+
     filename : str, optionsl
         File path to save the image buffer to. Use '\*.png' or '\*.png'
         as image formats.
-    
+
     vmin,vmax : float, optional
         Value limits ('clipping') to fit the color scale.
         If not set, color scale will span from minimum to maximum value
         in array
-        
+
     cmap : str, optional
         Name of the colormap for colorencoding.
-        
+
     Returns
     -------
     im : PIL.Image
         a `PIL.Image` object.
-         
+
     See also
     --------
     complex2rgb
-    
+
     Examples
     --------
     >>> from ptypy.utils import imsave
@@ -323,24 +323,24 @@ def imsave(a, filename=None, vmin=None, vmax=None, cmap=None):
     >>> pil = imsave(a)
     >>> plt.imshow(pil)
     >>> plt.show()
-    
+
     converts array a into, and returns a PIL image and displays it.
-    
-    >>> pil = imsave(a, /tmp/moon.png) 
-    
+
+    >>> pil = imsave(a, /tmp/moon.png)
+
     returns the image and also saves it to filename
-    
-    >>> imsave(a, vmin=0, vmax=0.5) 
-    
+
+    >>> imsave(a, vmin=0, vmax=0.5)
+
     clips the array to values between 0 and 0.5.
-    
-    >>> imsave(abs(a), cmap='gray') 
-    
+
+    >>> imsave(abs(a), cmap='gray')
+
     uses a matplotlib colormap with name 'gray'
     """
     if str(cmap) == cmap:
         cmap = mpl.cm.get_cmap(cmap)
-        
+
     if a.dtype.kind == 'c':
         i = complex2rgb(a, vmin=vmin, vmax=vmax)
         im = Image.fromarray(np.uint8(i), mode='RGB')
@@ -398,32 +398,32 @@ def franzmap():
     if im is not None:
         im.set_cmap(matplotlib.cm.get_cmap('franzmap'))
     mpl.pyplot.draw_if_interactive()
-    
+
 
 def rmphaseramp(a, weight=None, return_phaseramp=False):
     """
-    Attempts to remove the phase ramp in a two-dimensional complex array 
+    Attempts to remove the phase ramp in a two-dimensional complex array
     ``a``.
 
     Parameters
     ----------
     a : ndarray
         Input image as complex 2D-array.
-    
+
     weight : ndarray, str, optional
-        Pass weighting array or use ``'abs'`` for a modulus-weighted 
+        Pass weighting array or use ``'abs'`` for a modulus-weighted
         phaseramp and ``Non`` for no weights.
-    
+
     return_phaseramp : bool, optional
         Use True to get also the phaseramp array ``p``.
-    
+
     Returns
     -------
     out : ndarray
         Modified 2D-array, ``out=a*p``
     p : ndarray, optional
-        Phaseramp if ``return_phaseramp = True``, otherwise omitted 
-    
+        Phaseramp if ``return_phaseramp = True``, otherwise omitted
+
     Examples
     --------
     >>> b = rmphaseramp(image)
@@ -435,7 +435,7 @@ def rmphaseramp(a, weight=None, return_phaseramp=False):
         useweight = False
     elif weight == 'abs':
         weight = np.abs(a)
-        
+
     ph = np.exp(1j*np.angle(a))
     [gx, gy] = np.gradient(ph)
     gx = -np.real(1j*gx/ph)
@@ -470,41 +470,41 @@ def plot_storage(S, fignum=100, modulus='linear', slices=(slice(1), slice(None),
     Quickly display the data buffer of a :any:`Storage` instance.
 
     Keyword arguments are those of :any:`PtyAxis`
-    
+
     Parameters
     ----------
     S : Storage
         Storage instance
-        
+
     fignum : int, optional
-        Number of the figure. 
-        
+        Number of the figure.
+
     slices : tuple of slices or string of numpy index expression, optional
         Determines what part of Storage buffer is displayed, i.e. which
-        layers and which region-of-interest. Layers are subplotted 
+        layers and which region-of-interest. Layers are subplotted
         horizontically next to each other. Figsize is (6,6*layers)
-    
+
     modulus : str, optional
-        One of `sqrt`, `log` or `linear` to apply to modulus of array 
+        One of `sqrt`, `log` or `linear` to apply to modulus of array
         buffer. Useful to reduce dynamic range for diffraction images.
-        
+
     si_axes : str, optional
         One of 'x','xy','y' or None, determins which axes display
         length units instead of pixel units
-        
+
     mask : ndarray, scalar or None
         Bool array of valid pixel data for rescaling.
-        
+
     Returns
     -------
     fig : maplotlib.pyplot.figure
-        
+
     See also
     --------
     imsave
     :any:`Storage`
     """
-    
+
     if str(slices) == slices:
         slc = eval('np.index_exp['+slices+']')
     else:
@@ -518,21 +518,21 @@ def plot_storage(S, fignum=100, modulus='linear', slices=(slice(1), slice(None),
     else:
         phase = np.real(np.exp(1j*np.pi*np.angle(im)))  # -1 or 1
         channel = 'r'
-    
+
     if modulus == 'sqrt':
         im = np.sqrt(np.abs(im)).astype(im.dtype)*phase
     elif modulus == 'log':
         im = np.log10(np.abs(im)+1).astype(im.dtype)*phase
     else:
         modulus = 'linear'
-    
+
     ttl = str(S.ID) + '#%d' + ', ' + modulus + ' scaled'
     y_unit, y_mag, y_num = length_units(S.psize[0]*imsh[0])
     x_unit, x_mag, x_num = length_units(S.psize[1]*imsh[1])
 
     if im.ndim == 2:
         im = im.reshape((1,)+im.shape)
-        
+
     layers = im.shape[0]
     fig = plt.figure(fignum, figsize=(6*layers, 5))
     for l in range(layers):
@@ -557,24 +557,24 @@ def plot_storage(S, fignum=100, modulus='linear', slices=(slice(1), slice(None),
         else:
             ax.set_ylabel('y [Pixel]')
         ax.title.set_text(ttl % l)
-        
+
     plt.draw()
     return fig
 
 
 class PtyAxis(object):
     def __init__(self, ax=None, data=None, channel='r', cmap=None, fontsize=8, **kwargs):
-        
+
         if ax is None:
             fig = plt.figure()
             ax = fig.add_subplot(111)
         self.ax = ax
         self.shape = None
         self.data = None
-        
+
         if data is not None: self.set_data(data, False)
         # sets shape and data too
-        
+
         self.remove_phase_ramp = kwargs.get('rmramp', False)
         self.cax = None
         self.cax_aspect = None
@@ -597,7 +597,7 @@ class PtyAxis(object):
         self.psize = np.abs(psize)
         if update:
             self._update()
-    
+
     def set_channel(self, channel, update=True):
         assert channel in ['a', 'c', 'p', 'r', 'i'], \
             'Channel must be either (a)bs, (p)hase, (c)omplex, (r)eal or (i)maginary'
@@ -605,7 +605,7 @@ class PtyAxis(object):
         if update:
             self._update()
             self._update_colorscale()
-            
+
     def set_cmap(self, cmap, update=True):
         try:
             self.cmap = mpl.cm.get_cmap(cmap)
@@ -615,14 +615,14 @@ class PtyAxis(object):
         if update:
             self._update()
             self._update_colorscale()
-            
+
     def set_clims(self, vmin, vmax, update=True):
         self.vmin = vmin
         self.vmax = vmax
         assert vmin < vmax
         if update:
             self._update()
-            
+
     def set_mask(self, mask, update=True):
         if mask is not None:
             if np.isscalar(mask) and self.shape is not None:
@@ -638,7 +638,7 @@ class PtyAxis(object):
             self.mask = None
         if update:
             self._update()
-    
+
     def set_data(self, data, update=True):
         assert data.ndim == 2, 'Data must be two dimensional. It is %d-dimensional' % data.ndim
         self.data = data
@@ -650,7 +650,7 @@ class PtyAxis(object):
                 self._update(renew_image=True)
             else:
                 self._update()
-        
+
     def _update(self,renew_image=False):
         if str(self.channel) == 'a':
             imdata = np.abs(self.data)
@@ -676,12 +676,12 @@ class PtyAxis(object):
                 imdata = self.data
         else:
             imdata = np.abs(self.data)
-        
+
         if self.mask is not None:
             cdata = imdata if str(self.channel) != 'c' else np.abs(self.data)
             self.mx = np.max(cdata[self.mask])
             if self.vmax is None:  # or self.mx<self.vmax:
-                mx = self.mx 
+                mx = self.mx
             else:
                 mx = self.vmax
             self.mn = np.min(cdata[self.mask])
@@ -691,7 +691,7 @@ class PtyAxis(object):
                 mn = self.vmin
         else:
             mn, mx = self.vmin, self.vmax
-        
+
         pilim = imsave(imdata, cmap=self.cmap, vmin=mn, vmax=mx)
         if not self.ax.images or renew_image:
             self.ax.imshow(pilim, **self.kwargs)
@@ -731,10 +731,10 @@ class PtyAxis(object):
         self.cax.invert_yaxis()
         self._update_colorbar()
         plt.draw()
-        
+
     def _after_resize_event(self, evt):
         self._update_colorbar()
-        
+
     def _update_colorbar(self, mn=None, mx=None):
         mn = mn if mn is not None else self.mn
         mn = 0 if mn is None else mn
@@ -747,13 +747,13 @@ class PtyAxis(object):
         b = self.cax.get_position().bounds
 
         self.cax.set_position((b[0], a[1], self.cax_width, a[3]))
-        
+
         if self.channel == 'c':
             self.cax.xaxis.set_major_formatter(mpl.ticker.FixedFormatter(['0', '$\pi$', '2$\pi$']))
             self.cax.xaxis.set_major_locator(mpl.ticker.LinearLocator(3))
             self.cax.set_xlabel('phase [rad]', fontsize=self.fontsize+2)
             self.cax.xaxis.set_label_position("top")
-            
+
         locs = np.linspace(0.02, 1., max((int(a[3]*20), 5)))
         self.cax.yaxis.set_major_locator(mpl.ticker.FixedLocator(locs))
         formatter = lambda x, y: pretty_length(((1-x)*(mx-mn)+mn), 3)

--- a/ptypy/utils/scripts.py
+++ b/ptypy/utils/scripts.py
@@ -22,7 +22,7 @@ __all__ = ['hdr_image', 'diversify', 'cxro_iref', 'xradia_star', 'png2mpg',
 def diversify(A, noise=None, shift=None, power=1.0):
     """
     Add diversity to 3d numpy array `A`, *acts in-place*.
-    
+
     Parameters
     ----------
     A : np.array
@@ -30,16 +30,16 @@ def diversify(A, noise=None, shift=None, power=1.0):
 
     noise : 2-tuple or 4-tuple
         For detailed description see :any:`ptypy.utils.parallel.MPInoise2d`
-    
+
     power : float, tuple
         Relative power of layers with respect to the first (0) layer.
         Can be scalar or tuple / array
-        
+
     shift : float, tuple
         Relative shift of layers with respect to the first (0) layer.
         Can be scalar or tuple / array
         **not implemented yet**
-           
+
     See also
     --------
     ptypy.utils.parallel.MPInoise2d
@@ -49,11 +49,11 @@ def diversify(A, noise=None, shift=None, power=1.0):
         # No noise where the main mode is
         noise[0] = 1.0
         A *= noise
-        
+
     if shift is not None:
         raise NotImplementedError(
             'Diversity introduced by lateral shifts is not yet implemented.')
-        
+
     # Expand power to length
     p = (power,) if np.isscalar(power) else tuple(power)
     # Check
@@ -73,48 +73,48 @@ def hdr_image(img_list, exp_list, thresholds=[3000,50000], dark_list=[],
     """
     Generate a high dynamic range image from a list of images `img_list`
     and corresponding exposure information in `exp_list`.
-    
+
     Parameters
     ----------
     img_list : list
         Sequence of images (as 2d np.ndarray)
-    
+
     exp_list : list of float
         Associated exposures to each element of above sequence `img_list`
-        
+
     thresholds : list, 2-tuple
-        Tuple of lower limit (noise floor) and upper limit (overexposure) 
+        Tuple of lower limit (noise floor) and upper limit (overexposure)
         in the images.
-        
+
     dark_list : list
         Single frame or sequence of dark images (as 2d np.array) of the
         same length as `img_list`. These frames are used for dark-field
         correction
-        
+
     avg_type : str
         Type of combining all valid pixels:
-          
-          - `'highest'`, the next longest exposure is used to replace 
+
+          - `'highest'`, the next longest exposure is used to replace
             overexposed pixels.
           - `<other_string>`, overexposed pixels are replaced by the
-            pixel average of all other images with valid pixel values 
+            pixel average of all other images with valid pixel values
             for that pixel.
-        
-    mask_list : list 
+
+    mask_list : list
         Single frame or sequence of 2d np.array.
         Provide additional masking (dead pixels, hot pixels)
-                
+
     ClipLongestExposure : bool
         If True, also mask the noise floor in the longest exposure.
-        
+
     ClipShortestExposure : bool
         if True, also mask the overexposed pixels in the shortest exposure.
-    
+
     Returns
     -------
     out : ndarray
         Combined hdr-image with shape of one of the frame in `img_list`
-        
+
     Examples
     --------
     >>> from ptypy import io
@@ -122,8 +122,8 @@ def hdr_image(img_list, exp_list, thresholds=[3000,50000], dark_list=[],
     >>> img_list, meta= io.image_read('/path/to/images/ccd*.raw')
     >>> exp_list = [meta[j]['exposure_time__key'] for j in range(len(meta))]
     >>> hdr, masks = hdr_image(img_list, exp_list, dark_list=dark_list)
-        
-    
+
+
     """
     min_exp = min(exp_list)
     #print min_exp
@@ -133,7 +133,7 @@ def hdr_image(img_list, exp_list, thresholds=[3000,50000], dark_list=[],
         mask_list = [np.ones(img.shape) for img in img_list]
     elif len(mask_list) == 1:
         mask_list = mask_list * len(img_list)
-        
+
     if len(dark_list) == 0:
         dark_list = [np.zeros(img.shape) for img in img_list]
     elif len(dark_list) == 1:
@@ -143,7 +143,7 @@ def hdr_image(img_list, exp_list, thresholds=[3000,50000], dark_list=[],
     dark_list = [dark.astype(np.float) for dark in dark_list]
     exp_list = [np.float(exp) for exp in exp_list]
     mask_list = [mask.astype(np.int) for mask in mask_list]
-         
+
     for img, dark, exp,mask in zip(img_list, dark_list,exp_list,mask_list):
         img[:] = abs(img - dark)
         #img[img < 0] = 0
@@ -155,7 +155,7 @@ def hdr_image(img_list, exp_list, thresholds=[3000,50000], dark_list=[],
         elif abs(exp - max_exp) / exp < 0.01 and not ClipLongestExposure:
             mask *= maskhigh
         else:
-            mask *= masklow*maskhigh    
+            mask *= masklow*maskhigh
 
     if avg_type == 'highest':
         ix = list(np.argsort(exp_list))
@@ -180,7 +180,7 @@ def hdr_image(img_list, exp_list, thresholds=[3000,50000], dark_list=[],
             mask_sum += mask
         mask_sum[mask_sum == 0] = 1
         img_hdr = img_hdr / (mask_sum*1.)
-    
+
     return img_hdr,mask_list
 
 def png2mpg(listoffiles, framefile='frames.txt', fps=5, bitrate=2000,
@@ -188,66 +188,66 @@ def png2mpg(listoffiles, framefile='frames.txt', fps=5, bitrate=2000,
     """
     Makes a movie (\*.mpg) from a collection of \*.png or \*.jpeg frames.
     *Requires* binary of **mencoder** installed on system
-    
+
     Parameters
     ----------
     listoffiles : list of str
-        A list of paths to files. Each file will be reinterpreted as a 
+        A list of paths to files. Each file will be reinterpreted as a
         collection files in the same directory, e.g. only the first file
         in a series needs to be selected. All series for which a first
-        file was given will be concatenated in the movie. May also be 
+        file was given will be concatenated in the movie. May also be
         a textfile with a listing of frames in which case the creation
         of an intermediate file of frame paths will be skipped.
-    
+
     framefile : str
         Filepath, the respective file will be created to store a list
         of all frames. This file will be used by mencoder later.
-    
-    fps : scalar 
+
+    fps : scalar
         Frames per second in final movie
-        
+
     bitrate : int
         Encoding detail, determines video quality
-    
+
     codec : str
         Defines the codec to Use
-        
+
     Encode : bool
         If True, video will be encoded calling mencoder
-        If False, mencoder will not be called, but the necessary command 
+        If False, mencoder will not be called, but the necessary command
         expression will be returned instead. Very well suited for a dry-run
-        
+
     RemoveImages : bool
         If True, all images referred to by framefile are deleted except
         for the last frame.
-        
+
     Returns
     -------
     cmd : str
         Command string for the shell to encode the video later manually.
-    
+
     Examples
     --------
     >>> from ptypy.utils.scripts import png2mpg
     >>> png2mpg(['/path/to/image_000.png'])
-    
+
     The following happens:
     1) search for files similar to image_*.png in '/path/to/'
     2) found files get listed in a file '/path/to/frames.txt'
     3) calls mencoder to use that file to encode a movie with the default args.
     4) movie is in the same folder as 'frames.txt' and is called 'frames.mpg'
-    
-    
+
+
     >>> png2mpg(['/path1/to/imageA_040.png', '/path2/to/imageB_001.png'],
     >>>         framefile='./banana.txt')
-    
-    Generates list file 'banana_text' in current folder. The list file 
+
+    Generates list file 'banana_text' in current folder. The list file
     contains in order every path compatible with the wildcards
     '/path1/to/imageA_*.png' and '/path2/to/imageB_*.png'
-    
+
     >>> str = png2mpg(['/path/to/image_000.png'], Encode=False)
-    
-    Returns encoder argument string. Use os.system(encoderstring) for 
+
+    Returns encoder argument string. Use os.system(encoderstring) for
     encoding manually later
 
     """
@@ -264,7 +264,7 @@ def png2mpg(listoffiles, framefile='frames.txt', fps=5, bitrate=2000,
         # In case of single file path.
         if str(listoffiles) == listoffiles:
             listoffiles = [listoffiles]
-            
+
         for frame_or_list in listoffiles:
             if not os.path.isfile(frame_or_list):
                 raise ValueError('File %s not found' % frame_or_list)
@@ -273,7 +273,7 @@ def png2mpg(listoffiles, framefile='frames.txt', fps=5, bitrate=2000,
                 # In case of executing the script in the same directory.
                 if str(head) == '':
                     head = '.'
-                
+
                 if os.path.splitext(tail)[1] in ['.txt', '.dat']:
                     print('Found text file - try to interpret it as a list of '
                           'image files.')
@@ -304,12 +304,12 @@ def png2mpg(listoffiles, framefile='frames.txt', fps=5, bitrate=2000,
                     imagfiles = glob.glob(wcard)
                     imagfiles.sort()
                     framelist += imagfiles
-        
+
         if os.path.split(framefile)[0] == '':
             ff = head + os.sep + framefile
         else:
             ff = framefile
-        
+
         newframefile = open(ff, 'w')
         #newframefile.writelines(framelist)
         for frame in framelist:
@@ -324,7 +324,7 @@ def png2mpg(listoffiles, framefile='frames.txt', fps=5, bitrate=2000,
 
     frametype = os.path.splitext(last)[1].split('.')[-1]
     body = os.path.splitext(ff)[0]
-    
+
     mencode_dict = dict(
         listf = os.path.relpath(ff),
         outputf = os.path.relpath(body),
@@ -341,7 +341,7 @@ def png2mpg(listoffiles, framefile='frames.txt', fps=5, bitrate=2000,
                              '-ovc lavc ',
                              '-lavcopts vbitrate=%(bitrate)d:vcodec=%(codec)s ',
                              '-oac copy'])
-    
+
     encoderstring = encodepattern % mencode_dict
 
     if Encode:
@@ -368,7 +368,7 @@ def png2mpg(listoffiles, framefile='frames.txt', fps=5, bitrate=2000,
                     print('Removing %s' % ff)
                     os.remove(ff)
                 except OSError:
-                    print('Removing %s failed' % ff)                
+                    print('Removing %s failed' % ff)
     else:
         return encoderstring
 
@@ -378,44 +378,44 @@ def xradia_star(sh, spokes=48, std=0.5, minfeature=5, ringfact=2, rings=4,
     Creates an Xradia-like star pattern on an array of shape `sh`.
 
     Works superb as test pattern in ptychography.
-    
+
     *requires scipy*
-        
+
     Parameters
     ----------
     sh : int, tuple
         Shape of requested array.
 
-    std: float 
-        "Resolution" of xradia star, i.e. standard deviation of the 
+    std: float
+        "Resolution" of xradia star, i.e. standard deviation of the
          error function used for smoothing the edges (in pixel).
-         
+
     spokes : int, optional
         Number of spokes.
-        
+
     minfeature : float, optional
         Spoke width at the smallest (inner) tip (in pixel).
-        
+
     ringfact : float
         Increase in feature size from ring to ring (factor). Determines
         position of the rings.
-        
+
     rings : int
         Number of rings with spokes.
-        
-    contrast : float 
+
+    contrast : float
         Minimum contrast, set to zero for a gradual increase of the profile
         from zero to 1, set to 1 for no gradient in profile.
-                  
+
     Fast : bool
         If set to False, the error function is evaluated at the edges.
         Preferred choice when using fft, as edges are less prone to
         antialiasing in this case. If set to True, simple boolean
-        comparison will be used instead to draw the edges and the 
+        comparison will be used instead to draw the edges and the
         result is later smoothed with a gaussian filter. Preferred choice
         for impatient users, as this choice is roughly a factor 2 faster
         for larger arrays
-        
+
     Examples
     --------
     >>> from ptypy.utils.scripts import xradia_star
@@ -434,23 +434,23 @@ def xradia_star(sh, spokes=48, std=0.5, minfeature=5, ringfact=2, rings=4,
     >>> ax = plt.subplot(133)
     >>> ax.imshow(X3, cmap='gray')
     >>> plt.show()
-    
+
     """
     from scipy.ndimage import gaussian_filter
     from scipy.special import erf
-    
+
     def step(x, a, std=0.5):
         if not Fast:
             return 0.5 * erf((x - a) / (std*2)) + 0.5
         else:
             return (x > a).astype(float)
-            
+
     def rect(x,a):
         return step(x, -a / 2., std) * step(-x, -a / 2., std)
-    
+
     def rectint(x, a, b):
         return step(x, a, std) * step(-x, -b, std)
-    
+
     sh = expect2(sh)
     ind = np.indices(sh)
     cen = (sh - 1) / 2.0
@@ -472,10 +472,10 @@ def xradia_star(sh, spokes=48, std=0.5, minfeature=5, ringfact=2, rings=4,
             break
         rin *= ringfact
         rlist.append((rin * (1 - 2 * np.sin(spokestep / 4.)), rin))
-        
+
     spokes = np.zeros(sh)
     contrast = np.min((np.abs(contrast), 1))
-    
+
     mn = min(spokeint)
     mx = max(spokeint)
     for a in spokeint:
@@ -484,7 +484,7 @@ def xradia_star(sh, spokes=48, std=0.5, minfeature=5, ringfact=2, rings=4,
                  - step(np.real(z * np.exp(-1j*(a - spokestep / 4))), 0))
         spokes += ((spoke * color + 0.5 * np.abs(spoke)) * (1 - contrast)
                    + contrast * np.abs(spoke))
-    
+
     spokes *= step(r, r0)
     spokes *= step(rlist[-1][0], r)
     for ii in range(len(rlist) - 1):
@@ -500,53 +500,53 @@ def mass_center(A, axes=None):
     """
     Calculates mass center of n-dimensional array `A`
     along tuple of axis `axes`.
-    
+
     Parameters
     ----------
     A : ndarray
         input array
-        
+
     axes : list, tuple
-        Sequence of axes that contribute to distributed mass. If 
+        Sequence of axes that contribute to distributed mass. If
         ``axes==None``, all axes are considered.
-        
+
     Returns
     -------
     mass : 1d array
         Center of mass in pixel for each `axis` selected.
     """
     A = np.asarray(A)
-    
+
     if axes is None:
         axes = tuple(range(1, A.ndim + 1))
     else:
         axes = tuple(np.array(axes) + 1)
-        
+
     return np.sum(A * np.indices(A.shape), axis=axes) / np.sum(A)
-    
+
 def radial_distribution(A, radii=None):
     """
     Returns radial mass distribution up to radii in `radii`.
-    
+
     Parameters
     ----------
     A : ndarray
         input array
-        
+
     radii : list, tuple
-        Sequence of radii to calculate enclosed mass. If `None`, 
+        Sequence of radii to calculate enclosed mass. If `None`,
         the sequence defaults to ``range(1, np.min(A.shape) / 2)``
-        
+
     Returns
     -------
     radii, masses : list
         Sequence of used `radii` and corresponding integrated mass
         `masses`. Sequences have the same length.
-    
+
     """
     if radii is None:
         radii = range(1, np.min(A.shape) / 2)
-       
+
     coords = np.indices(A.shape) - np.reshape(mass_center(A),
                                               (A.ndim,) + A.ndim * (1,))
 
@@ -559,39 +559,39 @@ def stxm_analysis(storage, probe=None):
     Performs a stxm analysis on a storage using the pods.
 
     This function is MPI compatible.
-    
+
     Parameters
     ----------
     storage : ptypy.core.Storage instance
         A :any:`Storage` instance to be analysed
-        
+
     probe : None, scalar or array
-           
+
         - If None, picks a probe from the first view's pod
         - If scalar, uses a Gaussian with probe as standard deviation
         - Else: attempts to use passed value directly as 2d-probe
-           
+
     Returns
     -------
-    trans : ndarray 
+    trans : ndarray
         Transmission of shape ``storage.shape``.
-        
+
     dpc_row : ndarray
-        Differential phase contrast along row-coordinates, i.e. vertical 
+        Differential phase contrast along row-coordinates, i.e. vertical
         direction (y-direction) of shape ``storage.shape``.
-        
+
     dpc_col : ndarray
-        Differential phase contrast along column-coordinates, i.e. 
+        Differential phase contrast along column-coordinates, i.e.
         horizontal direction (x-direction) of shape ``storage.shape``.
     """
     s = storage
-    
+
     # Prepare buffers
     trans = np.zeros_like(s.data)
     dpc_row = np.zeros_like(s.data)
     dpc_col = np.zeros_like(s.data)
     nrm = np.zeros_like(s.data) + 1e-10
-    
+
     t2 = 0.
     # Pick a single probe view for preparation purpose:
     v = s.views[0]
@@ -604,7 +604,7 @@ def stxm_analysis(storage, probe=None):
     else:
         pr = np.asarray(probe)
         assert (pr.shape == pp.shape[-2:]), 'stxm probe has not the same shape as a view to this storage'
-        
+
     for v in s.views:
         pod = v.pods.values()[0]
         if not pod.active:
@@ -623,7 +623,7 @@ def stxm_analysis(storage, probe=None):
         dpc_col[ss] += q[1] * v.psize[1] * pr * 2 * np.pi/pod.geometry.lz
         trans[ss] += np.sqrt(t) * pr
         nrm[ss] += pr
-        
+
     parallel.allreduce(trans)
     parallel.allreduce(dpc_row)
     parallel.allreduce(dpc_col)
@@ -631,7 +631,7 @@ def stxm_analysis(storage, probe=None):
     dpc_row /= nrm
     dpc_col /= nrm
     trans /= nrm * np.sqrt(t2)
-    
+
     return trans, dpc_row, dpc_col
 
 def stxm_init(storage, probe=None):
@@ -639,18 +639,18 @@ def stxm_init(storage, probe=None):
     Convenience script that performs a STXM analysis for storage
     `storage` given a probe array `probe` and stores result back
     in storage.
-    
+
     See also
     --------
     stxm_analysis
     """
     trans, dpc_row, dpc_col = stxm_analysis(storage,probe)
     storage.data = trans * np.exp(-1j*phase_from_dpc(dpc_row, dpc_col))
-    
+
 def load_from_ptyr(filename, what='probe', ID=None, layer=None):
     """
     Convenience script to extract data from ``*.ptyr``-file.
-    
+
     Parameters
     ----------
     filename : str
@@ -665,12 +665,12 @@ def load_from_ptyr(filename, what='probe', ID=None, layer=None):
     layer : int, optional
         If an integer, the data buffer of chosen storage gets sliced
         with `layer` for its first index.
-    
+
     Returns
     -------
     data : ndarray
         If `layer` is provided, that layer ``storage,data[layer]``
-        will be sliced from the 3d data buffer, else the whole buffer 
+        will be sliced from the 3d data buffer, else the whole buffer
         ``storage.data`` will be returned.
     """
     from .. import io
@@ -690,25 +690,25 @@ def load_from_ptyr(filename, what='probe', ID=None, layer=None):
             return storage['data']
         else:
             return storage['data'][layer]
-        
+
 def phase_from_dpc(dpc_row, dpc_col):
     """
     Implements fourier integration method for two differential quantities.
-    
+
     Assumes 2 arrays of N-dimensions which contain differential quantities
     in X and Y, i.e. the LAST two dimensions (-2 & -1) in this case.
-    
+
     Parameters
     ----------
     dpc_row, dpc_col: ndarray
         Differential information along 2nd last dimension
         and last dimension respectively. Must be of the same shape.
-    
+
     Returns
     -------
     out : ndarray
         Integrated array of same shape as `dpc_row` and `dpc_col`.
-        
+
     """
     py =- dpc_row
     px =- dpc_col
@@ -730,7 +730,7 @@ def phase_from_dpc(dpc_row, dpc_col):
     inv_qc = 1. / (qx + 1j*qy)
     inv_qc[..., 0, 0] = 0
     nf = np.fft.ifft2(np.fft.fft2(f) * inv_qc)
-    
+
     return np.real(nf[..., :sh[-2], :sh[-1]])
 
 _cxro_server = 'http://henke.lbl.gov'
@@ -748,16 +748,16 @@ def cxro_iref(formula, energy, density=-1, npts=100):
     ----------
     formula: str
         String representation of the Formula to use.
-        
+
     energy : float or (float, float)
         Either a single energy (in eV) or the minimum/maximum bounds.
-        
+
     density : None or float, optional
-        Density of the material [g/ccm]. If ``None`` or ``<0`` the 
+        Density of the material [g/ccm]. If ``None`` or ``<0`` the
         regular density at ambient temperatures is used.
-        
+
     npts : int, optional
-        Number of points between the min and max energies. 
+        Number of points between the min and max energies.
 
     Returns
     -------
@@ -773,7 +773,7 @@ def cxro_iref(formula, energy, density=-1, npts=100):
 
     if density is None or density < 0:
         density = -1
-        
+
     data = cxro_iref.cxro_query % {'formula': formula,
                                    'emin': emin,
                                    'emax': emax,
@@ -801,7 +801,7 @@ def cxro_iref(formula, energy, density=-1, npts=100):
         return dt[-1, 0], dt[-1, 1], dt[-1, 2]
     else:
         return dt[:, 0], dt[:, 1], dt[:, 2]
-        
+
 cxro_iref.cxro_server = _cxro_server
 cxro_iref.cxro_query = _cxro_POST_query
 

--- a/ptypy/utils/validator.py
+++ b/ptypy/utils/validator.py
@@ -2,8 +2,8 @@
 """\
 Parameter validation. This module parses the file
 ``resources/parameters_descriptions.csv`` to extract the parameter
-defaults for |ptypy|. It saves all parameters in the form of 
-a :py:class:`PDesc` object, which are flat listed in 
+defaults for |ptypy|. It saves all parameters in the form of
+a :py:class:`PDesc` object, which are flat listed in
 `parameter_descriptions` or in `entry_points_dct`, which only contains
 parameters with subparameters (children).
 
@@ -83,7 +83,7 @@ _copytypes = ['str','file']
 class PDesc(object):
     """
     Small class to store all attributes of a ptypy parameter
-    
+
     """
 
     def __init__(self, description, parent=None):
@@ -92,39 +92,39 @@ class PDesc(object):
         """
         #: Name of parameter
         self.name = description.get('name', '')
-        
+
         #: Parent parameter (:py:class:`PDesc` type) if it has one.
         self.parent = parent
-            
+
         if parent is not None:
             parent.children[self.name] = self
-            
+
         #: Type can be a comma-separated list of types
         self.type = description.get('type', None)
-        
+
         if 'param' in self.type.lower() or 'dict' in self.type.lower():
             self.children = {}
             entry_points_dct[self.entry_point] = self
         else:
             self.children = None
-            
+
         if self.type is not None:
             self.type = [_typemap[x.strip()] if x.strip() in _typemap else x.strip() for x in self.type.split(',')]
-        
-        
+
+
         self.default = None
         """ Default value can be any type. None if unknown. """
-        
+
         self.set_default(description.get('default', ''))
-        
+
         # Static is 'TRUE' or 'FALSE'
         self.static = (description.get('static', 'TRUE') == 'TRUE')
-        
+
         #: Lower limit of parameter, None if unknown
         self.lowlim = None
         #: Upper limit of parameter, None if unknown
         self.uplim = None
-        
+
         ll = description.get('lowlim', None)
         ul = description.get('uplim', None)
         if 'int' in self.type:
@@ -133,7 +133,7 @@ class PDesc(object):
         else:
             self.lowlim = float(ll) if ll else None
             self.uplim = float(ul) if ul else None
-            
+
         # choices is an evaluable list
         c =  description.get('choices', '')
         #print c, self.name
@@ -144,27 +144,27 @@ class PDesc(object):
                 c = eval(c.strip())
             except SyntaxError('Evaluating `choices` %s for parameter %s failed' %(str(c),self.name)):
                 c = None
-        
+
         #: If parameter is a list of choices, these are listed here.
         self.choices = c
 
-        
+
         # Docs are strings
-        
+
         #: Short descriptive string of parameter
         self.shortdoc = description.get('shortdoc', '')
-        
+
         #: Longer documentation, may contain *sphinx* inline markup.
         self.longdoc = description.get('longdoc', '')
 
         # User level (for gui stuff) is an int
         ul = description.get('userlevel', 1)
-        
+
         self.userlevel = int(ul) if ul else None
-        """User level, a higher level means a parameter that is less 
+        """User level, a higher level means a parameter that is less
         likely to vary or harder to understand.
         """
-        
+
         # Validity is a string (the name of another parameter)
         # FIXME: this is not used currently
         self.validity = description.get('validity', '')
@@ -177,7 +177,7 @@ class PDesc(object):
             return ''
         else:
             return '.'.join([self.parent.entry_point, self.name])
-    
+
     @property
     def is_evaluable(self):
         for t in self.type:
@@ -185,16 +185,16 @@ class PDesc(object):
                 return True
                 break
         return False
-        
+
     def set_default(self,default='', check=False):
         """
         Sets default (str) and derives value (python type)
         """
         default = str(default)
-        
+
         # this destroys empty strings
         self.default = default if default else None
-        
+
         if self.default is None:
             out = None
         # should be only strings now
@@ -208,7 +208,7 @@ class PDesc(object):
             out = eval(self.default)
         else:
             out = self.default
-        
+
         self.value = out
         return out
     """
@@ -228,10 +228,10 @@ class PDesc(object):
             out = eval(self.default)
         else:
             out = self.default
-            
+
         return out
     """
-    
+
     def check(self, pars, walk):
         """
         Check that input parameter pars is consistent with parameter description.
@@ -328,22 +328,22 @@ def make_sub_default(entry_point, depth=1):
     """
     Creates a default parameter structure, from the loaded parameter
     descriptions in this module
-    
+
     Parameters
     ----------
     entry_point : str
         The node in the default parameter file
-        
+
     depth : int
         The depth in the structure to which all sub nodes are expanded
-        All nodes beyond depth will be returned as empty :any:`Param` 
+        All nodes beyond depth will be returned as empty :any:`Param`
         structure.
-        
+
     Returns
     -------
     pars : Param
         A parameter branch.
-    
+
     Examples
     --------
     >>> from ptypy.utils import validator
@@ -359,32 +359,32 @@ def make_sub_default(entry_point, depth=1):
         else:
             out[name] = child.value
     return out
-    
+
 def validate(pars, entry_point, walk=True, raisecodes=[CODES.FAIL, CODES.INVALID]):
     """
-    Check that the parameter structure `pars` matches the documented 
+    Check that the parameter structure `pars` matches the documented
     constraints at the given entry_point.
 
-    The function raises a RuntimeError if one of the code in the list 
-    `raisecodes` has been found. If raisecode is empty, the function will 
+    The function raises a RuntimeError if one of the code in the list
+    `raisecodes` has been found. If raisecode is empty, the function will
     always return successfully but problems will be logged using logger.
 
     Parameters
     ----------
     pars : Param
         A parameter set to validate
-        
+
     entry_point : str
         The node in the parameter structure to match to.
-    
+
     walk : bool
         If ``True`` (*default*), navigate sub-parameters.
-    
+
     raisecodes: list
         List of codes that will raise a RuntimeError.
     """
     from ptypy.utils.verbose import logger
-    
+
     pdesc = parameter_descriptions[entry_point]
     d = pdesc.check(pars, walk=walk)
     do_raise = False
@@ -398,17 +398,17 @@ def validate(pars, entry_point, walk=True, raisecodes=[CODES.FAIL, CODES.INVALID
 def create_default_template(filename=None,user_level=0,doc_level=2):
     """
     Creates a (descriptive) template for ptypy.
-    
+
     Parameters
     ----------
     filename : str
         python file (.py) to generate, will be overriden if it exists
-    
+
     user_level : int
         Filter parameters to display on those with less/equal user level
-    
+
     doc_level : int
-        - if ``0``, no comments. 
+        - if ``0``, no comments.
         - if ``1``, *short_doc* as comment in script
         - if ``>2``, *long_doc* and *short_doc* as comment in script
     """
@@ -433,10 +433,10 @@ def create_default_template(filename=None,user_level=0,doc_level=2):
             else:
                 out.append(line)
         if out:
-            return '# '+'\n# '.join(out)+'\n' 
+            return '# '+'\n# '.join(out)+'\n'
         else:
             return ''
-            
+
     if filename is None:
         f = open('ptypy_template.py','w')
     else:
@@ -472,33 +472,33 @@ def create_default_template(filename=None,user_level=0,doc_level=2):
         if doc_level > 1:
             f.write(_format_longdoc(pd.longdoc))
         f.write('p'+entry+ ' = ' + value+'\n')
-        
+
     f.write('\n\nPtycho(p,level=5)\n')
     f.close()
 
 def _add2argparser(parser=None, entry_point='',root=None,\
                         excludes=('scans','engines'), mode = 'add',group=None):
-    
+
     sep = '.'
-    
+
     pd = parameter_descriptions[entry_point]
-    
+
     has_children = hasattr(pd,'children') and pd.children is not None
-    
+
     if root is None:
-        root = pd.entry_point if has_children else pd.parent.entry_point 
-        
+        root = pd.entry_point if has_children else pd.parent.entry_point
+
     assert root in entry_points_dct.keys()
-    
+
     if excludes is not None:
         # remove leading '.'
         lexcludes = [e.strip()[1:] for e in excludes if e.strip().startswith(sep) ]
         loc_exclude = [e.split(sep)[0] for e in lexcludes if len(e.split())==1 ]
     else:
         excludes =['baguette'] #:)
-    
+
     if pd.name in excludes: return
-    
+
     if parser is None:
         from argparse import ArgumentParser
         description = """
@@ -506,15 +506,15 @@ def _add2argparser(parser=None, entry_point='',root=None,\
         Doc: %s
         """ % (pd.name, pd.shortdoc)
         parser = ArgumentParser(description=description)
-    
+
     # overload the parser
-    if not hasattr(parser,'_ptypy_translator'): 
+    if not hasattr(parser,'_ptypy_translator'):
         parser._ptypy_translator={}
-    
-    
+
+
     # convert to parser variable
     name = pd.entry_point.replace(root,'',1).partition(sep)[2].replace('.','-')
-    
+
     if has_children:
         entry = pd.entry_point
         if name !='':
@@ -526,11 +526,11 @@ def _add2argparser(parser=None, entry_point='',root=None,\
         for key,child in pd.children.iteritems():
             _add2argparser(parser, entry_point=child.entry_point,root=root,\
              excludes=excludes,mode = 'add',group=ngroup)
-                 
+
     if name=='': return parser
-    
+
     parse = parser if group is None else group
-    
+
     # this should be part of PDesc I guess.
     typ = None
     for t in pd.type:
@@ -543,31 +543,31 @@ def _add2argparser(parser=None, entry_point='',root=None,\
     if typ is None:
         u.verbose.logger.debug('Failed evaluate type strings %s of parameter %s in python' % (str(pd.type),name))
         return parser
-        
+
     if type(typ) is not type:
         u.verbose.logger.debug('Type %s of parameter %s is not python type' % (str(typ),name))
         return parser
-    
+
     elif typ is bool:
         flag = '--no-'+name if pd.value else '--'+name
         action='store_false' if pd.value else 'store_true'
-        parse.add_argument(flag, dest=name, action=action, 
+        parse.add_argument(flag, dest=name, action=action,
                          help=pd.shortdoc )
     else:
         d = pd.default
         defstr =  d.replace('%(','%%(') if str(d)==d else str(d)
-        parse.add_argument('--'+name, dest=name, type=typ, default = pd.value, choices=pd.choices, 
-                         help=pd.shortdoc +' (default=%s)' % defstr)            
+        parse.add_argument('--'+name, dest=name, type=typ, default = pd.value, choices=pd.choices,
+                         help=pd.shortdoc +' (default=%s)' % defstr)
 
     parser._ptypy_translator[name] = pd
-        
+
     return parser
-    
+
 if __name__ =='__main__':
     from ptypy import utils as u
-    
-    
-    
+
+
+
     parser = _add2argparser(entry_point='.scan.illumination')
     parser.parse_args()
-    
+

--- a/ptypy/utils/verbose.py
+++ b/ptypy/utils/verbose.py
@@ -40,7 +40,7 @@ FILE_FORMAT = {logging.ERROR : '%(asctime)s ERROR %(name)s - %(message)s',
                   logging.INFO : '%(asctime)s %(message)s',
                   INSPECT : '%(asctime)s INSPECT %(message)s',
                   logging.DEBUG : '%(asctime)s DEBUG %(pathname)s [%(lineno)d] - %(message)s'}
-            
+
 # How many characters per line in console
 LINEMAX = 80
 
@@ -52,7 +52,7 @@ LINEMAX = 80
 #    self._factory_log(*args, extra={'MPI':MPIswitch}, **kwargs)
 #
 #logging.Logger._factory_log = logging.Logger._log
-#logging.Logger._log = _MPIlog 
+#logging.Logger._log = _MPIlog
 
 # Logging filter
 class MPIFilter(object):
@@ -65,7 +65,7 @@ class MPIFilter(object):
         This behavior can be altered with allprocesses=True.
         """
         self.allprocesses = allprocesses
-        
+
     def filter(self, record):
         """
         Filter method, as expected by the logging API.
@@ -115,15 +115,15 @@ logger.addFilter(consolefilter)
 
 level_from_verbosity = {0:logging.CRITICAL, 1:logging.ERROR, 2:logging.WARN, 3:logging.INFO, 4: INSPECT, 5:logging.DEBUG}
 level_from_string = {'CRITICAL':logging.CRITICAL, 'ERROR':logging.ERROR, 'WARN':logging.WARN, 'WARNING':logging.WARN, 'INFO':logging.INFO, 'INSPECT': INSPECT, 'DEBUG':logging.DEBUG}
-vlevel_from_logging = dict([(v,k) for k,v in level_from_verbosity.items()]) 
-slevel_from_logging = dict([(v,k) for k,v in level_from_string.items()]) 
+vlevel_from_logging = dict([(v,k) for k,v in level_from_verbosity.items()])
+slevel_from_logging = dict([(v,k) for k,v in level_from_string.items()])
 
 def log(level,msg,parallel=False):
     if not parallel:
         logger.log(level_from_verbosity[level], msg)
     else:
         logger.log(level_from_verbosity[level], msg,extra={'allprocesses':True})
-        
+
 def set_level(level):
     """
     Set verbosity level. Kept here for backward compatibility
@@ -143,7 +143,7 @@ def get_level(num_or_string='num'):
         return vlevel_from_logging[logger.level]
     else:
         return slevel_from_logging[logger.level]
-        
+
 # Formatting helper
 def _(label, value):
     return '%-25s%s' % (label + ':', str(value))
@@ -167,43 +167,43 @@ def headerline(info='',align = 'c',fill='-'):
             right = 4
             left = empty-right
     return fill*left+info+fill*right
-    
+
 def report(thing,depth=4,noheader=False):
     """
     no protection for circular references
     """
     import time
     import numpy as np
-    
+
     indent = report.indent
     level = report.level
     maxchar = report.maxchar
     hn = report.headernewline
     star = report.asterisk
-    
+
     header = '\n---- Process #%d ---- ' % parallel.rank + time.asctime() + ' -----\n'
 
     def _(label,level,obj):
-        pre = " "*indent*level + star + ' ' 
+        pre = " "*indent*level + star + ' '
         extra = str(type(obj)).split("'")[1]
         pre+=str(label) if label is not None else "id"+np.base_repr(id(obj),base=32)
         if len(pre)>=25:
             pre = pre[:21] + '... '
         return "%-25s:" % pre, extra
-        
+
     def _format_dict(label, level, obj):
-        header,extra = _(label, level, obj) 
+        header,extra = _(label, level, obj)
         header+= ' %s(%d)' % (extra,len(obj)) + hn
         if level <= depth:
             #level +=1
             for k,v in obj.iteritems():
                 header += _format(k,level+1,v)
         return header
-    
+
     def _format_iterable(label, level, lst):
         l = len(lst)
         header,extra = _(label, level, lst)
-        header+= ' %s(%d)' % (extra,l) 
+        header+= ' %s(%d)' % (extra,l)
         string = str(lst)
         if len(string) <= maxchar-25 or level>=depth:
             return header +'= '+ string + hn
@@ -215,7 +215,7 @@ def report(thing,depth=4,noheader=False):
             return header
         else:
             pass
-    
+
     def _format_other(label, level, obj):
         header,extra = _(label, level, obj)
         if np.isscalar(obj):
@@ -223,7 +223,7 @@ def report(thing,depth=4,noheader=False):
         else:
             header += ' ' +extra+' = '+str(obj)
         return header[:maxchar]+'\n'
-         
+
     def _format_numpy(key, level,a):
         header,extra = _(key, level, a)
         if len(a) < 5 and a.ndim == 1:
@@ -231,7 +231,7 @@ def report(thing,depth=4,noheader=False):
         else:
             stringout = header + ' [' + (('%dx'*(a.ndim-1) + '%d') % a.shape) + ' ' + str(a.dtype) + ' array]\n'
         return stringout
-        
+
     def _format_None(key,level, obj):
         return _(key, level, obj)[0] + ' None\n'
 
@@ -249,7 +249,7 @@ def report(thing,depth=4,noheader=False):
         else:
             stringout = _format_other(key,level, obj)
         return stringout
-    
+
     if noheader:
         return _format(None,0,thing)
     else:

--- a/resources/__init__.py
+++ b/resources/__init__.py
@@ -7,5 +7,5 @@ def flowers(shape=None):
         ish = np.array(im.shape[:2])
         d = ish-sh
         im = u.crop_pad(im,d,axes=[0,1],cen=None,fillpar=0.0,filltype='mirror')
-        
+
     return im

--- a/scripts/ptypy.inspect
+++ b/scripts/ptypy.inspect
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python2
 
 import sys
 import argparse

--- a/scripts/ptypy.new
+++ b/scripts/ptypy.new
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python2
 
 import sys
 import argparse

--- a/scripts/ptypy.plot
+++ b/scripts/ptypy.plot
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python2
 
 import sys
 import argparse

--- a/scripts/ptypy.plotclient
+++ b/scripts/ptypy.plotclient
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python2
 
 import sys
 import argparse

--- a/scripts/ptypy.plotclient
+++ b/scripts/ptypy.plotclient
@@ -14,23 +14,23 @@ parser.add_argument('-d','--dir', dest='directory', type=str,default='./' ,
 args = parser.parse_args()
 for key,pd in parser._ptypy_translator.items():
     pd.set_default(getattr(args,key,pd.default))
-                   
+
 plot_pars = u.validator.make_sub_default('.io.autoplot')
 plot_pars['home'] = getattr(args,'directory',pd.value)
 client_pars = u.validator.make_sub_default('.io.interaction')
 """
 parser = argparse.ArgumentParser(description='Create a ZeroMQ plotting client.')
-parser.add_argument('-l', dest='layout', type=str, 
+parser.add_argument('-l', dest='layout', type=str,
                    help='layout of the plotter')
 parser.add_argument('--dump', dest='dump', action='store_true',
                    help='dump .png images')
 parser.add_argument('--movie', dest='dump', action='store_false',
                    help='create movie when reconstruction is finished')
-parser.add_argument('-i', dest='interval', type=int, 
+parser.add_argument('-i', dest='interval', type=int,
                    help='minimum plotting interval')
-parser.add_argument('-d', dest='directory', type=str, 
+parser.add_argument('-d', dest='directory', type=str,
                    help='image dump directory')
-parser.add_argument('-a', dest='address', type=str, 
+parser.add_argument('-a', dest='address', type=str,
                    help='address of reconstruction server')
 """
 #args = parser.parse_args()

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     name = 'Python Ptychography toolbox',
     version = VERSION,
     author = 'Pierre Thibault, Bjoern Enders, Martin Dierolf and others',
-    description = 'Ptychographic reconstruction toolbox', 
+    description = 'Ptychographic reconstruction toolbox',
     long_description = file('README.rst','r').read(),
     #install_requires = ['numpy>=1.8',\
                         #'h5py>=2.2',\

--- a/templates/make_sample_ptyd.py
+++ b/templates/make_sample_ptyd.py
@@ -16,14 +16,14 @@ data.dfile = 'sample.ptyd'
 data.shape = 128
 data.num_frames = 100
 data.save = 'append'
-data.label=None 
+data.label=None
 data.psize=None
 data.energy=None
 data.center=None
 data.distance = None
-data.auto_center = None 
-data.rebin = None  
-data.orientation = None  
+data.auto_center = None
+data.rebin = None
+data.orientation = None
 
 # create PtyScan instance
 MF = ptypy.core.data.MoonFlowerScan(data)

--- a/templates/minimal_load_and_run.py
+++ b/templates/minimal_load_and_run.py
@@ -1,5 +1,5 @@
 """
-This script is a test for ptychographic reconstruction after an 
+This script is a test for ptychographic reconstruction after an
 experiment has been carried out and the data is available in ptypy's
 data file format in "/tmp/ptypy/sample.ptyd"
 """
@@ -10,7 +10,7 @@ from ptypy import utils as u
 p = u.Param()
 p.verbose_level = 3
 p.io = u.Param()
-p.io.home = "/tmp/ptypy/"  
+p.io.home = "/tmp/ptypy/"
 p.autosave = None
 
 p.scans = u.Param()
@@ -26,9 +26,9 @@ p.engine.common = u.Param()
 # Total number of iterations
 p.engine.common.numiter = 100
 # Number of iterations to be executed in one go
-p.engine.common.numiter_contiguous = 1           
+p.engine.common.numiter_contiguous = 1
 # Fraction of valid probe area (circular) in probe frame
-p.engine.common.probe_support = None  
+p.engine.common.probe_support = None
 # Number of iterations before probe update starts
 p.engine.common.probe_update_start = 2
 # Clip object amplitude into this intrervall
@@ -36,26 +36,26 @@ p.engine.common.clip_object = None   # [0,1]
 
 ## DM default parameters
 p.engine.DM = u.Param()
-p.engine.DM.name = "DM"   
+p.engine.DM.name = "DM"
 # HIO parameter
-p.engine.DM.alpha = 1                            
+p.engine.DM.alpha = 1
 # Probe fraction kept from iteration to iteration
-p.engine.DM.probe_inertia = 0.01             
+p.engine.DM.probe_inertia = 0.01
 # Object fraction kept from iteration to iteration
-p.engine.DM.object_inertia = 0.1             
+p.engine.DM.object_inertia = 0.1
 # If False: update object before probe
-p.engine.DM.update_object_first = True     
+p.engine.DM.update_object_first = True
 # Gaussian smoothing (FWHM, pixel units) of object
 p.engine.DM.obj_smooth_std = 10
 # Loop the overlap constraint until probe changes lesser than this fraction
-p.engine.DM.overlap_converge_factor = 0.5  
+p.engine.DM.overlap_converge_factor = 0.5
 # Maximum iterations to be spent inoverlap constraint
-p.engine.DM.overlap_max_iterations = 100  
-# If rms of model vs diffraction data is smaller than this fraction, 
+p.engine.DM.overlap_max_iterations = 100
+# If rms of model vs diffraction data is smaller than this fraction,
 # Fourier constraint is considered fullfilled
-p.engine.DM.fourier_relax_factor = 0.05    
+p.engine.DM.fourier_relax_factor = 0.05
 
-p.engines = u.Param()              
+p.engines = u.Param()
 p.engines.engine00 = u.Param()
 p.engines.engine00.name = 'DM'
 p.engines.engine00.numiter = 30

--- a/templates/minimal_prep_and_run.py
+++ b/templates/minimal_prep_and_run.py
@@ -1,6 +1,6 @@
 """
 This script is a test for ptychographic reconstruction in the absence
-of actual data. It uses the test Scan class 
+of actual data. It uses the test Scan class
 `ptypy.core.data.MoonFlowerScan` to provide "data".
 """
 import ptypy
@@ -9,11 +9,11 @@ from ptypy import utils as u
 p = u.Param()
 
 # for verbose output
-p.verbose_level = 3                              
+p.verbose_level = 3
 
 # set home path
 p.io = u.Param()
-p.io.home = "/tmp/ptypy/"  
+p.io.home = "/tmp/ptypy/"
 p.io.autosave = None
 
 # max 100 frames (128x128px) of diffraction data
@@ -28,14 +28,14 @@ p.scans.MF.data.save = None
 ## special recipe paramters for this scan ##
 p.scans.MF.data.recipe = u.Param()
 # position distance in fraction of illumination frame
-p.scans.MF.data.recipe.density = 0.2 
+p.scans.MF.data.recipe.density = 0.2
 # total number of photon in empty beam
 p.scans.MF.data.recipe.photons = 1e8
 # Gaussian FWHM of possible detector blurring
 p.scans.MF.data.recipe.psf = 0.
 
 # attach a reconstrucion engine
-p.engines = u.Param()                              
+p.engines = u.Param()
 p.engines.engine00 = u.Param()
 p.engines.engine00.name = 'DM'
 p.engines.engine00.numiter = 30

--- a/templates/on_the_fly_ptyd.py
+++ b/templates/on_the_fly_ptyd.py
@@ -2,8 +2,8 @@
 This script creates a sample *.ptyd data file using the built-in
 test Scan `ptypy.core.data.MoonFlowerScan`.
 
-Instead of a monolithic file, this process while create data chunks in 
-separate and link to the main .ptyd file. The delay of 3 seconds 
+Instead of a monolithic file, this process while create data chunks in
+separate and link to the main .ptyd file. The delay of 3 seconds
 corresponds to a 0.3 seconds dwell time.
 
 Tested only as single process.
@@ -23,14 +23,14 @@ data.shape = 256
 data.num_frames = 200
 data.min_frames = 10
 data.save = 'link'
-data.label=None 
+data.label=None
 data.psize=172e-6
 data.energy= 6.2
 data.center='fftshift'
 data.distance = 7
-data.auto_center = None 
-data.rebin = None  
-data.orientation = None  
+data.auto_center = None
+data.rebin = None
+data.orientation = None
 
 # create PtyScan instance
 MF = ptypy.core.data.MoonFlowerScan(data)

--- a/templates/on_the_fly_rec.py
+++ b/templates/on_the_fly_rec.py
@@ -1,9 +1,9 @@
 """
-This script is a test for ptychographic reconstruction after an 
+This script is a test for ptychographic reconstruction after an
 experiment has been carried out and the data is available in ptypy's
 data file format in "/tmp/ptypy/sample.ptyd"
 
-This file is intended to be used in conjuction with 
+This file is intended to be used in conjuction with
 "on_the_fly_ptyd.py" although the script is absolutely generic.
 
 Tested to work with mpi
@@ -15,7 +15,7 @@ from ptypy import utils as u
 p = u.Param()
 p.verbose_level = 3
 p.io = u.Param()
-p.io.home = "/tmp/ptypy/"  
+p.io.home = "/tmp/ptypy/"
 p.io.autosave = None
 p.io.autoplot = u.Param()
 p.io.autoplot.layout = 'minimal'
@@ -33,9 +33,9 @@ p.engine.common = u.Param()
 # Total number of iterations
 p.engine.common.numiter = 100
 # Number of iterations to be executed in one go
-p.engine.common.numiter_contiguous = 2           
+p.engine.common.numiter_contiguous = 2
 # Fraction of valid probe area (circular) in probe frame
-p.engine.common.probe_support = None  
+p.engine.common.probe_support = None
 # Number of iterations before probe update starts
 p.engine.common.probe_update_start = 2
 # Clip object amplitude into this intrervall
@@ -43,26 +43,26 @@ p.engine.common.clip_object = None   # [0,1]
 
 ## DM default parameters
 p.engine.DM = u.Param()
-p.engine.DM.name = "DM"   
+p.engine.DM.name = "DM"
 # HIO parameter
-p.engine.DM.alpha = 1                            
+p.engine.DM.alpha = 1
 # Probe fraction kept from iteration to iteration
-p.engine.DM.probe_inertia = 0.01             
+p.engine.DM.probe_inertia = 0.01
 # Object fraction kept from iteration to iteration
-p.engine.DM.object_inertia = 0.1             
+p.engine.DM.object_inertia = 0.1
 # If False: update object before probe
-p.engine.DM.update_object_first = True     
+p.engine.DM.update_object_first = True
 # Gaussian smoothing (FWHM, pixel units) of object
 p.engine.DM.obj_smooth_std = None
 # Loop the overlap constraint until probe changes lesser than this fraction
-p.engine.DM.overlap_converge_factor = 0.5  
+p.engine.DM.overlap_converge_factor = 0.5
 # Maximum iterations to be spent inoverlap constraint
-p.engine.DM.overlap_max_iterations = 100  
-# If rms of model vs diffraction data is smaller than this fraction, 
+p.engine.DM.overlap_max_iterations = 100
+# If rms of model vs diffraction data is smaller than this fraction,
 # Fourier constraint is considered fullfilled
-p.engine.DM.fourier_relax_factor = 0.05    
+p.engine.DM.fourier_relax_factor = 0.05
 
-p.engines = u.Param()              
+p.engines = u.Param()
 p.engines.engine00 = u.Param()
 p.engines.engine00.name = 'DM'
 p.engines.engine00.numiter = 100

--- a/templates/pars_few_alldoc.py
+++ b/templates/pars_few_alldoc.py
@@ -42,7 +42,7 @@ p.io.interaction.active = True
 
 ## (16) Plotting client parameters
 # In script you may set this parameter to ``None`` or ``False`` for no automatic plotting.
-# 
+#
 p.io.autoplot = u.Param()
 
 ## (23) Scan parameters
@@ -86,8 +86,8 @@ p.scan.data.energy = None
 p.scan.data.num_frames = None
 
 ## (42) Determine if center in data is calculated automatically
-# - ``False``, no automatic centering 
-#  - ``None``, only if :py:data:`center` is ``None`` 
+# - ``False``, no automatic centering
+#  - ``None``, only if :py:data:`center` is ``None``
 #  - ``True``, it will be enforced
 p.scan.data.auto_center = None
 
@@ -100,7 +100,7 @@ p.scan.sharing = u.Param()
 
 ## (54) Physical parameters
 # All distances are in meters. Other units are specified in the documentation strings.
-# 
+#
 p.scan.geometry = u.Param()
 
 ## (55) Energy (in keV)
@@ -216,7 +216,7 @@ p.scan.illumination.diversity = u.Param()
 ## (94) Initial object modelization parameters
 # In script, you may pass a numpy.array here directly as the model. This array will be passed
 # to the storage instance with no checking whatsoever. Used in `~ptypy.core.sample`
-# 
+#
 p.scan.sample = u.Param()
 
 ## (95) Type of initial object model
@@ -228,7 +228,7 @@ p.scan.sample = u.Param()
 #  - *<template>* : one of the templates in sample module
 # In script, you may pass a numpy.array here directly as the model. This array will be processed
 # according to `process` in order to *simulate* a sample from e.g. a thickness profile.
-# 
+#
 p.scan.sample.model = None
 
 ## (96) Default fill value
@@ -259,7 +259,7 @@ p.scan.coherence.num_object_modes = 1
 
 ## (121) Param container for instances of `scan` parameters
 # If not specified otherwise, entries in *scans* will use parameter defaults from :py:data:`.scan`
-# 
+#
 p.scans = u.Param()
 
 ## (122) Default first scans entry

--- a/templates/ptypy_cSAXS_PseudoBone_6p2keV.py
+++ b/templates/ptypy_cSAXS_PseudoBone_6p2keV.py
@@ -6,29 +6,29 @@ import numpy as np
 p = u.Param()
 
 ### PTYCHO PARAMETERS
-p.verbose_level = 3                  
-p.data_type = "single"                            
+p.verbose_level = 3
+p.data_type = "single"
 p.run = None
 p.io = u.Param()
-p.io.home = "/tmp/ptypy/"             
+p.io.home = "/tmp/ptypy/"
 p.io.run = None
 p.io.autosave = None
 p.io.autoplot = False
 
 p.scan = u.Param()
 p.scan.geometry = u.Param()
-p.scan.geometry.energy = 6.2        
-p.scan.geometry.lam = None    
-p.scan.geometry.distance = 7    
-p.scan.geometry.psize = 172e-6       
-p.scan.geometry.shape = 256          
-p.scan.geometry.propagation = "farfield"     
+p.scan.geometry.energy = 6.2
+p.scan.geometry.lam = None
+p.scan.geometry.distance = 7
+p.scan.geometry.psize = 172e-6
+p.scan.geometry.shape = 256
+p.scan.geometry.propagation = "farfield"
 
 p.scan.illumination = u.Param()
 p.scan.illumination.model = None
-p.scan.illumination.aperture = u.Param() 
-p.scan.illumination.propagation = None 
-p.scan.illumination.diversity = None 
+p.scan.illumination.aperture = u.Param()
+p.scan.illumination.propagation = None
+p.scan.illumination.diversity = None
 
 p.scan.sample = u.Param()
 p.scan.sample.model = 'stxm'
@@ -36,26 +36,26 @@ p.scan.sample.process = None
 p.scan.sample.diversity = None
 
 p.scan.coherence = u.Param()
-p.scan.coherence.Nprobe_modes = 1               
-p.scan.coherence.Nobject_modes = 1               
-p.scan.coherence.energies = [1.0]                
+p.scan.coherence.Nprobe_modes = 1
+p.scan.coherence.Nobject_modes = 1
+p.scan.coherence.energies = [1.0]
 
 p.scan.sharing = u.Param()
-p.scan.sharing.object_shared_with = None 
-p.scan.sharing.object_share_power = 1  
-p.scan.sharing.probe_shared_with = None 
-p.scan.sharing.probe_share_power = 1      
+p.scan.sharing.object_shared_with = None
+p.scan.sharing.object_share_power = 1
+p.scan.sharing.probe_shared_with = None
+p.scan.sharing.probe_share_power = 1
 
 sim = u.Param()
 sim.xy = u.Param()
-sim.xy.model = "round"                
-sim.xy.spacing = 1e-6                
-sim.xy.steps = 10        
-sim.xy.extent = 10e-6      
+sim.xy.model = "round"
+sim.xy.spacing = 1e-6
+sim.xy.steps = 10
+sim.xy.extent = 10e-6
 
 sim.illumination = u.Param()
 sim.illumination.model = None
-sim.illumination.photons = 1e8       
+sim.illumination.photons = 1e8
 sim.illumination.aperture = u.Param()
 sim.illumination.aperture.diffuser = None
 sim.illumination.aperture.form = "circ"
@@ -63,7 +63,7 @@ sim.illumination.aperture.size = 2.5e-6
 sim.illumination.aperture.edge = 1
 sim.illumination.aperture.central_stop = None
 sim.illumination.propagation = u.Param()
-sim.illumination.propagation.focussed = None 
+sim.illumination.propagation.focussed = None
 sim.illumination.propagation.parallel = 0.004
 sim.illumination.propagation.spot_size = None
 
@@ -72,14 +72,14 @@ sim.sample = u.Param()
 from ptypy.resources import tree_obj
 sim.sample.model = tree_obj()
 sim.sample.process = u.Param()
-sim.sample.process.offset = (100,400)                    
-sim.sample.process.zoom = 1.0                         
-sim.sample.process.formula = "Ca"                     
-sim.sample.process.density = 1.5                     
-sim.sample.process.thickness = 20e-6  
-sim.sample.process.ref_index = None 
-sim.sample.process.smoothing = None  
-sim.sample.fill = 1.0+0.j 
+sim.sample.process.offset = (100,400)
+sim.sample.process.zoom = 1.0
+sim.sample.process.formula = "Ca"
+sim.sample.process.density = 1.5
+sim.sample.process.thickness = 20e-6
+sim.sample.process.ref_index = None
+sim.sample.process.smoothing = None
+sim.sample.fill = 1.0+0.j
 
 sim.verbose_level = 1
 sim.plot = False
@@ -87,7 +87,7 @@ sim.plot = False
 p.scans = u.Param()
 p.scans.CircSim = u.Param()
 p.scans.CircSim.data=u.Param()
-p.scans.CircSim.data.source = 'sim' 
+p.scans.CircSim.data.source = 'sim'
 p.scans.CircSim.data.recipe = sim.copy(depth=4)
 p.scans.CircSim.data.recipe.illumination.aperture.form = "circ"
 p.scans.CircSim.data.save = None
@@ -95,7 +95,7 @@ p.scans.CircSim.data.save = None
 p.scans.RectSim = u.Param()
 p.scans.RectSim.sharing= u.Param(object_share_with = 'CircSim')
 p.scans.RectSim.data=u.Param()
-p.scans.RectSim.data.source = 'sim' 
+p.scans.RectSim.data.source = 'sim'
 p.scans.RectSim.data.recipe = sim.copy(depth=4)
 p.scans.RectSim.data.recipe.illumination.aperture.form = "rect"
 p.scans.RectSim.data.save = None
@@ -103,26 +103,26 @@ p.scans.RectSim.data.save = None
 
 p.engine = u.Param()
 p.engine.common = u.Param()
-p.engine.common.numiter = 100     
-p.engine.common.numiter_contiguous = 1  
-p.engine.common.probe_support = 0.7        
-p.engine.common.probe_inertia = 0.01   
-p.engine.common.object_inertia = 0.1     
-p.engine.common.obj_smooth_std = 20   
-p.engine.common.clip_object = None    
-p.engine.common.probe_update_start = 2        
+p.engine.common.numiter = 100
+p.engine.common.numiter_contiguous = 1
+p.engine.common.probe_support = 0.7
+p.engine.common.probe_inertia = 0.01
+p.engine.common.object_inertia = 0.1
+p.engine.common.obj_smooth_std = 20
+p.engine.common.clip_object = None
+p.engine.common.probe_update_start = 2
 
 p.engine.DM = u.Param()
-p.engine.DM.name = "DM"                    
-p.engine.DM.alpha = 1                       
-p.engine.DM.update_object_first = True      
-p.engine.DM.overlap_converge_factor = 0.05      
-p.engine.DM.overlap_max_iterations = 100    
-p.engine.DM.fourier_relax_factor = 0.1   
+p.engine.DM.name = "DM"
+p.engine.DM.alpha = 1
+p.engine.DM.update_object_first = True
+p.engine.DM.overlap_converge_factor = 0.05
+p.engine.DM.overlap_max_iterations = 100
+p.engine.DM.fourier_relax_factor = 0.1
 
 p.engine.ML = u.Param()
 
-p.engines = u.Param()                        
+p.engines = u.Param()
 p.engines.engine00 = u.Param()
 p.engines.engine00.name = 'DM'
 p.engines.engine00.numiter = 50

--- a/templates/ptypy_i13_AuStar_nearfield_9p7keV.py
+++ b/templates/ptypy_i13_AuStar_nearfield_9p7keV.py
@@ -6,75 +6,75 @@ import numpy as np
 p = u.Param()
 
 ### PTYCHO PARAMETERS
-p.verbose_level = 3   
+p.verbose_level = 3
 
-p.data_type = "single"      
+p.data_type = "single"
 p.run = None
 p.io = u.Param()
-p.io.home = "/tmp/ptypy/"     
+p.io.home = "/tmp/ptypy/"
 p.io.run = None
 
 p.io.autoplot =  u.Param()
 p.io.autoplot.layout ='nearfield'
 
 p.scan = u.Param()
-p.scan.source = None           
+p.scan.source = None
 p.scan.geometry = u.Param()
-p.scan.geometry.energy = 9.7      
-p.scan.geometry.lam = None      
-p.scan.geometry.distance = 8.46e-2    
-p.scan.geometry.psize = 100e-9         
-p.scan.geometry.shape = 1024                    
-p.scan.geometry.propagation = "nearfield"      
+p.scan.geometry.energy = 9.7
+p.scan.geometry.lam = None
+p.scan.geometry.distance = 8.46e-2
+p.scan.geometry.psize = 100e-9
+p.scan.geometry.shape = 1024
+p.scan.geometry.propagation = "nearfield"
 
 p.scan.geometry.precedence = 'meta'
 
 sim = u.Param()
 sim.xy = u.Param()
-sim.xy.override = u.parallel.MPIrand_uniform(0.0,10e-6,(20,2))          
+sim.xy.override = u.parallel.MPIrand_uniform(0.0,10e-6,(20,2))
 #sim.xy.positions = np.random.normal(0.0,3e-6,(20,2))
 sim.verbose_level = 1
 
 sim.illumination = u.Param()
 sim.illumination.model = None
-sim.illumination.photons = 1e11              
+sim.illumination.photons = 1e11
 sim.illumination.aperture = u.Param()
 sim.illumination.aperture.diffuser = (8.0, 10.0)
 sim.illumination.aperture.form = "circ"
 sim.illumination.aperture.size = 90e-6
 sim.illumination.aperture.central_stop = 0.15
 sim.illumination.propagation = u.Param()
-sim.illumination.propagation.focussed = None#0.08 
+sim.illumination.propagation.focussed = None#0.08
 sim.illumination.propagation.parallel = 0.005
 sim.illumination.propagation.spot_size = None
 
 sim.sample = u.Param()
 sim.sample.model = u.xradia_star((1200,1200),minfeature=3,contrast=0.8)
 sim.sample.process = u.Param()
-sim.sample.process.offset = (0,0)        
-sim.sample.process.zoom = 1.0            
-sim.sample.process.formula = "Au"              
-sim.sample.process.density = 19.3                  
-sim.sample.process.thickness = 700e-9       
-sim.sample.process.ref_index = None           
-sim.sample.process.smoothing = None            
-sim.sample.fill = 1.0+0.j      
+sim.sample.process.offset = (0,0)
+sim.sample.process.zoom = 1.0
+sim.sample.process.formula = "Au"
+sim.sample.process.density = 19.3
+sim.sample.process.thickness = 700e-9
+sim.sample.process.ref_index = None
+sim.sample.process.smoothing = None
+sim.sample.fill = 1.0+0.j
 
-sim.detector = 'GenericCCD32bit' 
+sim.detector = 'GenericCCD32bit'
 sim.plot = False
 
 p.scan.update(sim.copy(depth=4))
 p.scan.coherence = u.Param()
-p.scan.coherence.Nprobe_modes = 1     
-p.scan.coherence.Nobject_modes = 1     
-p.scan.coherence.energies = [1.0]     
+p.scan.coherence.Nprobe_modes = 1
+p.scan.coherence.Nobject_modes = 1
+p.scan.coherence.energies = [1.0]
 
 # p.scan.sharing = u.Param()
 # p.scan.sharing.EP_sharing = False
-# p.scan.sharing.object_shared_with = None    
-# p.scan.sharing.object_share_power = 1      
-# p.scan.sharing.probe_shared_with = None    
-# p.scan.sharing.probe_share_power = 1    
+# p.scan.sharing.object_shared_with = None
+# p.scan.sharing.object_share_power = 1
+# p.scan.sharing.probe_shared_with = None
+# p.scan.sharing.probe_share_power = 1
 
 p.scan.sample = u.Param()
 #p.scan.sample.model = 'stxm'
@@ -88,34 +88,34 @@ p.scan.illumination.model = 'stxm'
 p.scans = u.Param()
 p.scans.sim = u.Param()
 p.scans.sim.data=u.Param()
-p.scans.sim.data.source = 'sim' 
-p.scans.sim.data.recipe = sim.copy(depth=4) 
+p.scans.sim.data.source = 'sim'
+p.scans.sim.data.recipe = sim.copy(depth=4)
 p.scans.sim.data.save = None #'append'
 p.scans.sim.data.shape = None
 p.scans.sim.data.num_frames = None
 
 p.engine = u.Param()
 p.engine.common = u.Param()
-p.engine.common.numiter = 100           
-p.engine.common.numiter_contiguous = 1   
-p.engine.common.probe_support = None          
-p.engine.common.probe_inertia = 0.001        
-p.engine.common.object_inertia = 0.1            
-p.engine.common.obj_smooth_std = 10          
-p.engine.common.clip_object = None            
+p.engine.common.numiter = 100
+p.engine.common.numiter_contiguous = 1
+p.engine.common.probe_support = None
+p.engine.common.probe_inertia = 0.001
+p.engine.common.object_inertia = 0.1
+p.engine.common.obj_smooth_std = 10
+p.engine.common.clip_object = None
 
 p.engine.DM = u.Param()
-p.engine.DM.name = "DM"                       
-p.engine.DM.alpha = 1                        
-p.engine.DM.probe_update_start = 2          
-p.engine.DM.update_object_first = True       
-p.engine.DM.overlap_converge_factor = 0.5    
-p.engine.DM.overlap_max_iterations = 100       
-p.engine.DM.fourier_relax_factor = 0.05   
+p.engine.DM.name = "DM"
+p.engine.DM.alpha = 1
+p.engine.DM.probe_update_start = 2
+p.engine.DM.update_object_first = True
+p.engine.DM.overlap_converge_factor = 0.5
+p.engine.DM.overlap_max_iterations = 100
+p.engine.DM.fourier_relax_factor = 0.05
 
 p.engine.ML = u.Param()
 
-p.engines = u.Param()                 
+p.engines = u.Param()
 p.engines.engine00 = u.Param()
 p.engines.engine00.name = 'DM'
 p.engines.engine00.numiter = 100

--- a/templates/ptypy_id16a_ffp_recons.py
+++ b/templates/ptypy_id16a_ffp_recons.py
@@ -19,13 +19,13 @@ except IndexError:
 p = u.Param()
 
 ### PTYCHO PARAMETERS
-p.verbose_level = 3                               
+p.verbose_level = 3
 
-p.data_type = "single"                            
+p.data_type = "single"
 
 p.io = u.Param()
 p.io.autoplot = u.Param()
-p.io.autoplot.interval = 1 
+p.io.autoplot.interval = 1
 p.io.autoplot.layout = 'weak'
 p.io.autoplot.threaded = False
 p.io.autoplot.make_movie = False
@@ -53,17 +53,17 @@ p.scans.sstar.illumination.aperture.form = 'rect'
 p.scans.sstar.illumination.aperture.size = 60e-6
 p.scans.sstar.illumination.propagation=u.Param()
 p.scans.sstar.illumination.propagation.focussed = 0.1
-p.scans.sstar.illumination.propagation.parallel = 2e-3 
+p.scans.sstar.illumination.propagation.parallel = 2e-3
 p.scans.sstar.illumination.diversity = u.Param()
 p.scans.sstar.illumination.diversity.power = 0.1
 p.scans.sstar.illumination.diversity.noise = (1,2)
 
-p.scans.sstar.sample= u.Param() 
+p.scans.sstar.sample= u.Param()
 
 p.scans.sstar.coherence = u.Param()
 p.scans.sstar.coherence.num_probe_modes = 3
 
-p.engines = u.Param()                                 
+p.engines = u.Param()
 p.engines.engine00 = u.Param()
 p.engines.engine00.name = 'DM'
 p.engines.engine00.numiter =200
@@ -73,8 +73,8 @@ p.engines.engine00.overlap_max_iterations = 10
 p.engines.engine00.update_object_first = True
 p.engines.engine00.probe_update_start = 2
 p.engines.engine00.object_smooth_std = 5
-p.engines.engine00.probe_inertia = 0.01             
-p.engines.engine00.object_inertia = 0.1             
+p.engines.engine00.probe_inertia = 0.01
+p.engines.engine00.object_inertia = 0.1
 p.engines.engine01 = u.Param()
 p.engines.engine01.name = 'ML'
 p.engines.engine01.numiter = 100

--- a/templates/ptypy_id22ni_AuStar_focussed_17keV.py
+++ b/templates/ptypy_id22ni_AuStar_focussed_17keV.py
@@ -5,7 +5,7 @@ from ptypy import utils as u
 p = u.Param()
 
 ### PTYCHO PARAMETERS
-p.verbose_level = 3 
+p.verbose_level = 3
 
 p.interaction = u.Param()
 
@@ -13,7 +13,7 @@ p.data_type = "single"
 p.run = None
 
 p.io = u.Param()
-p.io.home = "/tmp/ptypy/" 
+p.io.home = "/tmp/ptypy/"
 p.io.run = None
 p.io.autoplot = u.Param()
 p.io.autoplot.layout='weak'
@@ -21,10 +21,10 @@ p.io.autosave = None
 
 sim = u.Param()
 sim.xy = u.Param()
-sim.xy.model = "round" 
-sim.xy.spacing = 250e-9   
-sim.xy.steps = 30        
-sim.xy.extent = 4e-6 
+sim.xy.model = "round"
+sim.xy.spacing = 250e-9
+sim.xy.steps = 30
+sim.xy.extent = 4e-6
 
 sim.illumination = u.Param()
 sim.illumination.model = None
@@ -35,17 +35,17 @@ sim.illumination.aperture.form = "rect"
 sim.illumination.aperture.size = 35e-6
 sim.illumination.aperture.central_stop = None
 sim.illumination.propagation = u.Param()
-sim.illumination.propagation.focussed = 0.08 
+sim.illumination.propagation.focussed = 0.08
 sim.illumination.propagation.parallel = 0.0014
 sim.illumination.propagation.spot_size = None
 
 sim.sample = u.Param()
 sim.sample.model = u.xradia_star((1000,1000),minfeature=3,contrast=0.0)
 sim.sample.process = u.Param()
-sim.sample.process.offset = (100,100) 
-sim.sample.process.zoom = 1.0 
-sim.sample.process.formula = "Au" 
-sim.sample.process.density = 19.3 
+sim.sample.process.offset = (100,100)
+sim.sample.process.zoom = 1.0
+sim.sample.process.formula = "Au"
+sim.sample.process.density = 19.3
 sim.sample.process.thickness = 2000e-9
 sim.sample.process.ref_index = None
 sim.sample.process.smoothing = None
@@ -87,33 +87,33 @@ p.scan.illumination.diversity.noise = (np.pi,3.0)
 p.scans = u.Param()
 p.scans.sim = u.Param()
 p.scans.sim.data=u.Param()
-p.scans.sim.data.source = 'sim' 
+p.scans.sim.data.source = 'sim'
 p.scans.sim.data.recipe = sim
 p.scans.sim.data.save = None
 
 
 p.engine = u.Param()
 p.engine.common = u.Param()
-p.engine.common.numiter = 100       
-p.engine.common.numiter_contiguous = 1    
-p.engine.common.probe_support = 0.7    
-p.engine.common.probe_inertia = 0.01    
-p.engine.common.object_inertia = 0.1  
-p.engine.common.clip_object = [0,1.]        
+p.engine.common.numiter = 100
+p.engine.common.numiter_contiguous = 1
+p.engine.common.probe_support = 0.7
+p.engine.common.probe_inertia = 0.01
+p.engine.common.object_inertia = 0.1
+p.engine.common.clip_object = [0,1.]
 
 p.engine.DM = u.Param()
-p.engine.DM.name = "DM"             
-p.engine.DM.alpha = 1                
-p.engine.DM.probe_update_start = 2     
-p.engine.DM.update_object_first = True   
-p.engine.DM.overlap_converge_factor = 0.05 
-p.engine.DM.overlap_max_iterations = 100    
-p.engine.DM.fourier_relax_factor = 0.1     
-p.engine.DM.obj_smooth_std = 5 
+p.engine.DM.name = "DM"
+p.engine.DM.alpha = 1
+p.engine.DM.probe_update_start = 2
+p.engine.DM.update_object_first = True
+p.engine.DM.overlap_converge_factor = 0.05
+p.engine.DM.overlap_max_iterations = 100
+p.engine.DM.fourier_relax_factor = 0.1
+p.engine.DM.obj_smooth_std = 5
 
 p.engine.ML = u.Param()
 
-p.engines = u.Param()                          
+p.engines = u.Param()
 p.engines.engine00 = u.Param()
 p.engines.engine00.name = 'DM'
 p.engines.engine00.numiter = 150

--- a/templates/ptypy_laser_logo_focussed_632nm.py
+++ b/templates/ptypy_laser_logo_focussed_632nm.py
@@ -7,12 +7,12 @@ p = u.Param()
 
 
 ### PTYCHO PARAMETERS
-p.verbose_level = 3                  
-p.data_type = "single"                            
+p.verbose_level = 3
+p.data_type = "single"
 
 p.run = None
 p.io = u.Param()
-p.io.home = "/tmp/ptypy/"             
+p.io.home = "/tmp/ptypy/"
 p.io.run = None
 p.io.autosave = None
 p.io.autoplot = u.Param()
@@ -30,14 +30,14 @@ p.scan.geometry.propagation = "farfield"
 
 sim = u.Param()
 sim.xy = u.Param()
-sim.xy.model = "round"                
-sim.xy.spacing = 0.3e-3                
-sim.xy.steps = 60        
-sim.xy.extent = (5e-3,10e-3)      
+sim.xy.model = "round"
+sim.xy.spacing = 0.3e-3
+sim.xy.steps = 60
+sim.xy.extent = (5e-3,10e-3)
 
 sim.illumination = u.Param()
 sim.illumination.model = None
-sim.illumination.photons = 1e9           
+sim.illumination.photons = 1e9
 sim.illumination.aperture = u.Param()
 sim.illumination.aperture.diffuser = None#(0.7,3)
 sim.illumination.aperture.form = "circ"
@@ -45,28 +45,28 @@ sim.illumination.aperture.size = 1.0e-3
 sim.illumination.aperture.edge = 2
 sim.illumination.aperture.central_stop = None
 sim.illumination.propagation = u.Param()
-sim.illumination.propagation.focussed = None 
+sim.illumination.propagation.focussed = None
 sim.illumination.propagation.parallel = 0.03
 sim.illumination.propagation.spot_size = None
 
 sim.sample = u.Param()
 sim.sample.model = -u.rgb2complex(u.imload('../resources/ptypy_logo_1M.png')[::-1,:,:-1])
 sim.sample.process = u.Param()
-sim.sample.process.offset = (0,0)                   
-sim.sample.process.zoom = 0.5                         
-sim.sample.process.formula = None                    
-sim.sample.process.density = None       
-sim.sample.process.thickness = None    
-sim.sample.process.ref_index = None          
-sim.sample.process.smoothing = None    
-sim.sample.fill = 1.0+0.j 
+sim.sample.process.offset = (0,0)
+sim.sample.process.zoom = 0.5
+sim.sample.process.formula = None
+sim.sample.process.density = None
+sim.sample.process.thickness = None
+sim.sample.process.ref_index = None
+sim.sample.process.smoothing = None
+sim.sample.fill = 1.0+0.j
 sim.plot=False
 sim.detector = dict(dtype=np.uint32,full_well=2**32-1,psf=None)
 
 p.scans = u.Param()
 p.scans.ptypy = u.Param()
 p.scans.ptypy.data = u.Param()
-p.scans.ptypy.data.source = 'sim' 
+p.scans.ptypy.data.source = 'sim'
 p.scans.ptypy.data.recipe = sim.copy(depth=4)
 
 p.scans.ptypy.coherence = u.Param()
@@ -82,26 +82,26 @@ p.scans.ptypy.illumination.aperture.edge = 10
 
 p.engine = u.Param()
 p.engine.common = u.Param()
-p.engine.common.numiter = 100            
-p.engine.common.numiter_contiguous = 1  
-p.engine.common.probe_support = 0.9      
-p.engine.common.probe_inertia = 0.01  
-p.engine.common.object_inertia = 0.1    
-p.engine.common.clip_object = None    
+p.engine.common.numiter = 100
+p.engine.common.numiter_contiguous = 1
+p.engine.common.probe_support = 0.9
+p.engine.common.probe_inertia = 0.01
+p.engine.common.object_inertia = 0.1
+p.engine.common.clip_object = None
 
 p.engine.DM = u.Param()
-p.engine.DM.name = "DM"        
-p.engine.DM.alpha = 1      
-p.engine.DM.probe_update_start = 2           
-p.engine.DM.update_object_first = True    
-p.engine.DM.overlap_converge_factor = 0.05  
-p.engine.DM.overlap_max_iterations = 100   
-p.engine.DM.fourier_relax_factor = 0.05    
-p.engine.DM.obj_smooth_std = 5    
+p.engine.DM.name = "DM"
+p.engine.DM.alpha = 1
+p.engine.DM.probe_update_start = 2
+p.engine.DM.update_object_first = True
+p.engine.DM.overlap_converge_factor = 0.05
+p.engine.DM.overlap_max_iterations = 100
+p.engine.DM.fourier_relax_factor = 0.05
+p.engine.DM.obj_smooth_std = 5
 
 p.engine.ML = u.Param()
 
-p.engines = u.Param()                  
+p.engines = u.Param()
 p.engines.engine00 = u.Param()
 p.engines.engine00.name = 'DM'
 p.engines.engine00.numiter = 40

--- a/tutorial/minimal_script.py
+++ b/tutorial/minimal_script.py
@@ -1,8 +1,8 @@
 # This tutorial explains the minimal settings to get a reconstruction
 # runnig in |ptypy|. A |ptypy| script consists of two parts:
 
-# * Creation of a parameter tree with parameters 
-#   as listed in :ref:`parameters` and 
+# * Creation of a parameter tree with parameters
+#   as listed in :ref:`parameters` and
 # * calling a :any:`Ptycho` instance with this parameter tree,
 #   specifying a level that determines how much the Ptycho
 #   instance will do.
@@ -12,7 +12,7 @@
 
 # We begin with opening an empty python file of arbitrary name
 # in an editor of your choice, e.g.::
-# 
+#
 #   $ gedit minimal_script.py
 
 # Next we create an empty parameter tree. In |ptypy|, parameters
@@ -23,29 +23,29 @@ from ptypy import utils as u
 p = u.Param()  # root level
 
 # We set the verbosity to a high level, in order to have information on the
-# reconstruction process printed to the terminal. 
+# reconstruction process printed to the terminal.
 # See :py:data:`.verbose_level`.
-p.verbose_level = 3                              
+p.verbose_level = 3
 
 # We limit this reconstruction to single precision. The other choice is to
 # use double precision.
-p.data_type = "single"                           
+p.data_type = "single"
 
-# We give this reconstruction the name ``'minimal'`` although it 
+# We give this reconstruction the name ``'minimal'`` although it
 # will automatically choose one from the file name of the script if we put in ``None``.
 # (But then the tutorial may not work on your computer as the chosen
 # run name may differ from the one that this tutorial was created with)
 p.run = 'minimal'
 
-# Next, we set the home path. The :any:`Ptycho` instance will use this 
+# Next, we set the home path. The :any:`Ptycho` instance will use this
 # path as base for any other relative file path (e.g :py:data:`.io.autosave.path`
 # or :py:data:`.io.rfile`). Relative paths lack a leading "/"
-# (or "C:\\" on windows). Make sure to replace all "/" with "\\" 
+# (or "C:\\" on windows). Make sure to replace all "/" with "\\"
 # if you run the scripts on a Windows system.
 p.io = u.Param()
 p.io.home = "/tmp/ptypy/"
 
-# We want an intermediate result of the reconstruction 
+# We want an intermediate result of the reconstruction
 # to be dumped regularly every 20 reconstructions.
 p.io.autosave = u.Param()
 p.io.autosave.interval = 20
@@ -53,7 +53,7 @@ p.io.autosave.interval = 20
 # In this tutorial we switch off the threaded plotting client.
 p.io.autoplot = False
 
-# Since we do not want to plot anything, we don't need the 
+# Since we do not want to plot anything, we don't need the
 # interaction server either.
 p.io.interaction = False
 
@@ -74,23 +74,23 @@ p.scan = u.Param()
 # branch mentioned above.
 # Obviously at least the ``data`` branch will differ from
 # :py:data:`.scan.data`. In this tutorial we
-# create a new scan parameter branch ``MF`` where we only specify 
+# create a new scan parameter branch ``MF`` where we only specify
 # the data branch and tell |ptypy| to use scan meta data when possible.
 p.scans = u.Param()
 p.scans.MF = u.Param()
 p.scans.MF.if_conflict_use_meta = True
 p.scans.MF.data = u.Param()
 
-# As data source we have choosen the *'test'* source. 
-# That will make |ptypy| use the internal 
+# As data source we have choosen the *'test'* source.
+# That will make |ptypy| use the internal
 # :py:class:`~ptypy.core.data.MoonFlowerScan` class.
 # This class is meant for testing, and it provides/simulates
-# diffraction patterns without using the more complex generic 
+# diffraction patterns without using the more complex generic
 # :any:`SimScan` class.
 p.scans.MF.data.source = 'test'
 
-# We set the diffraction frame shape to a small value (128x128px) and 
-# limit the number af diffraction patterns at 100. The 
+# We set the diffraction frame shape to a small value (128x128px) and
+# limit the number af diffraction patterns at 100. The
 # :py:class:`~ptypy.core.data.MoonFlowerScan` instance will balance the
 # diffraction patterns accordingly.
 p.scans.MF.data.shape = 128
@@ -98,11 +98,11 @@ p.scans.MF.data.num_frames = 100
 
 # We skip saving the "prepared" data file for now. The |ptypy| data
 # management is described in detail in :ref:`ptypy_data`
-p.scans.MF.data.save = None 
+p.scans.MF.data.save = None
 
 # Needlees to say, we need to specify a reconstruction engine. We choose
 # 40 iterations of difference map algorithm.
-p.engines = u.Param()                                  
+p.engines = u.Param()
 p.engines.engine00 = u.Param()
 p.engines.engine00.name = 'DM'
 p.engines.engine00.numiter = 40

--- a/tutorial/ownengine.py
+++ b/tutorial/ownengine.py
@@ -10,19 +10,19 @@ import numpy as np
 # Preparing a managing Ptycho instance
 # ------------------------------------
 
-# We need to prepare a managing :any:`Ptycho` instance. 
+# We need to prepare a managing :any:`Ptycho` instance.
 # It requires a parameter tree, as specified in :ref:`parameters`
 
-# First, we create a most basic input paramater tree. There 
+# First, we create a most basic input paramater tree. There
 # are many default values, but we specify manually only a more verbose
 # output and single precision for the data type.
 p = u.Param()
-p.verbose_level = 3                              
-p.data_type = "single"                           
+p.verbose_level = 3
+p.data_type = "single"
 
-# Now, we need to create a set of scans that we wish to reconstruct 
+# Now, we need to create a set of scans that we wish to reconstruct
 # in the reconstruction run. We will use a single scan that we call 'MF' and
-# mark the data source as 'test' to use the |ptypy| internal 
+# mark the data source as 'test' to use the |ptypy| internal
 # :any:`MoonFlowerScan`
 p.scans = u.Param()
 p.scans.MF = u.Param()
@@ -33,8 +33,8 @@ p.scans.MF.data.num_frames = 400
 
 # This bare parameter tree will be the input for the :any:`Ptycho`
 # class which is constructed at ``level=2``. It means that it creates
-# all necessary basic :any:`Container` instances like *probe*, *object* 
-# *diff* , etc. It also loads the first chunk of data and creates all 
+# all necessary basic :any:`Container` instances like *probe*, *object*
+# *diff* , etc. It also loads the first chunk of data and creates all
 # :any:`View` and :any:`POD` instances, as the verbose output will tell.
 P = ptypy.core.Ptycho(p, level=2)
 
@@ -45,8 +45,8 @@ fig.savefig('ownengine_%d.png' % fig.number, dpi=300)
 # Plot of simulated diffraction data for the first two positions.
 
 # We don't need to use |ptypy|'s :any:`Ptycho` class to arrive at this
-# point. The structure ``P`` that we arrive with at the end of 
-# :ref:`simupod` suffices completely. 
+# point. The structure ``P`` that we arrive with at the end of
+# :ref:`simupod` suffices completely.
 
 # Probe and object are not so exciting to look at for now. As default,
 # probes are initialized with an aperture like support.
@@ -63,7 +63,7 @@ fig.savefig('ownengine_%d.png' % fig.number, dpi=300)
 # Now we can start implementing a simple DM algorithm. We need three basic
 # functions, one is the ``fourier_update`` that implements the Fourier
 # modulus constraint.
- 
+
 # .. math::
 #    \psi_{d,\lambda,k} = \mathcal{D}_{\lambda,z}^{-1}\left\{\sqrt{I_{d}}\frac{\mathcal{D}_{\lambda,z} \{\psi_{d,\lambda,k}\}}{\sum_{\lambda,k} |\mathcal{D}_{\lambda,z} \{\psi_{d,\lambda,k}\} |^2}\right\}
 
@@ -75,8 +75,8 @@ def fourier_update(pods):
     modulus = np.sqrt(np.abs(pod.diff))
     # Create temporary buffers
     Imodel = np.zeros_like(pod.diff)
-    err = 0.                             
-    Dphi = {}                                
+    err = 0.
+    Dphi = {}
     # Propagate the exit waves
     for gamma, pod in pods.iteritems():
         Dphi[gamma] = pod.fw(2*pod.probe*pod.object - pod.exit)
@@ -93,7 +93,7 @@ def fourier_update(pods):
 
 def probe_update(probe, norm, pods, fill=0.):
     """
-    Updates `probe`. A portion `fill` of the probe is kept from 
+    Updates `probe`. A portion `fill` of the probe is kept from
     iteration to iteration. Requires `norm` buffer and pod dictionary
     """
     probe *= fill
@@ -109,7 +109,7 @@ def probe_update(probe, norm, pods, fill=0.):
 
 def object_update(obj, norm, pods, fill=0.):
     """
-    Updates `object`. A portion `fill` of the object is kept from 
+    Updates `object`. A portion `fill` of the object is kept from
     iteration to iteration. Requires `norm` buffer and pod dictionary
     """
     obj *= fill
@@ -149,13 +149,13 @@ def iterate(Ptycho, num):
 # We start off with a small number of iterations.
 iterate(P, 9)
 
-# We note that the error (here only displayed for 3 iterations) is 
-# already declining. That is a good sign. 
+# We note that the error (here only displayed for 3 iterations) is
+# already declining. That is a good sign.
 # Let us have a look how the probe has developed.
 fig = u.plot_storage(P.probe.S['S00G00'], 2)
 fig.savefig('ownengine_%d.png' % fig.number, dpi=300)
 # Plot of the reconstructed probe after 9 iterations. We observe that
-# the actaul illumination of the sample must be larger than the initial 
+# the actaul illumination of the sample must be larger than the initial
 # guess.
 
 # Looks like the probe is on a good way. How about the object?
@@ -167,7 +167,7 @@ fig.savefig('ownengine_%d.png' % fig.number, dpi=300)
 # Ok, let us do some more iterations. 36 will do.
 iterate(P, 36)
 
-# Error is still on a steady descent. Let us look at the final 
+# Error is still on a steady descent. Let us look at the final
 # reconstructed probe and object.
 fig = u.plot_storage(P.probe.S['S00G00'], 4)
 fig.savefig('ownengine_%d.png' % fig.number, dpi=300)
@@ -177,7 +177,7 @@ fig.savefig('ownengine_%d.png' % fig.number, dpi=300)
 
 fig = u.plot_storage(P.obj.S['S00G00'], 5, slices='0,120:-120,120:-120')
 fig.savefig('ownengine_%d.png' % fig.number, dpi=300)
-# Plot of the reconstructed object after a total of 45 iterations. 
+# Plot of the reconstructed object after a total of 45 iterations.
 # It's a bunch of flowers !
 
 

--- a/tutorial/ptypyclasses.py
+++ b/tutorial/ptypyclasses.py
@@ -1,17 +1,17 @@
 # This tutorial explains how |ptypy| accesses data / memory.
-# The data access is governed by three classes: 
+# The data access is governed by three classes:
 # :py:class:`~ptypy.core.classes.Container`,
 # :py:class:`~ptypy.core.classes.Storage`,
 # and :py:class:`~ptypy.core.classes.View`
 
-# First a short reminder from the :py:mod:`~ptypy.core.classes` Module 
+# First a short reminder from the :py:mod:`~ptypy.core.classes` Module
 # about the classes this tutorial covers.
 
 """
 **Container class**
     A high-level container that keeps track of sub-containers (Storage)
     and Views onto them. A container can copy itself to produce a buffer
-    needed for calculations. Some basic Mathematical operations are 
+    needed for calculations. Some basic Mathematical operations are
     implemented at this level as in-place operations.
     In general, operations on arrays should be done using the Views, which
     simply return numpy arrays.
@@ -42,16 +42,16 @@ plt = mpl.pyplot
 # A single Storage in one Container
 # ---------------------------------
 
-# The governing object is a :any:`Container` instance, which we need 
+# The governing object is a :any:`Container` instance, which we need
 # to construct as first object. It does not need much for an input but
 # the data type.
 C1 = Container(data_type='real')
 
-# This class itself holds nothing at first. In order to store data in 
+# This class itself holds nothing at first. In order to store data in
 # ``C1`` we have to add a :any:`Storage` to that container.
 S1 = C1.new_storage(shape=(1, 7, 7))
 
-# Similarly we can contruct the Storage from a data buffer. 
+# Similarly we can contruct the Storage from a data buffer.
 # ``S1=C1.new_storage(data=np.ones((1,7,7)))`` would have also worked.
 
 # All of |ptypy|'s special classes carry a uniue ID, which is needed
@@ -61,7 +61,7 @@ S1 = C1.new_storage(shape=(1, 7, 7))
 # In this case that will be ``S0000`` where the *S* refers to the class type.
 print S1.ID
 
-# Let's have a look at what kind of data Storage holds. 
+# Let's have a look at what kind of data Storage holds.
 print S1.formatted_report()[0]
 
 # Apart from the ID on the left we discover a few other entries, for
@@ -92,9 +92,9 @@ print g[1]
 
 # We observe that the center has in fact moved one pixel up and one left.
 # The :py:func:`~ptypy.core.classes.Storage.center` property uses pixel
-# units. 
-# If we want to use a physical quantity to shift the center, 
-# we may instead set the top left pixel to a new value, 
+# units.
+# If we want to use a physical quantity to shift the center,
+# we may instead set the top left pixel to a new value,
 # which shifts the center to a new position.
 S1.origin -= 0.12
 y, x = S1.grids()
@@ -102,14 +102,14 @@ print y
 print x
 print S1.center
 
-# Up until now our actual *data* numpy array located at ``S1.data`` is 
-# still filled with ones, i.e. flat. We can use 
+# Up until now our actual *data* numpy array located at ``S1.data`` is
+# still filled with ones, i.e. flat. We can use
 # :any:`Storage.fill` to fill that container with an array.
 S1.fill(x+y)
 print S1.data
 
-# We can have visual check on the data using 
-# :py:func:`~ptypy.utils.plot_utils.plot_storage` 
+# We can have visual check on the data using
+# :py:func:`~ptypy.utils.plot_utils.plot_storage`
 fig = u.plot_storage(S1, 0)
 fig.savefig('ptypyclasses_%d.png' % fig.number, dpi=300)
 # A plot of the data stored in ``S1``
@@ -145,24 +145,24 @@ print V1.storageID
 print V1.psize
 print V1.storage
 
-# The update also set new attributes of the View which all start with 
-# a lower ``d`` and are locally cached information about data access. 
+# The update also set new attributes of the View which all start with
+# a lower ``d`` and are locally cached information about data access.
 print V1.dlayer, V1.dlow, V1.dhigh
 
-# Finally, we can retrieve the data subset 
+# Finally, we can retrieve the data subset
 # by applying the View to the storage.
 data = S1[V1]
 print data
 
-# It does not matter if we apply the View to Storage ``S1`` or the 
-# container ``C1``, or use the View internal 
+# It does not matter if we apply the View to Storage ``S1`` or the
+# container ``C1``, or use the View internal
 # View.\ :py:meth:`~ptypy.core.classes.View.data` property.
 print np.allclose(data, C1[V1])
 print np.allclose(data, V1.data)
 
-# The first access yielded a similar result because the 
-# :py:attr:`~ptypy.core.classes.View.storageID` ``S0000`` is in ``C1`` 
-# and the second acces method worked because it uses the View's 
+# The first access yielded a similar result because the
+# :py:attr:`~ptypy.core.classes.View.storageID` ``S0000`` is in ``C1``
+# and the second acces method worked because it uses the View's
 # :py:attr:`~ptypy.core.classes.View.storage` attribute.
 print V1.storage is S1
 print V1.storageID in C1.S.keys()
@@ -172,27 +172,27 @@ print V1.storageID in C1.S.keys()
 # as possible. The coordinate in data space that the View would have as
 # center is the attribute :py:meth:`~ptypy.core.classes.View.pcoord` while
 # :py:meth:`~ptypy.core.classes.View.dcoord` is the closest data coordinate.
-# The difference is held by :py:meth:`~ptypy.core.classes.View.sp` such 
+# The difference is held by :py:meth:`~ptypy.core.classes.View.sp` such
 # that a subpixel correction may be applied if needed (future release)
 print V1.dcoord, V1.pcoord, V1.sp
 
 # .. note::
-#    Please note that we cannot guarantee any API stability for other 
+#    Please note that we cannot guarantee any API stability for other
 #    attributes / properties besides *.data*, *.shape* and *.coord*
 
 # If we set the coordinate to some other value in the grid, we can eliminate
 # the subpixel misfit. By changing the *.coord* property, we need to
 # update the View manually, as the View-Storage interaction is non-automatic
-# apart from the moment the View is constructed - a measure to prevent 
+# apart from the moment the View is constructed - a measure to prevent
 # unwanted feedback loops.
 V1.coord = (0.08, 0.08)
 S1.update_views(V1)
-print V1.dcoord, V1.pcoord, V1.sp 
+print V1.dcoord, V1.pcoord, V1.sp
 
 # We observe that the high range limit of the View is close to the border
 # of the data buffer.
 print V1.dhigh
- 
+
 # What happens if we push the coordinate further?
 V1.coord = (0.28, 0.28)
 S1.update_views(V1)
@@ -206,8 +206,8 @@ print S1[V1].shape, V1.shape
 
 # One important feature of the :any:`Storage` class is that it can detect
 # all out-of-bounds accesses and reformat the data buffer accordingly.
-# A simple call to 
-# *Storage*.\ :py:meth:`~ptypy.core.classes.Storage.reformat` should do. 
+# A simple call to
+# *Storage*.\ :py:meth:`~ptypy.core.classes.Storage.reformat` should do.
 print S1.shape
 mn = S1[V1].mean()
 S1.fill_value = mn
@@ -215,11 +215,11 @@ S1.reformat()
 print S1.shape
 
 # Oh no, the Storage data buffer has shrunk! But don't worry, that is
-# intended behavior. A call to *.reformat()* crops and pads the data 
-# buffer around all **active** Views. 
+# intended behavior. A call to *.reformat()* crops and pads the data
+# buffer around all **active** Views.
 # We would need to set ``S1.padonly = True``
 # if we wanted to avoid that the data buffer is cropped. We leave this
-# as an exercise for now. Instead, we add a new View at a different 
+# as an exercise for now. Instead, we add a new View at a different
 # location to verify that the buffer will adapt to reach both Views.
 ar2 = ar.copy()
 ar2.coord = (-0.82, -0.82)
@@ -256,7 +256,7 @@ fig.savefig('ptypyclasses_%d.png' % fig.number, dpi=300)
 # exist.
 ar = DEFAULT_ACCESSRULE.copy()
 ar.shape = 200
-ar.coord = 0.      
+ar.coord = 0.
 ar.storageID = 'S100'
 ar.psize = 1.0
 V3=View(C1, ID=None, accessrule=ar)

--- a/tutorial/scipt2rst.py
+++ b/tutorial/scipt2rst.py
@@ -26,6 +26,6 @@ for line in fpy:
     else:
         wline = '>>> '+line
     frst.write(wline)
-    
+
 
 

--- a/tutorial/simupod.py
+++ b/tutorial/simupod.py
@@ -1,7 +1,7 @@
 # In the :ref:`ptypyclasses` we have learned to deal with the
 # basic storage-and-access classes on small toy arrays.
 
-# In this tutorial we will learn how to create :any:`POD` and 
+# In this tutorial we will learn how to create :any:`POD` and
 # :any:`Geo` instances to imitate a ptychography experiment
 # and to use larger arrays.
 
@@ -24,7 +24,7 @@ scriptname = sys.argv[0].split('.')[0]
 
 # We create a managing top-level class instance. We will not use the
 # the :any:`Ptycho` class for now, as its rich set of methods may be
-# a bit overwhelming to start with. Instead we take a plain 
+# a bit overwhelming to start with. Instead we take a plain
 # :py:class:`~ptypy.core.classes.Base` instance.
 P = Base()
 P.CType = np.complex128
@@ -47,9 +47,9 @@ G = geometry.Geo(owner=P, pars=g)
 
 # The Geo instance ``G`` has done a lot already at this moment. For
 # example, we find forward and backward propagators at ``G.propagator.fw``
-# and ``G.propagator.bw``. It has also calculated the appropriate 
+# and ``G.propagator.bw``. It has also calculated the appropriate
 # pixel size in the sample plane (aka resolution),
-print G.resolution 
+print G.resolution
 
 # which sets the shifting frame to be of the following size:
 fsize = G.shape * G.resolution
@@ -58,20 +58,20 @@ print "%.2fx%.2fmm" % tuple(fsize*1e3)
 # Create probing illumination
 # ---------------------------
 
-# Next, we need to create a probing illumination. 
+# Next, we need to create a probing illumination.
 # We start with a suited container that we call *probe*
 P.probe = Container(P, 'Cprobe', data_type='complex')
 
-# For convenience, there is a test probing illumination in |ptypy|'s 
+# For convenience, there is a test probing illumination in |ptypy|'s
 # resources.
 from ptypy.resources import moon_pr
 pr = -moon_pr(G.shape)
 pr = P.probe.new_storage(data=pr, psize=G.resolution)
 fig = u.plot_storage(pr, 0)
 fig.savefig('%s_%d.png' % (scriptname, fig.number), dpi=300)
-# Ptypy's default testing illumination, an image of the moon. 
+# Ptypy's default testing illumination, an image of the moon.
 
-# Of course, we could have also used the coordinate grids 
+# Of course, we could have also used the coordinate grids
 # from the propagator to model a probe,
 y, x = G.propagator.grids_sam
 apert = u.smooth_step(fsize[0]/5-np.sqrt(x**2+y**2), 1e-6)
@@ -87,7 +87,7 @@ apert = u.smooth_step(fsize[0]/5-np.abs(x), 3e-5)*u.smooth_step(fsize[1]/5-np.ab
 pr3.fill(apert)
 fig = u.plot_storage(pr3, 2)
 fig.savefig('%s_%d.png' % (scriptname, fig.number), dpi=300)
-# Square test illumination. 
+# Square test illumination.
 
 # In order to put some physics in the illumination we set the number of
 # photons to 1 billion
@@ -110,9 +110,9 @@ fig.savefig('%s_%d.png' % (scriptname, fig.number), dpi=300)
 
 # We use the :py:mod:`ptypy.core.xy` module to create a scan pattern.
 pos = u.Param()
-pos.model = "round"                
-pos.spacing = fsize[0]/8                
-pos.steps = None        
+pos.model = "round"
+pos.spacing = fsize[0]/8
+pos.steps = None
 pos.extent = fsize*1.5
 from ptypy.core import xy
 positions = xy.from_pars(pos)
@@ -122,7 +122,7 @@ ax.plot(positions[:, 1], positions[:, 0], 'o-')
 fig.savefig('%s_%d.png' % (scriptname, fig.number), dpi=300)
 # Created scan pattern.
 
-# Next, we need to model a sample through an object transmisson function. 
+# Next, we need to model a sample through an object transmisson function.
 # We start of with a suited container which we call *obj*.
 P.obj = Container(P, 'Cobj', data_type='complex')
 
@@ -142,7 +142,7 @@ for pos in positions:
     r.coord = pos
     V = View(P.obj, None, r)
 
-# We let the Storages in ``P.obj`` reformat in order to 
+# We let the Storages in ``P.obj`` reformat in order to
 # include all Views. Conveniently, this can be initiated from the top
 # with Container.\ :py:meth:`~ptypy.core.classes.Container.reformat`
 P.obj.reformat()
@@ -159,15 +159,15 @@ fig.savefig('%s_%d.png' % (scriptname, fig.number), dpi=300)
 # Creating additional Views and the PODs
 # --------------------------------------
 
-# A single coherent propagation in |ptypy| is represented by 
+# A single coherent propagation in |ptypy| is represented by
 # an instance of the :py:class:`~ptypy.core.classes.POD` class.
 print POD.__doc__
 print POD.__init__.__doc__
 
-# For creating a single POD we need a 
+# For creating a single POD we need a
 # :py:class:`~ptypy.core.classes.View` to *probe*, *object*,
-# *exit* wave and *diff*\ raction containers as well as the :any:`Geo` 
-# class instance which represents the experimental setup. 
+# *exit* wave and *diff*\ raction containers as well as the :any:`Geo`
+# class instance which represents the experimental setup.
 
 # First we create the missing :py:class:`~ptypy.core.classes.Container`'s.
 P.exit = Container(P, 'Cexit', data_type='complex')
@@ -186,15 +186,15 @@ probe_ar.active = True
 probe_ar.storageID = pr.ID
 prview = View(P.probe, None, probe_ar)
 
-# We construct the exit wave View. This construction is shorter as we only 
+# We construct the exit wave View. This construction is shorter as we only
 # change a few bits in the access rule.
 exit_ar = probe_ar.copy()
 exit_ar.layer = 0
 exit_ar.active = True
 exview = View(P.exit, None, exit_ar)
 
-# We construct diffraction and mask Views. Even shorter is the 
-# construction of the mask View as, for the mask, we are 
+# We construct diffraction and mask Views. Even shorter is the
+# construction of the mask View as, for the mask, we are
 # essentially using the same access as for the diffraction data.
 diff_ar = probe_ar.copy()
 diff_ar.layer = 0
@@ -210,13 +210,13 @@ views = {'probe': prview, 'obj': obview, 'exit': exview, 'diff': diview, 'mask':
 pod = POD(P, ID=None, views=views, geometry=G)
 pods.append(pod)
 
-# The :any:`POD` is the most important class in |ptypy|. Its instances 
+# The :any:`POD` is the most important class in |ptypy|. Its instances
 # are used to write the reconstruction algorithms using
 # its attributes as local references. For example we can create and store an exit
 # wave in the following convenient fashion:
 pod.exit = pod.probe * pod.object
 
-# The result of the calculation above is stored in the appropriate 
+# The result of the calculation above is stored in the appropriate
 # storage of ``P.exit``.
 # Therefore we can use this command to plot the result.
 exit_storage = P.exit.storages.values()[0]
@@ -232,8 +232,8 @@ diff_storage = P.diff.storages.values()[0]
 fig = u.plot_storage(diff_storage, 7, modulus='log')
 fig.savefig('%s_%d.png' % (scriptname, fig.number), dpi=300)
 
- 
-# Creating the rest of the pods is now straight-forward 
+
+# Creating the rest of the pods is now straight-forward
 # since the data accesses are similar.
 for obview in objviews[1:]:
     # we keep the same probe access
@@ -250,7 +250,7 @@ for obview in objviews[1:]:
     pod = POD(P, ID=None, views=views, geometry=G)
     pods.append(pod)
 
-# We let the storage arrays adapt to the new Views.    
+# We let the storage arrays adapt to the new Views.
 for C in [P.mask, P.exit, P.diff, P.probe]:
     C.reformat()
 
@@ -294,7 +294,7 @@ with open(save_path+'geometry.txt', 'w') as f:
     f.close()
 
 # Next, we save positions and the diffraction images. We don't burden
-# ourselves for now with converting to an image file format such as .tiff 
+# ourselves for now with converting to an image file format such as .tiff
 # or a data format like .hdf5 but instead we use numpy's binary storage
 # format.
 with open(save_path+'positions.txt', 'w') as f:

--- a/tutorial/subclassptyscan.py
+++ b/tutorial/subclassptyscan.py
@@ -1,7 +1,7 @@
-# In this tutorial, we learn how to subclass :any:`PtyScan` to make 
+# In this tutorial, we learn how to subclass :any:`PtyScan` to make
 # ptypy work with any experimental setup.
 
-# This tutorial can be used as a direct follow-up to :ref:`simupod` 
+# This tutorial can be used as a direct follow-up to :ref:`simupod`
 # if section :ref:`store` was completed
 
 # Again, the imports first.
@@ -17,28 +17,28 @@ import sys
 save_path = '/tmp/ptypy/sim/'
 
 # Furthermore, we assume that a file about the experimental geometry is
-# located at 
+# located at
 geofilepath = save_path + 'geometry.txt'
 print geofilepath
 # and has contents of the following form
 print ''.join([line for line in open(geofilepath, 'r')])
 
-# The scanning positions are in 
+# The scanning positions are in
 positionpath = save_path + 'positions.txt'
 print positionpath
 
 # with a list of positions for vertical and horizontanl movement and the
-# image frame from the "camera" 
+# image frame from the "camera"
 print ''.join([line for line in open(positionpath, 'r')][:6])+'....'
 
 # Writing a subclass
 # ------------------
 
-# A subclass of :any:`PtyScan` takes the same input parameter 
+# A subclass of :any:`PtyScan` takes the same input parameter
 # tree as PtyScan itself, i.e :py:data:`.scan.data`. As the subclass
-# will most certainly require additional parameters, there has to be 
-# a flexible additional container. For PtyScan, that is the 
-# :py:data:`.scan.data.recipe` parameter. A subclass must extract all 
+# will most certainly require additional parameters, there has to be
+# a flexible additional container. For PtyScan, that is the
+# :py:data:`.scan.data.recipe` parameter. A subclass must extract all
 # additional parameters from this source and, in script, you fill
 # the recipe with the appropriate items.
 
@@ -69,17 +69,17 @@ print u.verbose.report(DEFAULT, noheader=True)
 class NumpyScan(PtyScan):
     # We overwrite the DEFAULT with the new DEFAULT.
     DEFAULT = DEFAULT
-    
+
     def __init__(self, pars=None, **kwargs):
         # In init we need to call the parent.
         super(NumpyScan, self).__init__(pars, **kwargs)
 
 # Of course this class does nothing special beyond PtyScan.
 
-# An additional step of initialisation would be to retrieve 
+# An additional step of initialisation would be to retrieve
 # the geometric information that we stored in ``geofilepath`` and update
 # the input parameters with it.
- 
+
 # We write a tiny file parser.
 def extract_geo(base_path):
     out = {}
@@ -92,29 +92,29 @@ def extract_geo(base_path):
 # We test it.
 print extract_geo(save_path)
 
-# That seems to work. We can integrate this parser into 
-# the initialisation as we assume that this small access can be 
+# That seems to work. We can integrate this parser into
+# the initialisation as we assume that this small access can be
 # done by all MPI nodes without data access problems. Hence,
 # our subclass becomes
 class NumpyScan(PtyScan):
     # We overwrite the DEFAULT with the new DEFAULT.
     DEFAULT = DEFAULT
-    
+
     def __init__(self, pars=None, **kwargs):
         p = DEFAULT.copy(depth=2)
-        p.update(pars) 
-        
+        p.update(pars)
+
         with open(p.recipe.base_path+'geometry.txt') as f:
             for line in f:
                 key, value = line.strip().split()
                 # we only replace Nones or missing keys
                 if p.get(key) is None:
                     p[key] = eval(value)
-        
+
         super(NumpyScan, self).__init__(p, **kwargs)
 
 # Good! Next, we need to implement how the class finds out about
-# the positions in the scan. The method 
+# the positions in the scan. The method
 # :py:meth:`~ptypy.core.data.PtyScan.load_positions` can be used
 # for this purpose.
 print PtyScan.load_positions.__doc__
@@ -138,23 +138,23 @@ print pos[:2]
 class NumpyScan(PtyScan):
     # We overwrite the DEFAULT with the new DEFAULT.
     DEFAULT = DEFAULT
-    
+
     def __init__(self,pars=None, **kwargs):
         p = DEFAULT.copy(depth=2)
-        p.update(pars) 
-        
+        p.update(pars)
+
         with open(p.recipe.base_path+'geometry.txt') as f:
             for line in f:
                 key, value = line.strip().split()
                 # we only replace Nones or missing keys
                 if p.get(key) is None:
                     p[key]=eval(value)
-        
+
         super(NumpyScan, self).__init__(p, **kwargs)
         # all input data is now in self.info
-        
+
     def load_positions(self):
-        # the base path is now stored in 
+        # the base path is now stored in
         base_path = self.info.recipe.base_path
         with open(base_path+'positions.txt') as f:
             for line in f:
@@ -168,11 +168,11 @@ class NumpyScan(PtyScan):
 # manually adapt :py:meth:`~ptypy.core.data.PtyScan.check`
 
 # The last step is to overwrite the actual loading of data.
-# Loading happens (MPI-compatible) in 
+# Loading happens (MPI-compatible) in
 # :py:meth:`~ptypy.core.data.PtyScan.load`
 print PtyScan.load.__doc__
 
-# Load seems a bit more complex than ``self.load_positions`` for its 
+# Load seems a bit more complex than ``self.load_positions`` for its
 # return values. However, we can opt-out of providing weights (masks)
 # and positions, as we have already adapted ``self.load_positions``
 # and there were no bad pixels in the (linear) detector
@@ -181,24 +181,24 @@ print PtyScan.load.__doc__
 class NumpyScan(PtyScan):
     # We overwrite the DEFAULT with the new DEFAULT.
     DEFAULT = DEFAULT
-    
+
     def __init__(self,pars=None, **kwargs):
         p = DEFAULT.copy(depth=2)
-        p.update(pars) 
-        
+        p.update(pars)
+
         with open(p.recipe.base_path+'geometry.txt') as f:
             for line in f:
                 key, value = line.strip().split()
                 # we only replace Nones or missing keys
                 if p.get(key) is None:
                     p[key]=eval(value)
-        
+
         super(NumpyScan, self).__init__(p, **kwargs)
         # all input data is now in self.info
-        
+
     def load_positions(self):
         # the base path is now stored in
-        pos=[] 
+        pos=[]
         base_path = self.info.recipe.base_path
         with open(base_path+'positions.txt') as f:
             for line in f:
@@ -206,7 +206,7 @@ class NumpyScan(PtyScan):
                 pos.append((eval(y),eval(x)))
                 files.append(fname)
         return np.asarray(pos)
-    
+
     def load(self, indices):
         raw = {}
         bp = self.info.recipe.base_path
@@ -221,10 +221,10 @@ class NumpyScan(PtyScan):
 NPS = NumpyScan()
 NPS.initialize()
 
-# In order to process the data. We need to call 
+# In order to process the data. We need to call
 # :py:meth:`~ptypy.core.data.PtyScan.auto` with the chunk size
 # as arguments. It returns a data chunk that we can inspect
-# with :py:func:`ptypy.utils.verbose.report`. The information is 
+# with :py:func:`ptypy.utils.verbose.report`. The information is
 # concatenated, but the length of iterables or dicts is always indicated
 # in parantheses.
 print u.verbose.report(NPS.auto(80), noheader=True)
@@ -234,7 +234,7 @@ print u.verbose.report(NPS.auto(80), noheader=True)
 # as we only had 114 frames of data.
 
 # So where is the *.ptyd* data-file? As default, PtyScan does not
-# actually save data. We have to manually activate it in in the 
+# actually save data. We have to manually activate it in in the
 # input paramaters.
 data = NPS.DEFAULT.copy(depth=2)
 data.save = 'append'
@@ -245,7 +245,7 @@ for i in range(50):
     if msg == NPS.EOS:
         break
 
-# We can analyse the saved ``npy.ptyd`` with 
+# We can analyse the saved ``npy.ptyd`` with
 # :py:func:`~ptypy.io.h5IO.h5info`
 from ptypy.io import h5info
 print h5info(NPS.info.dfile)


### PR DESCRIPTION
This series introduces some changes to Ptypy, the most important of which is using pyFFTW as the default method to perform the Fourier transforms, a change which boosts the performance by up to 60%.
Besides that, some minor optimizations are made to slightly improve the performance beyond that, as well as some refactoring which carries no performance benefits, but makes the code more readable and PEP 8 compliant.

These patches are based on the currently available master branch (commit 208ca77) and are tested on a series of real-world NFP datasets.

Best regards,
Leonid.
