### PR TITLE
Upgraded function for NFP at ID16A beamline at ESRF and removal of deprecated function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,12 @@
 PTYPY - Ptychography Reconstruction for Python
 ==============================================
 
-|doi|
+|ptypysite|
 
 Welcome Ptychonaut!
 -------------------
      
-|ptypy| [#pronounciation]_ is a
+|ptypy| [#pronounciation]_ [#ptypypaper]_ is a
 framework for scientific ptychography compiled by 
 P. Thibault and B. Enders and licensed under the GPLv2 license.
 
@@ -111,14 +111,16 @@ The project is licensed under a GPLv2 license.
 
 .. |ptypy| replace:: PtyPy
 
-.. |doi| image:: https://zenodo.org/badge/6834/ptycho/ptypy.png
-         :target: http://dx.doi.org/10.5281/zenodo.12480
+.. |ptypysite| image:: https://ptycho.github.io/ptypy/_static/logo_100px.png
+         :target: https://ptycho.github.io/ptypy/
 
 
 References
 ----------
 
 .. [#pronounciation] Pronounced *typy*, forget the *p*, as in psychology.
+
+.. [#ptypypaper] B.Enders and P.Thibault, *Proc. R. Soc. A* **472**, `doi <http://doi.org/10.1098/rspa.2016.0640>`_
 
 .. [#states] P.Thibault and A.Menzel, *Nature* **494**, 68 (2013), `doi <http://dx.doi.org/10.1038/nature11806>`_
 

--- a/ptypy/experiment/ID16Anfp.py
+++ b/ptypy/experiment/ID16Anfp.py
@@ -239,7 +239,7 @@ class ID16AScan(PtyScan):
         # Load positions
         if self.ext == '.h5':
             for ii in xrange(self.num_frames):
-                projobj = io.h5read(self.frame_format.format(ii),self.h5_path)[self.h5_path]
+                projobj = io.h5read(self.filelist[ii],self.h5_path)[self.h5_path]
                 metadata = projobj['parameters']
                 motor_mne = str(metadata['motor_mne ']).split() # motor names
                 motor_pos = [eval(ii) for ii in str(metadata['motor_pos ']).split()] # motor pos

--- a/ptypy/io/h5rw.py
+++ b/ptypy/io/h5rw.py
@@ -96,7 +96,8 @@ def _h5write(filename, mode, *args, **kwargs):
     ids = []
 
     # This is needed to store strings
-    dt = h5py.new_vlen(str)
+    #dt = h5py.new_vlen(str) # deprecated
+    dt = h5py.special_dtype(vlen = str)
 
     def check_id(id):
         if id in ids:
@@ -453,16 +454,20 @@ def h5read(filename, *args, **kwargs):
         return d
 
     def _load_numpy_record_array(dset):
-        return cPickle.loads(dset.value.encode('utf-8'))
+        #return cPickle.loads(dset.value.encode('utf-8'))
+        return cPickle.loads(dset[()].encode('utf-8'))
 
     def _load_str(dset):
-        return str(dset.value)
+        #return str(dset.value)
+        return str(dset[()])
 
     def _load_unicode(dset):
-        return dset.value.decode('utf-8')
+        #return dset.value.decode('utf-8')
+        return dset[()].decode('utf-8')
 
     def _load_pickle(dset):
-        return cPickle.loads(dset.value)
+        #return cPickle.loads(dset.value)
+        return cPickle.loads(dset[()])
 
     def _load(dset, depth, sl=None):
         dset_type = dset.attrs.get('type', None)

--- a/ptypy/utils/math_utils.py
+++ b/ptypy/utils/math_utils.py
@@ -166,13 +166,13 @@ def delxf(a, axis=-1, out=None):
     if out == None:
         out = np.zeros_like(a)
 
-    out[slice2] = a[slice1] - a[slice2]
+    out[tuple(slice2)] = a[tuple(slice1)] - a[tuple(slice2)]
 
     if out is a:
         # required for in-place operation
         slice3 = [slice(-2, None) if i == axis else slice(None)
                   for i in range(nd)]
-        out[slice3] = 0.0
+        out[tuple(slice3)] = 0.0
 
     return out
 
@@ -203,7 +203,7 @@ def delxb(a, axis=-1):
     slice1 = [slice(1, None) if i == axis else slice(None) for i in range(nd)]
     slice2 = [slice(None, -1) if i == axis else slice(None) for i in range(nd)]
     b = np.zeros_like(a)
-    b[slice1] = a[slice1] - a[slice2]
+    b[tuple(slice1)] = a[tuple(slice1)] - a[tuple(slice2)]
     return b
 
 def delxc(a,axis=-1):

--- a/ptypy/utils/plot_utils.py
+++ b/ptypy/utils/plot_utils.py
@@ -742,7 +742,7 @@ class PtyAxis(object):
             plt.setp(self.ax.get_yticklabels(), fontsize=self.fontsize)
             # determine number of points.
             v, h = self.shape
-            steps = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 1500, 2000]
+            steps = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 1500, 2000, 3000]
             Nindex = steps[max([v / s <= 4 for s in steps].index(True) - 1, 0)]
             self.ax.yaxis.set_major_locator(mpl.ticker.IndexLocator(Nindex, 0.5))
             Nindex = steps[max([h / s <= 4 for s in steps].index(True) - 1, 0)]


### PR DESCRIPTION
I've upgraded the function ID16Anfp.py for NFP experiments at ID16A beamline at ESRF to take into account the new HDF5 format of the acquired data. 
I also remove the deprecation warning in math_utils.py and in h5rw.py and extended the steps in plot_utils.py