### PR TITLE
Fixed bug in position refinement parameter parsing

### DIFF
--- a/ptypy/engines/DM.py
+++ b/ptypy/engines/DM.py
@@ -122,11 +122,6 @@ class DM(PositionCorrectionEngine):
         """
         super(DM, self).__init__(ptycho_parent, pars)
 
-        p = self.DEFAULT.copy()
-        if pars is not None:
-            p.update(pars)
-        self.p = p
-
         # Instance attributes
         self.error = None
 

--- a/ptypy/engines/ML.py
+++ b/ptypy/engines/ML.py
@@ -110,11 +110,6 @@ class ML(PositionCorrectionEngine):
         """
         super(ML, self).__init__(ptycho_parent, pars)
 
-        p = self.DEFAULT.copy()
-        if pars is not None:
-            p.update(pars)
-        self.p = p
-
         # Instance attributes
 
         # Object gradient

--- a/ptypy/engines/base.py
+++ b/ptypy/engines/base.py
@@ -15,7 +15,6 @@ from ..utils import parallel
 from ..utils.verbose import logger, headerline, log
 from ..utils.descriptor import EvalDescriptor
 from .posref import AnnealingRefine
-from .. import defaults_tree
 import gc
 
 __all__ = ['BaseEngine', 'Base3dBraggEngine', 'DEFAULT_iter_info', 'PositionCorrectionEngine']

--- a/ptypy/engines/base.py
+++ b/ptypy/engines/base.py
@@ -365,6 +365,7 @@ class PositionCorrectionEngine(BaseEngine):
         """
         super(PositionCorrectionEngine, self).__init__(ptycho_parent, pars)
 
+        # TODO: this just a workaround fix, see issue #256
         # Make a copy of position refinenment defaults
         p = self.DEFAULT.position_refinement.copy()
         # If position correction is turned on, use defaults and start from beginning

--- a/ptypy/engines/base.py
+++ b/ptypy/engines/base.py
@@ -358,20 +358,29 @@ class PositionCorrectionEngine(BaseEngine):
     type = bool
     help = record movement of positions
     """
-        
+
+    def __init__(self, ptycho_parent, pars):
+        """
+        Position Correction engine.
+        """
+        super(PositionCorrectionEngine, self).__init__(ptycho_parent, pars)
+
+        # Make a copy of position refinenment defaults
+        p = self.DEFAULT.position_refinement.copy()
+        # If position correction is turned on, use defaults and start from beginning
+        if self.p.position_refinement is True:
+            p.start = 0
+        # If new position correction params are provided, update defaults
+        elif isinstance(self.p.position_refinement,u.Param):
+            p.update(self.p.position_refinement)
+        # Overwrite position refinement parameters
+        self.p.position_refinement = p
+
+
     def engine_initialize(self):
         """
         Prepare the position refinement object for use further down the line.
         """
-        p = self.DEFAULT.position_refinement.copy()
-        
-        # If position correction is turned on, use defaults and start from beginning
-        if self.p.position_refinement is True:
-            p.start = 0
-        # If position correction params are provided, update defaults
-        elif isinstance(self.p.position_refinement,u.Param):
-            p.update(self.p.position_refinement)
-        self.p.position_refinement = p
 
         # Switch for position refinement
         if (self.p.position_refinement.start is None) and (self.p.position_refinement.stop is None):

--- a/ptypy/test/engine_tests/DM_test.py
+++ b/ptypy/test/engine_tests/DM_test.py
@@ -11,6 +11,22 @@ from ptypy.test import utils as tu
 from ptypy import utils as u
 
 class DMTest(unittest.TestCase):
+
+    def test_DM_position_refinement(self):
+        engine_params = u.Param()
+        engine_params.name = 'DM'
+        engine_params.numiter = 5
+        engine_params.alpha =1
+        engine_params.probe_update_start = 2
+        engine_params.overlap_converge_factor = 0.05
+        engine_params.overlap_max_iterations = 10
+        engine_params.probe_inertia = 1e-3
+        engine_params.object_inertia = 0.1
+        engine_params.fourier_relax_factor = 0.01
+        engine_params.obj_smooth_std = 20
+        engine_params.position_refinement = True
+        tu.EngineTestRunner(engine_params)
+
     def test_DM(self):
         engine_params = u.Param()
         engine_params.name = 'DM'

--- a/ptypy/test/engine_tests/ML_old_test.py
+++ b/ptypy/test/engine_tests/ML_old_test.py
@@ -1,5 +1,5 @@
 """
-Test for the DM_simple engine.
+Test for the ML_new engine.
 
 This file is part of the PTYPY package.
     :copyright: Copyright 2014 by the PTYPY team, see AUTHORS.

--- a/ptypy/test/engine_tests/ML_test.py
+++ b/ptypy/test/engine_tests/ML_test.py
@@ -1,5 +1,5 @@
 """
-Test for the DM_simple engine.
+Test for the ML engine.
 
 This file is part of the PTYPY package.
     :copyright: Copyright 2014 by the PTYPY team, see AUTHORS.
@@ -11,6 +11,21 @@ from ptypy.test import utils as tu
 from ptypy import utils as u
 
 class MLTest(unittest.TestCase):
+
+    def test_ML_farfield_position_refinement(self):
+        engine_params = u.Param()
+        engine_params.name = 'ML'
+        engine_params.numiter = 5
+        engine_params.probe_update_start = 2
+        engine_params.floating_intensities = False
+        engine_params.intensity_renormalization = 1.0
+        engine_params.reg_del2 =True
+        engine_params.reg_del2_amplitude = 0.01
+        engine_params.smooth_gradient = 0.0
+        engine_params.scale_precond =False
+        engine_params.probe_update_start = 0
+        engine_params.position_refinement = True
+        tu.EngineTestRunner(engine_params)
 
     def test_ML_farfield_floating_intensities(self):
         engine_params = u.Param()

--- a/ptypy/test/engine_tests/dummy_test.py
+++ b/ptypy/test/engine_tests/dummy_test.py
@@ -1,5 +1,5 @@
 """
-Test for the DM_simple engine.
+Test for the Dummy engine.
 
 This file is part of the PTYPY package.
     :copyright: Copyright 2014 by the PTYPY team, see AUTHORS.


### PR DESCRIPTION
I found that in the current version of the position correction engine, that defaults and user-provided parameters are not updated properly. Position correction only works if all posref parameters are provided in the configuration. 

I've made a quick fix for this. @pierrethibault is there are more elegant way of solving this?

I've also included new tests.