### PR TITLE
Corrected shebang in scripts and changed Matplotlib backend to tkagg

### DIFF
--- a/ptypy/utils/plot_utils.py
+++ b/ptypy/utils/plot_utils.py
@@ -17,7 +17,7 @@ import matplotlib.cm
 # importing pyplot may fail when no display is available.
 NODISPLAY = (os.getenv("DISPLAY") is None)
 if NODISPLAY:
-    matplotlib.use('agg')
+    matplotlib.use('tkagg')
 import matplotlib.pyplot as plt
 
 from .verbose import logger

--- a/ptypy/utils/plot_utils.py
+++ b/ptypy/utils/plot_utils.py
@@ -13,11 +13,6 @@ import os
 from PIL import Image
 import matplotlib as mpl
 import matplotlib.cm
-
-# importing pyplot may fail when no display is available.
-NODISPLAY = (os.getenv("DISPLAY") is None)
-if NODISPLAY:
-    matplotlib.use('tkagg')
 import matplotlib.pyplot as plt
 
 from .verbose import logger

--- a/scripts/ptypy.csv2cp
+++ b/scripts/ptypy.csv2cp
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python3
 
 from ptypy import utils as u
 import textwrap

--- a/scripts/ptypy.inspect
+++ b/scripts/ptypy.inspect
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 from ptypy import utils as u
 from ptypy import io

--- a/scripts/ptypy.new
+++ b/scripts/ptypy.new
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import sys
 import argparse

--- a/scripts/ptypy.plot
+++ b/scripts/ptypy.plot
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import sys
 import argparse

--- a/scripts/ptypy.plotclient
+++ b/scripts/ptypy.plotclient
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import sys
 import argparse

--- a/scripts/ptypy.run
+++ b/scripts/ptypy.run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import json


### PR DESCRIPTION
Corrects the shebang in scripts to be compatible with Python3 and to drop Python2 compatibility. In order to make ptypy.plotclient to run properly, I changed the matplotlib backend from agg to tkagg in case of NODISPLAY in plot_utils.py. When using the backend agg, neither ptypy.plotclient nor ptypy.plot display any plots. 
