### PR TITLE
PYCUDA smoothing kernel

### DIFF
--- a/ptypy/accelerate/py_cuda/__init__.py
+++ b/ptypy/accelerate/py_cuda/__init__.py
@@ -9,14 +9,14 @@ debug_options = ['-O3', '-DNDEBUG', '-std=c++11', '-lineinfo'] # release mode fl
 context = None
 queue = None
 
-def get_context(new_queue=False):
+def get_context(new_context=False, new_queue=False):
 
     from ptypy.utils import parallel
 
     global context
     global queue
 
-    if context is None:
+    if context is None or new_context:
         cuda.init()
         if parallel.rank_local < cuda.Device.count():
             context = cuda.Device(parallel.rank_local).make_context()
@@ -26,7 +26,7 @@ def get_context(new_queue=False):
         #                                              str(cuda.Device.count())))
         # print("parallel.rank:%s, parallel.rank_local:%s" % (str(parallel.rank),
         #                                                     str(parallel.rank_local)))
-    if queue is None:
+    if queue is None or new_queue:
         queue = cuda.Stream()
     return context, queue
 

--- a/ptypy/accelerate/py_cuda/cuda/convolution.cu
+++ b/ptypy/accelerate/py_cuda/cuda/convolution.cu
@@ -1,0 +1,187 @@
+#include <thrust/complex.h>
+using thrust::complex;
+#include <iostream>
+
+// allow testing this on CPU
+#ifndef __NVCC__
+#define __device__
+#endif
+
+/** Implements reflect-mode index wrapping
+ *
+ * maps indexes like this (reflects on both ends):
+ * Extension      | Input     | Extension
+ *  5 6 6 5 4 3 2 | 2 3 4 5 6 | 6 5 4 3 2 2 3 4 5 6 6
+ *
+ */
+ class IndexReflect
+ {
+ public:
+   /** Create index range. maxX is not included in the valid range,
+    * i.e., the range is [minX, maxX)
+    */
+   __device__ IndexReflect(int minX, int maxX) : maxX_(maxX), minX_(minX) {}
+ 
+   /// Map given index to the valid range using reflect mode
+   __device__ int operator()(int idx) const
+   {
+     if (idx < maxX_ && idx >= minX_)
+       return idx;
+     auto ddd = (idx - minX_) / (maxX_ - minX_);
+     auto mmm = (idx - minX_) % (maxX_ - minX_);
+     if (mmm < 0)
+       mmm = -mmm - 1;
+     // if odd it goes backwards from max
+     // if even it goes upwards from min
+     return ddd % 2 == 0 ? minX_ + mmm : maxX_ - mmm - 1;
+   }
+ 
+ private:
+   int maxX_, minX_;
+ };
+
+
+/*
+Row convolution kernel
+*/
+extern "C" __global__ void convolution_row(const DTYPE *__restrict__ input,
+                                           DTYPE *output,
+                                           int height,
+                                           int width,
+                                           const float* kernel,
+                                           int kernel_radius)
+{
+    int tx = threadIdx.x;
+    int ty = threadIdx.y;
+    int bx = blockIdx.x;
+    int by = blockIdx.y;
+
+    // offset for batch
+    input  += width * height * blockIdx.z;
+    output += width * height * blockIdx.z;
+
+    // reinterpret to avoid compiler warning that
+    // constructor of complex<float>() cannot be called if it's
+    // shared memory - polluting the outputs
+    extern __shared__ char shr[];
+    auto shm = reinterpret_cast<DTYPE *>(shr);
+                                       
+    // Offset to block start of core area
+    int gbx = bx * BDIM_X;
+    int gby = by * BDIM_Y;
+    int start = gbx * width + gby;
+    input  += start;
+    output += start;
+
+    // width of shared memory
+    int shwidth = BDIM_Y + 2 * kernel_radius;
+
+    // fill up shared memory    
+    if (gbx + tx < height)
+    {
+        // main part - reflecting as needed
+        IndexReflect ind(-gby, width - gby);
+        shm[tx * shwidth + (kernel_radius + ty)] = input[tx * width + ind(ty)];
+
+        // left halo (kernel radius before)
+        for (int i = ty - kernel_radius; i < 0; i += BDIM_Y)
+        {
+        shm[tx * shwidth + (i + kernel_radius)] = input[tx * width + ind(i)];
+        }
+
+        // right halo (kernel radius after)
+        for (int i = ty + BDIM_Y; i < BDIM_Y + kernel_radius; i += BDIM_Y)
+        {
+        shm[tx * shwidth + (i + kernel_radius)] = input[tx * width + ind(i)];
+        }
+    }
+
+    __syncthreads();
+
+    // safe to return now, after syncing
+    if (gby + ty >= width || gbx + tx >= height)
+        return;
+
+    // compute
+    auto sum = shm[tx * shwidth + (ty + kernel_radius)] * kernel[0];
+    for (int i = 1; i <= kernel_radius; ++i)
+    {
+        sum += (shm[tx * shwidth + (ty + i + kernel_radius)] +
+                shm[tx * shwidth + (ty - i + kernel_radius)]) *
+                kernel[i];
+    }
+
+    output[tx * width + ty] = sum;
+}
+
+
+/*
+Column convolution kernel
+*/
+extern "C" __global__ void convolution_col(const DTYPE *__restrict__ input,
+                                           DTYPE *output,
+                                           int height,
+                                           int width,
+                                           const float* kernel,
+                                           int kernel_radius)
+{
+    int tx = threadIdx.x;
+    int ty = threadIdx.y;
+    int bx = blockIdx.x;
+    int by = blockIdx.y;
+
+    // offset for batch
+    input  += width * height * blockIdx.z;
+    output += width * height * blockIdx.z;
+
+    // reinterpret to avoid compiler warning that
+    // constructor of complex<float>() cannot be called if it's
+    // shared memory - polluting the outputs
+    extern __shared__ char shr[];
+    auto shm = reinterpret_cast<DTYPE *>(shr);
+
+    // Offset to block start of core area
+    int gbx = bx * BDIM_X;
+    int gby = by * BDIM_Y;
+    int start = gbx * width + gby;
+    input  += start;
+    output += start;
+
+    // only do this if column index is in range
+    // (need to keep threads with us, so that synchthreads below doesn't deadlock)
+    if (gby + ty < width)
+    {
+        // // main data (center point for each thread) - reflecting if needed
+        IndexReflect ind(-gbx, height - gbx);
+        shm[(kernel_radius + tx) * BDIM_Y + ty] = input[ind(tx) * width + ty];
+
+        // upper halo (kernel radius before)
+        for (int i = tx - kernel_radius; i < 0; i += BDIM_X)
+        {
+            shm[(i + kernel_radius) * BDIM_Y + ty] = input[ind(i) * width + ty];
+        }
+
+        // lower halo (kernel radius after)
+        for (int i = tx + BDIM_X; i < BDIM_X + kernel_radius; i += BDIM_X)
+        {
+            shm[(i + kernel_radius) * BDIM_Y + ty] = input[ind(i) * width + ty];
+        }
+    }
+
+    __syncthreads();
+
+    // safe to return now, after syncing
+    if (gby + ty >= width || gbx + tx >= height)
+        return;
+
+    // compute
+    auto sum = shm[(tx + kernel_radius) * BDIM_Y + ty] * kernel[0];
+    for (int i = 1; i <= kernel_radius; ++i)
+    {
+        sum += (shm[(tx + i + kernel_radius) * BDIM_Y + ty] +
+                shm[(tx - i + kernel_radius) * BDIM_Y + ty]) *
+                kernel[i];
+    }
+
+    output[tx * width + ty] = sum;
+}

--- a/ptypy/accelerate/py_cuda/import_fft.py
+++ b/ptypy/accelerate/py_cuda/import_fft.py
@@ -62,7 +62,7 @@ class NvccCompiler(UnixCCompiler):
         cmp = cuda_driver.Context.get_device().compute_capability()
         archflag = '-arch=sm_{}{}'.format(cmp[0], cmp[1])
         self.src_extensions.append('.cu')
-        self.LD_FLAGS = ["-lcufft_static", "-lculibos", "-ldl", "-lrt", "-lpthread", "-cudart shared"]
+        self.LD_FLAGS = [archflag, "-lcufft_static", "-lculibos", "-ldl", "-lrt", "-lpthread", "-cudart shared"]
         self.NVCC_FLAGS = ["-dc", archflag]
         self.CXXFLAGS = ['"-fPIC"']
         pybind_includes = [pybind11.get_include(), sysconfig.get_path('include')]  

--- a/ptypy/accelerate/py_cuda/kernels.py
+++ b/ptypy/accelerate/py_cuda/kernels.py
@@ -260,7 +260,7 @@ class GradientDescentKernel(ab.GradientDescentKernel):
         self.gpu.fic_tmp = gpuarray.to_gpu(tmp)
 
         # temporary array for the reduction in fill_b
-        sh = (3, (np.prod(self.fshape)*self.nmodes + 1023) // 1024)
+        sh = (3, int((np.prod(self.fshape)*self.nmodes + 1023) // 1024))
         self.gpu.Btmp = gpuarray.zeros(sh, dtype=np.float64)
 
     def make_model(self, b_aux, addr):

--- a/ptypy/engines/DM_pycuda.py
+++ b/ptypy/engines/DM_pycuda.py
@@ -19,7 +19,7 @@ from ..utils import parallel
 from . import BaseEngine, register, DM_serial, DM
 from ..accelerate import py_cuda as gpu
 from ..accelerate.py_cuda.kernels import FourierUpdateKernel, AuxiliaryWaveKernel, PoUpdateKernel, PositionCorrectionKernel
-from ..accelerate.py_cuda.array_utils import ArrayUtilsKernel
+from ..accelerate.py_cuda.array_utils import ArrayUtilsKernel, GaussianSmoothingKernel
 from ..accelerate.array_based import address_manglers
 
 MPI = parallel.size > 1
@@ -60,12 +60,15 @@ class DM_pycuda(DM_serial.DM_serial):
         # self.const_allocator = cl.tools.ImmediateAllocator(queue, cl.mem_flags.READ_ONLY)
         ## gaussian filter
         # dummy kernel
-        if not self.p.obj_smooth_std:
-            gauss_kernel = gaussian_kernel(1, 1).astype(np.float32)
-        else:
-            gauss_kernel = gaussian_kernel(self.p.obj_smooth_std, self.p.obj_smooth_std).astype(np.float32)
+        # if not self.p.obj_smooth_std:
+        #     gauss_kernel = gaussian_kernel(1, 1).astype(np.float32)
+        # else:
+        #     gauss_kernel = gaussian_kernel(self.p.obj_smooth_std, self.p.obj_smooth_std).astype(np.float32)
+        # self.gauss_kernel_gpu = gpuarray.to_gpu(gauss_kernel)
+        
+        # Gaussian Smoothing Kernel
+        self.GSK = GaussianSmoothingKernel(queue=self.queue)
 
-        self.gauss_kernel_gpu = gpuarray.to_gpu(gauss_kernel)
 
     def engine_initialize(self):
         """
@@ -361,20 +364,16 @@ class DM_pycuda(DM_serial.DM_serial):
         queue.synchronize()
         for oID, ob in self.ob.storages.items():
             obn = self.ob_nrm.S[oID]
-            """
+            cfact = self.ob_cfact[oID]
+
             if self.p.obj_smooth_std is not None:
                 logger.info('Smoothing object, cfact is %.2f' % cfact)
-                t2 = time.time()
-                self.prg.gaussian_filter(queue, (info[3],info[4]), None, obj_gpu.data, self.gauss_kernel_gpu.data)
-                queue.synchronize()
-                obj_gpu *= cfact
-                print 'gauss: '  + str(time.time()-t2)
-            else:
-                obj_gpu *= cfact
-            """
-            cfact = self.ob_cfact[oID]
+                smooth_mfs = [self.p.obj_smooth_std, self.p.obj_smooth_std]
+                ob_gpu_tmp = gpuarray.empty(ob.shape, dtype=np.complex64)
+                self.GSK.convolution(ob.gpu, ob_gpu_tmp, smooth_mfs)
+                ob.gpu = ob_gpu_tmp
+                
             ob.gpu *= cfact
-            # obn.gpu[:] = cfact
             obn.gpu.fill(cfact)
             queue.synchronize()
 

--- a/ptypy/engines/DM_pycuda.py
+++ b/ptypy/engines/DM_pycuda.py
@@ -52,10 +52,13 @@ class DM_pycuda(DM_serial.DM_serial):
         """
         Difference map reconstruction engine.
         """
-
         super(DM_pycuda, self).__init__(ptycho_parent, pars)
 
-        self.context, self.queue = gpu.get_context()
+    def engine_initialize(self):
+        """
+        Prepare for reconstruction.
+        """
+        self.context, self.queue = gpu.get_context(new_context=True, new_queue=True)
         # allocator for READ only buffers
         # self.const_allocator = cl.tools.ImmediateAllocator(queue, cl.mem_flags.READ_ONLY)
         ## gaussian filter
@@ -69,13 +72,7 @@ class DM_pycuda(DM_serial.DM_serial):
         # Gaussian Smoothing Kernel
         self.GSK = GaussianSmoothingKernel(queue=self.queue)
 
-
-    def engine_initialize(self):
-        """
-        Prepare for reconstruction.
-        """
         super(DM_pycuda, self).engine_initialize()
-
         self.error = []
 
     def _setup_kernels(self):

--- a/ptypy/engines/DM_pycuda_streams.py
+++ b/ptypy/engines/DM_pycuda_streams.py
@@ -442,17 +442,14 @@ class DM_pycuda_streams(DM_pycuda.DM_pycuda):
                         cfact = self.ob_cfact[oID]
                         obn = self.ob_nrm.S[oID]
                         obb = self.ob_buf.S[oID]
-                        """
+                        
                         if self.p.obj_smooth_std is not None:
                             logger.info('Smoothing object, cfact is %.2f' % cfact)
-                            t2 = time.time()
-                            self.prg.gaussian_filter(queue, (info[3],info[4]), None, obj_gpu.data, self.gauss_kernel_gpu.data)
-                            queue.finish()
-                            obj_gpu *= cfact
-                            print 'gauss: '  + str(time.time()-t2)
-                        else:
-                            obj_gpu *= cfact
-                        """
+                            smooth_mfs = [self.p.obj_smooth_std, self.p.obj_smooth_std]
+                            ob_gpu_tmp = gpuarray.empty(ob.shape, dtype=np.complex64)
+                            self.GSK.convolution(ob.gpu, ob_gpu_tmp, smooth_mfs)
+                            ob.gpu = ob_gpu_tmp
+                        
                         ob.gpu._axpbz(np.complex64(cfact), 0, obb.gpu, stream=streamdata.queue)
                         obn.gpu.fill(np.float32(cfact), stream=streamdata.queue)
                 

--- a/ptypy/engines/ML_pycuda.py
+++ b/ptypy/engines/ML_pycuda.py
@@ -140,19 +140,19 @@ class ML_pycuda(ML_serial):
         """
         super().__init__(ptycho_parent, pars)
 
-        self.context, self.queue = gpu.get_context()
+    def engine_initialize(self):
+        """
+        Prepare for ML reconstruction.
+        """
+        self.context, self.queue = gpu.get_context(new_context=True, new_queue=True)
 
         self.dmp = DeviceMemoryPool()
         self.queue_transfer = cuda.Stream()
         
         self.GSK = GaussianSmoothingKernel(queue=self.queue)
-
-    def engine_initialize(self):
-        """
-        Prepare for ML reconstruction.
-        """
+        
         super().engine_initialize()
-        self._setup_kernels()
+        #self._setup_kernels()
 
     def _setup_kernels(self):
         """

--- a/ptypy/engines/ML_pycuda.py
+++ b/ptypy/engines/ML_pycuda.py
@@ -188,7 +188,7 @@ class ML_pycuda(ML_serial):
                 nmodes = 1
 
             # create buffer arrays
-            ash = (fpc * nmodes,) + tuple(geo.shape)
+            ash = (fpc * nmodes,) + tuple([int(s) for s in geo.shape])
             aux = gpuarray.zeros(ash, dtype=np.complex64)
             kern.aux = aux
             kern.a = gpuarray.zeros(ash, dtype=np.complex64)

--- a/ptypy/test/accelerate_tests/py_cuda_tests/array_utils_test.py
+++ b/ptypy/test/accelerate_tests/py_cuda_tests/array_utils_test.py
@@ -7,7 +7,6 @@ import unittest
 import numpy as np
 from . import perfrun, PyCudaTest, have_pycuda
 from ptypy.accelerate.array_based import array_utils as au
-from ptypy.utils import gaussian2D
 
 if have_pycuda():
     from pycuda import gpuarray


### PR DESCRIPTION
* reimplemented gaussian smoothing kernel for PYCUDA
* wrote new UNITY tests, all passing (although had to lower tolerance to 1e-4 for some of them)
* made DM_pycuda and DM_pycuda_streams use the new kernel for smoothing the object -> tested and seems to work
* fixed ML_pycuda to use new kernel for smoothing the gradient -> tested and seems to work
* few more fixes to avoid some warnings
* moved context creation from init() to engine_initialize(), this way we can use a new context for each pycuda engine.