### PR TITLE
resolved some of current warnings

### DIFF
--- a/ptypy/core/data.py
+++ b/ptypy/core/data.py
@@ -93,8 +93,8 @@ class PtyScan(object):
         <newline>
         - ``None``: No saving
         - ``'merge'``: attemts to merge data in single chunk **[not implemented]**
-        - ``'append'``: appends each chunk in master \*.ptyd file
-        - ``'link'``: appends external links in master \*.ptyd file and stores chunks separately
+        - ``'append'``: appends each chunk in master \\*.ptyd file
+        - ``'link'``: appends external links in master \\*.ptyd file and stores chunks separately
         <newline>
         in the path given by the link. Links file paths are relative to master file.
     userlevel = 1
@@ -316,7 +316,7 @@ class PtyScan(object):
         Begins the Data preparation and intended as the first method
         that does read-write access on (large) data. Does the following:
 
-        * Creates a \*.ptyd data file at location specified by
+        * Creates a \\*.ptyd data file at location specified by
           :py:data:`dfile` (master node only)
         * Calls :py:meth:`load_weight`, :py:meth:`load_positions`
           :py:meth:`load_common` (master node only for

--- a/ptypy/test/core_tests/core_test.py
+++ b/ptypy/test/core_tests/core_test.py
@@ -13,7 +13,6 @@ from ptypy.core.classes import DEFAULT_ACCESSRULE
 class CoreTest(unittest.TestCase):
     C1 = Container(data_type='real')
     S1 = C1.new_storage(shape=(1, 7, 7))
-    S1=C1.new_storage(data=np.ones((1,7,7)))
     ar = DEFAULT_ACCESSRULE.copy()
     ar.shape = (4, 4)  # ar.shape = 4 would have been also valid.
     ar.coord = 0.      # ar.coord = (0.,0.) would have been accepted, too.
@@ -29,7 +28,6 @@ class CoreTest(unittest.TestCase):
     data = S1[V1]
     V1.coord = (0.28, 0.28)
     S1.update_views(V1)
-    print(V1.storageID)
     mn = S1[V1].mean()
     S1.fill_value = mn
     S1.reformat()

--- a/ptypy/utils/array_utils.py
+++ b/ptypy/utils/array_utils.py
@@ -330,7 +330,7 @@ c_affine_transform.__doc__='*complex input*\n\n'+c_affine_transform.__doc__
 """
 
 def shift_zoom(c,zoom,cen_old,cen_new,**kwargs):
-    """\
+    """
     Move array from center `cen_old` to `cen_new` and perform a zoom `zoom`.
     
     This function wraps `scipy.ndimage.affine_transform <https://docs.scipy.org/
@@ -370,7 +370,7 @@ def shift_zoom(c,zoom,cen_old,cen_new,**kwargs):
 
 
 def fill3D(A,B,offset=[0,0,0]):
-    """\
+    """
     Fill 3-dimensional array A with B.
     """
     if A.ndim != 3 or B.ndim!=3:
@@ -392,7 +392,7 @@ def fill3D(A,B,offset=[0,0,0]):
 
 
 def mirror(A,axis=-1):
-    """\
+    """
     Mirrors array `A` along one axis `axis`
 
     Parameters

--- a/ptypy/utils/array_utils.py
+++ b/ptypy/utils/array_utils.py
@@ -338,7 +338,7 @@ def shift_zoom(c,zoom,cen_old,cen_new,**kwargs):
     uses the same keyword arguments.
 
     Addiionally, it allows for complex input and out by complex overloading, see
-    :any:`complex_overload`\ . 
+    :any:`complex_overload`. 
 
     Parameters
     ----------

--- a/ptypy/utils/math_utils.py
+++ b/ptypy/utils/math_utils.py
@@ -57,8 +57,8 @@ def gaussian(x, std=1.0, off=0.0):
     Evaluates gaussian standard normal
 
     .. math::
-        g(x)=\\frac{1}{\mathrm{std}\sqrt{2\pi}}\,\exp
-        \\left(-\\frac{(x-\mathrm{off})^2}{2 \mathrm{std}^2 }\\right)
+        g(x)=\\frac{1}{\\mathrm{std}\\sqrt{2\\pi}}\\,\\exp
+        \\left(-\\frac{(x-\\mathrm{off})^2}{2 \\mathrm{std}^2 }\\right)
 
     Parameters
     ----------


### PR DESCRIPTION
- Removed invalid "\\" sequences
- Fixed core_tests which was using depecrated syntax

Only remaining warning is related to h5py - but is going to be fixed with PR #273 