### PR TITLE
Allow list or tuple to be valid version of each other in the validator.

### DIFF
--- a/ptypy/core/manager.py
+++ b/ptypy/core/manager.py
@@ -518,7 +518,7 @@ class BlockScanModel(ScanModel):
         if not self.containers_initialized:
             self._initialize_containers()
 
-        sh = (1,) + tuple(self.shape)
+        sh = (1,) + tuple(self.diff_shape)
 
         # this is a hack for now
         dp = self._new_data_extra_analysis(dp)
@@ -529,7 +529,7 @@ class BlockScanModel(ScanModel):
             chunk = dp['chunk']
 
         # Generalized shape which works for 2d and 3d cases
-        sh = (max(len(chunk.indices_node),1),) + tuple(self.shape)
+        sh = (max(len(chunk.indices_node),1),) + tuple(self.diff_shape)
         indices_node = chunk['indices_node']
         
         diff = self.Cdiff.new_storage(shape=sh, psize=self.psize, padonly=True,
@@ -538,7 +538,7 @@ class BlockScanModel(ScanModel):
                                       fill=1.0, layermap=indices_node)
         # Prepare for View generation
         AR_diff = DEFAULT_ACCESSRULE.copy()
-        AR_diff.shape = self.shape # this is None due to init
+        AR_diff.shape = self.diff_shape # this is None due to init
         AR_diff.coord = 0.0
         AR_diff.psize = self.psize
         AR_mask = AR_diff.copy()

--- a/ptypy/utils/descriptor.py
+++ b/ptypy/utils/descriptor.py
@@ -850,6 +850,8 @@ class EvalDescriptor(ArgParseDescriptor):
         if pars is None or \
                 (type(pars).__name__ in self.type) or \
                 (hasattr(pars, 'items') and 'Param' in self.type) or \
+                (type(pars).__name__ == 'tuple' and 'list' in self.type) or \
+                (type(pars).__name__ == 'list' and 'tuple' in self.type) or \
                 (type(pars).__name__ == 'int' and 'float' in self.type) or \
                 (type(pars).__name__[:5] == 'float' and 'float' in self.type):
             yield {'d': self, 'path': path, 'status': 'ok', 'info': ''}


### PR DESCRIPTION
For our uses it really doesn't matter if the parameter is a tuple or a list, and it's a consistent error I get from the validator.

The conversion between mutable and immutable is application dependent and so should happen code side.

I didn't check if the type was iterable, because that would include dictionaries, which is definitely wrong.