### PR TITLE
Large position offset causes error

### DIFF
--- a/ptypy/core/classes.py
+++ b/ptypy/core/classes.py
@@ -1256,6 +1256,7 @@ class View(Base):
             sh = (1,) + tuple(self.shape) if self.shape is not None else None
             s = self.owner.new_storage(ID=self.storageID,
                                        psize=rule.psize,
+                                       origin=rule.coord,
                                        shape=sh)
         self.storage = s
 

--- a/ptypy/core/data.py
+++ b/ptypy/core/data.py
@@ -1558,7 +1558,7 @@ class MoonFlowerScan(PtyScan):
         self.p = p
 
     def load_positions(self):
-        return self.pos + 0.5
+        return self.pos
 
     def load_weight(self):
         return np.ones(self.pr.shape)

--- a/ptypy/core/data.py
+++ b/ptypy/core/data.py
@@ -1558,7 +1558,7 @@ class MoonFlowerScan(PtyScan):
         self.p = p
 
     def load_positions(self):
-        return self.pos
+        return self.pos + 0.5
 
     def load_weight(self):
         return np.ones(self.pr.shape)


### PR DESCRIPTION
I came across this problem, when there is a large offset in the positions (relative to the step size). 

The problem is the following:
The origin for each scan is defined based on the shape of the data and the pixelsize, the coordinated on the other hand can in principle be far from away from that origin (as is the case here). This leads to very large numbers in the pixel coordinates (_to_pix conversion). The issue occurs than a bit later when we reformat the object. If there is a misfit (even just extending by a single pixel) and because the pixel coordinates are very large (> 1e6 pixels) the crop_and_pad method is trying to pad a large number of pixels on one side and then crop a similarily large on the other side. This is obviously not ideal, usually takes a long time and can cause memory allocation errors. 

I have included a test example in the templates, which reproduces this problem. 

@pierrethibault @bjoernenders is this by design? And you expect positions to always be relatively small numbers? If yes, we could easily fix this problem on the data loading side (e.g. the HDF5 loader) or do you think we should consider this case to be fixed in the ptypy/core? 