### PR TITLE
Workaround for the rounding errors that cause issue #74

### DIFF
--- a/ptypy/core/classes.py
+++ b/ptypy/core/classes.py
@@ -549,7 +549,7 @@ class Storage(Base):
 
         # Integer part (note that np.round is not stable for odd arrays)
         v.dcoord = np.empty((2,), dtype=int)
-        for i in (0, 1):
+        for i in range(len(v.pcoord)):
             dec = (v.pcoord[i] - np.floor(v.pcoord[i]))
             if dec > .4999 and dec < .5001:
                 v.dcoord[i] = int(np.ceil(v.pcoord[i]))

--- a/ptypy/core/classes.py
+++ b/ptypy/core/classes.py
@@ -548,13 +548,7 @@ class Storage(Base):
             v.pcoord = self._to_pix(v.coord)
 
         # Integer part (note that np.round is not stable for odd arrays)
-        v.dcoord = np.empty((2,), dtype=int)
-        for i in range(len(v.pcoord)):
-            dec = (v.pcoord[i] - np.floor(v.pcoord[i]))
-            if dec > .4999 and dec < .5001:
-                v.dcoord[i] = int(np.ceil(v.pcoord[i]))
-            else:
-                v.dcoord[i] = int(np.round(v.pcoord[i]))
+        v.dcoord = np.round(v.pcoord + 0.00001).astype(int)
 
         # These are the important attributes used when accessing the data
         v.dlow = v.dcoord - v.shape/2

--- a/ptypy/core/classes.py
+++ b/ptypy/core/classes.py
@@ -548,7 +548,13 @@ class Storage(Base):
             v.pcoord = self._to_pix(v.coord)
 
         # Integer part (note that np.round is not stable for odd arrays)
-        v.dcoord = np.round(v.pcoord).astype(int)
+        v.dcoord = np.empty((2,), dtype=int)
+        for i in (0, 1):
+            dec = (v.pcoord[i] - np.floor(v.pcoord[i]))
+            if dec > .4999 and dec < .5001:
+                v.dcoord[i] = int(np.ceil(v.pcoord[i]))
+            else:
+                v.dcoord[i] = int(np.round(v.pcoord[i]))
 
         # These are the important attributes used when accessing the data
         v.dlow = v.dcoord - v.shape/2

--- a/ptypy/test/core_tests/storage_test.py
+++ b/ptypy/test/core_tests/storage_test.py
@@ -1,15 +1,36 @@
 '''
-A test for the Base
+A test for the Storage class
 '''
 
 import unittest
-from ptypy.core import Storage, Container
-
+from ptypy.core import Storage, Container, View
 
 class StorageTest(unittest.TestCase):
     def test_storage(self):
+        """
+        Tests that the Storage constructor runs.
+        """
         cont = Container()
         a = Storage(cont)
+
+    def test_storage_reformat(self):
+        """
+        Tests that storages reformat when adding views
+        """
+        # These values are chosen because of an earlier bug, issue #74
+        psize = .1
+        center = 54.75
+        shape = (84,75)
+
+        C = Container(data_dims=2)
+        S = C.new_storage(shape=128, padonly=False, psize=psize)
+        V = View(container=C, storageID=S.ID, coord=center, 
+                             shape=shape, psize=psize)
+        # repeated reformatting should not change these relations
+        for i in range(10):
+            S.reformat()
+            assert S[V].shape == shape
+            assert S.data.shape == (1,) + shape
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Making sure that dcoord=round(pcoord) is always rounded in the same direction if the decimal part of pcoord is very close to 0.5. It's essential, because otherwise the behavior is unpredictable and Storage.reformat() screws up the Views as in issue #74.

I'm sure this can be done in a prettier way, using the decimal module or something. But this is simple and works.