### PR TITLE
Bugfix for data prepared prior to fly scan commit

### DIFF
--- a/ptypy/core/data.py
+++ b/ptypy/core/data.py
@@ -1204,6 +1204,8 @@ class PtydScan(PtyScan):
         with h5py.File(source, 'r') as f:
             check = f.get('chunks/0')
             # Get number of frames supposedly in the file
+            # FIXME: try/except clause only for backward compatibilty 
+            # for .ptyd files created priot to commit 2e626ff
             try:
                 source_frames = f.get('info/num_frames_actual')[...].item()
             except TypeError:

--- a/ptypy/core/data.py
+++ b/ptypy/core/data.py
@@ -1204,7 +1204,10 @@ class PtydScan(PtyScan):
         with h5py.File(source, 'r') as f:
             check = f.get('chunks/0')
             # Get number of frames supposedly in the file
-            source_frames = f.get('info/num_frames_actual')[...].item()
+            try:
+                source_frames = f.get('info/num_frames_actual')[...].item()
+            except TypeError:
+                source_frames = len(f.get('info/positions_scan')[...])
             f.close()
 
         if check is None:


### PR DESCRIPTION
num_frames_actual was introduced with the fly scan commit, leading to a None TypeError when older prepared data is run with the current version of the code