### PR TITLE
[bugfix] Gaussian kernel now works with non-square images

### DIFF
--- a/ptypy/accelerate/py_cuda/array_utils.py
+++ b/ptypy/accelerate/py_cuda/array_utils.py
@@ -247,7 +247,7 @@ class GaussianSmoothingKernel:
                 raise MemoryError("Cannot run kernel in shared memory")
 
             blk = (bx, by, 1)
-            grd = (int((x + bx -1)// bx), int((y + by-1)// by), batches)
+            grd = (int((y + bx -1)// bx), int((x + by-1)// by), batches)
             self.convolution_row(input, output, np.int32(y), np.int32(x), kernel, np.int32(r), 
                                  block=blk, grid=grd, shared=shared, stream=self.queue)
 
@@ -269,7 +269,7 @@ class GaussianSmoothingKernel:
                 raise MemoryError("Cannot run kernel in shared memory")
 
             blk = (bx, by, 1)
-            grd = (int((x + bx -1)// bx), int((y + by-1)// by), batches)
+            grd = (int((y + bx -1)// bx), int((x + by-1)// by), batches)
             self.convolution_col(input, output, np.int32(y), np.int32(x), kernel, np.int32(r), 
                                  block=blk, grid=grd, shared=shared, stream=self.queue)
 

--- a/ptypy/accelerate/py_cuda/kernels.py
+++ b/ptypy/accelerate/py_cuda/kernels.py
@@ -77,7 +77,8 @@ class PropagationKernel:
         self._queue = queue
         self._fft1.queue = queue
         self._fft2.queue = queue
-        self._fft3.queue = queue
+        if self.prop_type == "nearfield":
+            self._fft3.queue = queue
 
 class FourierUpdateKernel(ab.FourierUpdateKernel):
 

--- a/ptypy/engines/ML_serial.py
+++ b/ptypy/engines/ML_serial.py
@@ -260,6 +260,9 @@ class ML_serial(ML):
             self.pr += self.pr_h
             # Newton-Raphson loop would end here
 
+            # Allow for customized modifications at the end of each iteration
+            self._post_iterate_update()
+
             # increase iteration counter
             self.curiter += 1
 

--- a/ptypy/test/accelerate_tests/py_cuda_tests/array_utils_test.py
+++ b/ptypy/test/accelerate_tests/py_cuda_tests/array_utils_test.py
@@ -194,6 +194,26 @@ class ArrayUtilsTest(PyCudaTest):
         out = out_dev.get()
         np.testing.assert_allclose(out_exp, out, rtol=1e-4)
 
+    def test_complex_gaussian_filter_2d_nonsquare_UNITY(self):
+        # Arrange
+        inp = np.zeros((32, 16), dtype=np.complex64)
+        inp[3:4, 11:12] = 2.0+2.0j
+        inp[3:5, 3:5] = 2.0+2.0j
+        inp[20:25,3:5] = 2.0+2.0j
+        mfs = 1.0,1.0
+        inp_dev = gpuarray.to_gpu(inp)
+        out_dev = gpuarray.empty(inp.shape, dtype=np.complex64)
+
+        # Act
+        GS = gau.GaussianSmoothingKernel()
+        GS.convolution(inp_dev, out_dev, mfs)
+
+        # Assert
+        out_exp = au.complex_gaussian_filter(inp, mfs)
+        out = out_dev.get()
+
+        np.testing.assert_allclose(out_exp, out, rtol=1e-4)
+
     def test_complex_gaussian_filter_2d_batched(self):
         # Arrange
         batch_number = 2


### PR DESCRIPTION
Discovered that pycuda Gaussian smoothing kernel was broken for non-square images.

- Added test with non-square input data
- Found bug and fixed it
- Added post_iterate_update function to ML_serial, now in line with ML
- Fixed a bug in Propagation kernel: _fft3 queue should only be updated for nearfield