### PR TITLE
doc changes to Ptycho class to add 'scan' parameter defaults

### DIFF
--- a/ptypy/core/ptycho.py
+++ b/ptypy/core/ptycho.py
@@ -239,6 +239,13 @@ class Ptycho(Base):
     doc = Switch to request the production of a movie from the dumped plots at the end of the
       reconstruction.
 
+    [scan]
+    default = None
+    type = Param
+    help = Container for common scan parameters
+    doc = Acts as a default template when there is more than one scan. Scan-specific
+      parameters have to be placed in :py:data:`scans`.
+
     [scans]
     default = None
     type = Param


### PR DESCRIPTION
Added default for `scan` parameter to Ptycho docstring to fix tutorial problems (#205 )