### PR TITLE
Allow for negative propagation in geometry.py

### DIFF
--- a/ptypy/core/data.py
+++ b/ptypy/core/data.py
@@ -1207,7 +1207,7 @@ class PtyScan(object):
                 hddaddress = self.dfile + '.part%03d' % num
                 io.h5write(hddaddress, todisk)
 
-                with h5py.File(self.dfile) as f:
+                with h5py.File(self.dfile, 'a') as f:
                     f[h5address] = h5py.ExternalLink(hddaddress, '/')
                     f.close()
 

--- a/ptypy/core/geometry.py
+++ b/ptypy/core/geometry.py
@@ -83,7 +83,6 @@ class Geo(Base):
     help = Distance from object to detector (in meters)
     doc =
     userlevel = 0
-    lowlim = 0
 
     [psize]
     type = float

--- a/ptypy/io/h5rw.py
+++ b/ptypy/io/h5rw.py
@@ -443,7 +443,7 @@ def h5read(filename, *args, **kwargs):
 
     def _load_str(dset):
         #return str(dset[()])
-        return dset.asstr()
+        return dset.asstr()[0]
 
     def _load_unicode(dset):
         return dset[()].decode('utf-8')

--- a/ptypy/io/h5rw.py
+++ b/ptypy/io/h5rw.py
@@ -443,7 +443,7 @@ def h5read(filename, *args, **kwargs):
 
     def _load_str(dset):
         #return str(dset[()])
-        dset[()].asstr()
+        return dset.asstr()
 
     def _load_unicode(dset):
         return dset[()].decode('utf-8')

--- a/ptypy/io/h5rw.py
+++ b/ptypy/io/h5rw.py
@@ -442,9 +442,11 @@ def h5read(filename, *args, **kwargs):
         return d
 
     def _load_str(dset):
-        #return str(dset[()])
-        return dset.asstr()[0]
-
+        if h5py.version.version_tuple[0]>2:
+            return dset[()].decode('utf-8')
+        else:
+            return str(dset[()])
+        
     def _load_unicode(dset):
         return dset[()].decode('utf-8')
 

--- a/ptypy/io/h5rw.py
+++ b/ptypy/io/h5rw.py
@@ -442,7 +442,8 @@ def h5read(filename, *args, **kwargs):
         return d
 
     def _load_str(dset):
-        return str(dset[()])
+        #return str(dset[()])
+        dset[()].asstr()
 
     def _load_unicode(dset):
         return dset[()].decode('utf-8')


### PR DESCRIPTION
Removed lower limit of 0 from `distance` parameter to allow for negative propagation.