### PR TITLE
Fixed windows COM overflow issue

### DIFF
--- a/ptypy/utils/scripts.py
+++ b/ptypy/utils/scripts.py
@@ -522,7 +522,7 @@ def mass_center(A, axes=None):
     else:
         axes = tuple(np.array(axes) + 1)
 
-    return np.sum(A * np.indices(A.shape), axis=axes, dtype=np.int64) / np.sum(A)
+    return np.sum(A * np.indices(A.shape), axis=axes, dtype=np.float) / np.sum(A, dtype=np.float)
 
 def radial_distribution(A, radii=None):
     """

--- a/ptypy/utils/scripts.py
+++ b/ptypy/utils/scripts.py
@@ -522,7 +522,7 @@ def mass_center(A, axes=None):
     else:
         axes = tuple(np.array(axes) + 1)
 
-    return np.sum(A * np.indices(A.shape), axis=axes) / np.sum(A)
+    return np.sum(A * np.indices(A.shape), axis=axes, dtype=np.int64) / np.sum(A)
 
 def radial_distribution(A, radii=None):
     """


### PR DESCRIPTION
Fixes the center automatic guess overflow issue in #91 for windows where `np.int32` seems to be the default `int`.