### PR TITLE
Gpu flexible datatypes

### DIFF
--- a/ptypy/accelerate/cuda_pycuda/__init__.py
+++ b/ptypy/accelerate/cuda_pycuda/__init__.py
@@ -42,6 +42,9 @@ def load_kernel(name, subs={}, file=None):
         kernel = f.read()
     for k,v in list(subs.items()):
         kernel = kernel.replace(k, str(v))
+    # insert a preprocessor line directive to assist compiler errors
+    escaped = fn.replace("\\", "\\\\")
+    kernel = '#line 1 "{}"\n'.format(escaped) + kernel
     mod = SourceModule(kernel, include_dirs=[np.get_include()], no_extern_c=True, options=debug_options)
     return mod.get_function(name)
 

--- a/ptypy/accelerate/cuda_pycuda/array_utils.py
+++ b/ptypy/accelerate/cuda_pycuda/array_utils.py
@@ -16,7 +16,9 @@ class ArrayUtilsKernel:
             'ACC_TYPE': 'double' if acc_dtype==np.float64 else 'float'
         })
         self.full_reduce_cuda = load_kernel("full_reduce", {
-            'DTYPE': 'double' if acc_dtype==np.float64 else 'float',
+            'IN_TYPE': 'double' if acc_dtype==np.float64 else 'float',
+            'OUT_TYPE': 'double' if acc_dtype==np.float64 else 'float',
+            'ACC_TYPE': 'double' if acc_dtype==np.float64 else 'float',
             'BDIM_X': 1024
         })
         self.transpose_cuda = load_kernel("transpose", {

--- a/ptypy/accelerate/cuda_pycuda/array_utils.py
+++ b/ptypy/accelerate/cuda_pycuda/array_utils.py
@@ -8,12 +8,12 @@ class ArrayUtilsKernel:
         self.queue = queue
         self.acc_dtype = acc_dtype
         self.cdot_cuda = load_kernel("dot", {
-            'INTYPE': 'complex<float>',
-            'ACCTYPE': 'double' if acc_dtype==np.float64 else 'float'
+            'IN_TYPE': 'complex<float>',
+            'ACC_TYPE': 'double' if acc_dtype==np.float64 else 'float'
         })
         self.dot_cuda = load_kernel("dot", {
-            'INTYPE': 'float',
-            'ACCTYPE': 'double' if acc_dtype==np.float64 else 'float'
+            'IN_TYPE': 'float',
+            'ACC_TYPE': 'double' if acc_dtype==np.float64 else 'float'
         })
         self.full_reduce_cuda = load_kernel("full_reduce", {
             'DTYPE': 'double' if acc_dtype==np.float64 else 'float',

--- a/ptypy/accelerate/cuda_pycuda/array_utils.py
+++ b/ptypy/accelerate/cuda_pycuda/array_utils.py
@@ -103,25 +103,29 @@ class DerivativesKernel:
             'IS_FORWARD': 'true',
             'BDIM_X': str(self.last_axis_block[0]),
             'BDIM_Y': str(self.last_axis_block[1]),
-            'DTYPE': stype
+            'IN_TYPE': stype,
+            'OUT_TYPE': stype
         })
         self.delxb_last = load_kernel("delx_last", file="delx_last.cu", subs={
             'IS_FORWARD': 'false',
             'BDIM_X': str(self.last_axis_block[0]),
             'BDIM_Y': str(self.last_axis_block[1]),
-            'DTYPE': stype
+            'IN_TYPE': stype,
+            'OUT_TYPE': stype
         })
         self.delxf_mid = load_kernel("delx_mid", file="delx_mid.cu", subs={
             'IS_FORWARD': 'true',
             'BDIM_X': str(self.mid_axis_block[0]),
             'BDIM_Y': str(self.mid_axis_block[1]),
-            'DTYPE': stype
+            'IN_TYPE': stype,
+            'OUT_TYPE': stype
         })
         self.delxb_mid = load_kernel("delx_mid", file="delx_mid.cu", subs={
             'IS_FORWARD': 'false',
             'BDIM_X': str(self.mid_axis_block[0]),
             'BDIM_Y': str(self.mid_axis_block[1]),
-            'DTYPE': stype
+            'IN_TYPE': stype,
+            'OUT_TYPE': stype
         })
 
     def delxf(self, input, out, axis=-1):

--- a/ptypy/accelerate/cuda_pycuda/cuda/batched_multiply.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/batched_multiply.cu
@@ -1,13 +1,19 @@
 /** This kernel was used for FFT pre- and post-scaling,
     to test if cuFFT via python is worthwhile.
     It turned out it wasn't.
-*/
+ * 
+ * Data types:
+ * - IN_TYPE: the data type for the inputs
+ * - OUT_TYPE: the data type for the outputs
+ * - MATH_TYPE: the data type used for computation (filter)
+ */
+
 #include <thrust/complex.h>
 using thrust::complex;
 
-extern "C" __global__ void batched_multiply(const complex<float>* input,
-                                            complex<float>* output,
-                                            const complex<float>* filter,
+extern "C" __global__ void batched_multiply(const complex<IN_TYPE>* input,
+                                            complex<OUT_TYPE>* output,
+                                            const complex<MATH_TYPE>* filter,
                                             float scale,
                                             int nBatches,
                                             int rows,

--- a/ptypy/accelerate/cuda_pycuda/cuda/build_aux_position_correction.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/build_aux_position_correction.cu
@@ -1,12 +1,20 @@
+/** build_aux for position correction.
+ *
+ * Data types:
+ * - IN_TYPE: the data type for the inputs (float or double)
+ * - OUT_TYPE: the data type for the outputs (float or double - for aux wave)
+ * - MATH_TYPE: the data type used for computation 
+ */
+
 #include <thrust/complex.h>
 using thrust::complex;
 
 extern "C" __global__ void build_aux_position_correction(
-    complex<float>* auxiliary_wave,
-    const complex<float>* __restrict__ probe,
+    complex<OUT_TYPE>* auxiliary_wave,
+    const complex<IN_TYPE>* __restrict__ probe,
     int B,
     int C,
-    const complex<float>* __restrict__ obj,
+    const complex<IN_TYPE>* __restrict__ obj,
     int H,
     int I,
     const int* __restrict__ addr)
@@ -30,7 +38,9 @@ extern "C" __global__ void build_aux_position_correction(
                    // (it will work for less as well)
     for (int c = tx; c < C; c += blockDim.x)
     {
-      auxiliary_wave[b * C + c] = obj[b * I + c] * probe[b * C + c];
+      complex<MATH_TYPE> t_obj = obj[b * I + c];
+      complex<MATH_TYPE> t_probe = probe[b * C + c];
+      auxiliary_wave[b * C + c] = t_obj * t_probe;
     }
   }
 }

--- a/ptypy/accelerate/cuda_pycuda/cuda/convolution.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/convolution.cu
@@ -1,3 +1,11 @@
+/**
+ * Data types:
+ * - DTYPE (float/double/complex<float>/complex<double>)
+ * - MATH_TYPE (float/double) - used for the convolution kernel itself
+ * 
+ * A symmetric convolution kernel is assumed here
+ */
+
 #include <thrust/complex.h>
 using thrust::complex;
 
@@ -42,7 +50,7 @@ extern "C" __global__ void convolution_row(const DTYPE *__restrict__ input,
                                            DTYPE *output,
                                            int height,
                                            int width,
-                                           const float* kernel,
+                                           const MATH_TYPE* kernel,
                                            int kernel_radius)
 {
     int tx = threadIdx.x;
@@ -97,7 +105,7 @@ extern "C" __global__ void convolution_row(const DTYPE *__restrict__ input,
     if (gby + ty >= width || gbx + tx >= height)
         return;
 
-    // compute
+    // compute  - will be complex<double> if kernel is double
     auto sum = shm[tx * shwidth + (ty + kernel_radius)] * kernel[0];
     for (int i = 1; i <= kernel_radius; ++i)
     {
@@ -117,7 +125,7 @@ extern "C" __global__ void convolution_col(const DTYPE *__restrict__ input,
                                            DTYPE *output,
                                            int height,
                                            int width,
-                                           const float* kernel,
+                                           const MATH_TYPE* kernel,
                                            int kernel_radius)
 {
     int tx = threadIdx.x;
@@ -169,7 +177,7 @@ extern "C" __global__ void convolution_col(const DTYPE *__restrict__ input,
     if (gby + ty >= width || gbx + tx >= height)
         return;
 
-    // compute
+    // compute - will be complex<double> if kernel is double
     auto sum = shm[(tx + kernel_radius) * BDIM_Y + ty] * kernel[0];
     for (int i = 1; i <= kernel_radius; ++i)
     {

--- a/ptypy/accelerate/cuda_pycuda/cuda/delx_last.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/delx_last.cu
@@ -1,3 +1,10 @@
+/** difference along last axis
+ *
+ * Data types:
+ * - IN_TYPE: the data type for the inputs 
+ * - OUT_TYPE: the data type for the outputs 
+ */
+
 #include <thrust/complex.h>
 using thrust::complex;
 
@@ -10,14 +17,14 @@ using thrust::complex;
  * Otherwise it follows the same ideas as delx_mid - please read the
  * description there.
   */
-extern "C" __global__ void delx_last(const DTYPE *__restrict__ input,
-                                     DTYPE *output,
+extern "C" __global__ void delx_last(const IN_TYPE *__restrict__ input,
+                                     OUT_TYPE *output,
                                      int flat_dim,
                                      int axis_dim)
 {
   // reinterpret to avoid constructor of complex<float>() + compiler warning
-  __shared__ char shr[BDIM_X * BDIM_Y * sizeof(DTYPE)];
-  auto shared_data = reinterpret_cast<DTYPE *>(shr);
+  __shared__ char shr[BDIM_X * BDIM_Y * sizeof(IN_TYPE)];
+  auto shared_data = reinterpret_cast<IN_TYPE *>(shr);
 
   unsigned int tx = threadIdx.x;
   unsigned int ty = threadIdx.y;
@@ -43,7 +50,7 @@ extern "C" __global__ void delx_last(const DTYPE *__restrict__ input,
     {
       if (IS_FORWARD)
       {
-        DTYPE plus1;
+        IN_TYPE plus1;
         if (tx < BDIM_X - 1 &&
             ix < axis_dim - 1)  // we have a next element in shared data
         {
@@ -62,7 +69,7 @@ extern "C" __global__ void delx_last(const DTYPE *__restrict__ input,
       }
       else
       {
-        DTYPE minus1;
+        IN_TYPE minus1;
         if (tx > 0)  // we have a previous element in shared
         {
           minus1 = shared_data[ty * BDIM_X + tx - 1];

--- a/ptypy/accelerate/cuda_pycuda/cuda/delx_mid.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/delx_mid.cu
@@ -1,3 +1,10 @@
+/** difference along any axis
+ *
+ * Data types:
+ * - IN_TYPE: the data type for the inputs 
+ * - OUT_TYPE: the data type for the outputs 
+ */
+
 #include <thrust/complex.h>
 using thrust::complex;
 
@@ -40,8 +47,8 @@ using thrust::complex;
  * zero if it's the end of the input.
  *
  */
-extern "C" __global__ void delx_mid(const DTYPE *__restrict__ input,
-                                    DTYPE *output,
+extern "C" __global__ void delx_mid(const IN_TYPE *__restrict__ input,
+                                    OUT_TYPE *output,
                                     int lower_dim,   // x for 3D
                                     int higher_dim,  // z for 3D
                                     int axis_dim)
@@ -49,8 +56,8 @@ extern "C" __global__ void delx_mid(const DTYPE *__restrict__ input,
   // reinterpret to avoid compiler warning that
   // constructor of complex<float>() cannot be called if it's
   // shared memory - polluting the outputs
-  __shared__ char shr[BDIM_X * BDIM_Y * sizeof(DTYPE)];
-  auto shared_data = reinterpret_cast<DTYPE *>(shr);
+  __shared__ char shr[BDIM_X * BDIM_Y * sizeof(IN_TYPE)];
+  auto shared_data = reinterpret_cast<IN_TYPE *>(shr);
 
   unsigned int tx = threadIdx.x;
   unsigned int ty = threadIdx.y;
@@ -82,7 +89,7 @@ extern "C" __global__ void delx_mid(const DTYPE *__restrict__ input,
     {
       if (IS_FORWARD)
       {
-        DTYPE plus1;
+        IN_TYPE plus1;
         if (ty < BDIM_Y - 1 &&
             iy < axis_dim - 1)  // we have a next element in shared data
         {
@@ -100,7 +107,7 @@ extern "C" __global__ void delx_mid(const DTYPE *__restrict__ input,
       }
       else
       {
-        DTYPE minus1;
+        IN_TYPE minus1;
         if (ty > 0)  // we have a previous element in shared
         {
           minus1 = shared_data[(ty - 1) * BDIM_X + tx];

--- a/ptypy/accelerate/cuda_pycuda/cuda/dot.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/dot.cu
@@ -15,15 +15,15 @@ __device__ inline T dotmul(const complex<T>& a, const complex<T>& b)
   return a.real() * b.real() + a.imag() * b.imag();
 }
 
-extern "C" __global__ void dot(const INTYPE* a,
-                               const INTYPE* b,
+extern "C" __global__ void dot(const IN_TYPE* a,
+                               const IN_TYPE* b,
                                int size,
-                               ACCTYPE* out)
+                               ACC_TYPE* out)
 {
   int tx = threadIdx.x;
   int ix = tx + blockIdx.x * blockDim.x;
 
-  __shared__ ACCTYPE sh[1024];
+  __shared__ ACC_TYPE sh[1024];
 
   if (ix < size)
   {
@@ -31,7 +31,7 @@ extern "C" __global__ void dot(const INTYPE* a,
   }
   else
   {
-    sh[tx] = ACCTYPE(0);
+    sh[tx] = ACC_TYPE(0);
   }
   __syncthreads();
 

--- a/ptypy/accelerate/cuda_pycuda/cuda/error_reduce.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/error_reduce.cu
@@ -27,7 +27,7 @@ extern "C" __global__ void error_reduce(const IN_TYPE* ferr,
     {
       int idx = batch * M * N + m * N +
                 n;  // idx is index qwith respect to the full stack
-      sum += ferr[idx];
+      sum += ACC_TYPE(ferr[idx]);
     }
   }
 

--- a/ptypy/accelerate/cuda_pycuda/cuda/error_reduce.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/error_reduce.cu
@@ -1,17 +1,24 @@
+/** error_reduce kernel.
+ *
+ * Data types:
+ * - IN_TYPE: the data type for the inputs (float or double)
+ * - OUT_TYPE: the data type for the outputs (float or double)
+ * - ACC_TYPE: the data type used for computation 
+ */
 
-extern "C" __global__ void error_reduce(const float* ferr,
-                                        float* err_fmag,
+extern "C" __global__ void error_reduce(const IN_TYPE* ferr,
+                                        OUT_TYPE* err_fmag,
                                         int M,
                                         int N)
 {
   int tx = threadIdx.x;
   int ty = threadIdx.y;
   int batch = blockIdx.x;
-  extern __shared__ float sum_v[1024];
+  extern __shared__ ACC_TYPE sum_v[1024];
 
   int shidx =
       ty * blockDim.x + tx;  // shidx: index in shared memory for this block
-  float sum = 0.0f;
+  ACC_TYPE sum = ACC_TYPE(0.0);
 
   for (int m = ty; m < M; m += blockDim.y)
   {
@@ -44,6 +51,6 @@ extern "C" __global__ void error_reduce(const float* ferr,
 
   if (shidx == 0)
   {
-    err_fmag[batch] = float(sum_v[0]);
+    err_fmag[batch] = OUT_TYPE(sum_v[0]);
   }
 }

--- a/ptypy/accelerate/cuda_pycuda/cuda/fill_b_reduce.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/fill_b_reduce.cu
@@ -1,12 +1,21 @@
+/** fill_b_reduce - for second-stage reduction used after fill_b.
+ * 
+ * Note that the IN_TYPE here must match what's produced by the fill_b kernel
+ * Data types:
+ * - IN_TYPE: the data type for the inputs
+ * - OUT_TYPE: the data type for the outputs
+ * - ACC_TYPE: the accumulator type for summing
+ */
+
 #include <cassert>
 
-extern "C" __global__ void fill_b_reduce(const double* in, FTYPE* B, int blocks)
+extern "C" __global__ void fill_b_reduce(const IN_TYPE* in, OUT_TYPE* B, int blocks)
 {
   // always a single thread block for 2nd stage
   assert(gridDim.x == 1);
   int tx = threadIdx.x;
 
-  __shared__ double smem[3][BDIM_X];
+  __shared__ ACC_TYPE smem[3][BDIM_X];
 
   double sum0 = 0.0, sum1 = 0.0, sum2 = 0.0;
   for (int ix = tx; ix < blocks; ix += blockDim.x)
@@ -37,8 +46,8 @@ extern "C" __global__ void fill_b_reduce(const double* in, FTYPE* B, int blocks)
 
   if (tx == 0)
   {
-    B[0] += FTYPE(smem[0][0]);
-    B[1] += FTYPE(smem[1][0]);
-    B[2] += FTYPE(smem[2][0]);
+    B[0] += OUT_TYPE(smem[0][0]);
+    B[1] += OUT_TYPE(smem[1][0]);
+    B[2] += OUT_TYPE(smem[2][0]);
   }
 }

--- a/ptypy/accelerate/cuda_pycuda/cuda/fmag_all_update.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/fmag_all_update.cu
@@ -1,15 +1,23 @@
+/** fmag_all_update.
+ *
+ * Data types:
+ * - IN_TYPE: the data type for the inputs (float or double)
+ * - OUT_TYPE: the data type for the outputs (float or double)
+ * - MATH_TYPE: the data type used for computation 
+ */
+
 #include <cmath>
 #include <thrust/complex.h>
 using std::sqrt;
 using thrust::complex;
 
-extern "C" __global__ void fmag_all_update(complex<float>* f,
-                                           const float* fmask,
-                                           const float* fmag,
-                                           const float* fdev,
-                                           const float* err_fmag,
+extern "C" __global__ void fmag_all_update(complex<OUT_TYPE>* f,
+                                           const IN_TYPE* fmask,
+                                           const IN_TYPE* fmag,
+                                           const IN_TYPE* fdev,
+                                           const IN_TYPE* err_fmag,
                                            const int* addr_info,
-                                           float pbound,
+                                           IN_TYPE pbound_,
                                            int A,
                                            int B)
 {
@@ -17,23 +25,24 @@ extern "C" __global__ void fmag_all_update(complex<float>* f,
   int tx = threadIdx.x;
   int ty = threadIdx.y;
   int addr_stride = 15;
+  MATH_TYPE pbound = pbound_;
 
   const int* ea = addr_info + batch * addr_stride + 6;
   const int* da = addr_info + batch * addr_stride + 9;
   const int* ma = addr_info + batch * addr_stride + 12;
 
   fmask += ma[0] * A * B;
-  float err = err_fmag[da[0]];
+  MATH_TYPE err = err_fmag[da[0]];
   fdev += da[0] * A * B;
   fmag += da[0] * A * B;
   f += ea[0] * A * B;
-  float renorm = sqrt(pbound / err);
+  MATH_TYPE renorm = sqrt(pbound / err);
 
   for (int a = ty; a < A; a += blockDim.y)
   {
     for (int b = tx; b < B; b += blockDim.x)
     {
-      float m = fmask[a * A + b];
+      MATH_TYPE m = fmask[a * A + b];
       if (renorm < 1.0f)
       {
         /*
@@ -42,10 +51,10 @@ extern "C" __global__ void fmag_all_update(complex<float>* f,
           ((fmag[a * A + b] + fdev[a * A + b] * renorm) / (fdev[a * A + b] +
         fmag[a * A + b]  + 1e-7f)) ;
         */
-        auto fmagv = fmag[a * A + b];
-        auto fdevv = fdev[a * A + b];
-        float fm = (1.0f - m) +
-                   m * ((fmagv + fdevv * renorm) / (fmagv + fdevv + 1e-7f));
+        MATH_TYPE fmagv = fmag[a * A + b];
+        MATH_TYPE fdevv = fdev[a * A + b];
+        MATH_TYPE fm = (MATH_TYPE(1) - m) +
+                   m * ((fmagv + fdevv * renorm) / (fmagv + fdevv + MATH_TYPE(1e-7)));
         f[a * A + b] *= fm;
       }
     }

--- a/ptypy/accelerate/cuda_pycuda/cuda/fourier_error.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/fourier_error.cu
@@ -1,3 +1,12 @@
+/** fourier_error.
+ *
+ * Data types:
+ * - IN_TYPE: the data type for the inputs (float or double)
+ * - OUT_TYPE: the data type for the outputs (float or double)
+ * - MATH_TYPE: the data type used for computation 
+ */
+
+
 #include <cassert>
 #include <cmath>
 #include <thrust/complex.h>
@@ -11,12 +20,12 @@ using thrust::complex;
 // (guided by profiler)
 extern "C" __global__ void __launch_bounds__(1024, 2)
     fourier_error(int nmodes,
-                  complex<float> *f,
-                  const float *fmask,
-                  const float *fmag,
-                  float *fdev,
-                  float *ferr,
-                  const float *mask_sum,
+                  const complex<IN_TYPE> *f,
+                  const IN_TYPE *fmask,
+                  const IN_TYPE *fmag,
+                  OUT_TYPE *fdev,
+                  OUT_TYPE *ferr,
+                  const IN_TYPE *mask_sum,
                   const int *addr,
                   int A,
                   int B)
@@ -39,15 +48,16 @@ extern "C" __global__ void __launch_bounds__(1024, 2)
   {
     for (int b = tx; b < B; b += blockDim.x)
     {
-      float acc = 0.0;
+      MATH_TYPE acc = MATH_TYPE(0);
       for (int idx = 0; idx < nmodes; ++idx)
       {
-        float abs_exit_wave = abs(f[a * B + b + idx * A * B]);
+        complex<MATH_TYPE> t_f = f[a * B + b + idx * A * B];
+        MATH_TYPE abs_exit_wave = abs(t_f);
         acc += abs_exit_wave *
                abs_exit_wave;  // if we do this manually (real*real +imag*imag)
                                // we get differences to numpy due to rounding
       }
-      auto fdevv = sqrt(acc) - fmag[a * B + b];
+      auto fdevv = sqrt(acc) - MATH_TYPE(fmag[a * B + b]);
       ferr[a * B + b] = (fmask[a * B + b] * fdevv * fdevv) / mask_sum[ma[0]];
       fdev[a * B + b] = fdevv;
     }

--- a/ptypy/accelerate/cuda_pycuda/cuda/full_reduce.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/full_reduce.cu
@@ -1,16 +1,25 @@
+/** full_reduce kernel.
+ *
+ * Data types:
+ * - IN_TYPE: the data type for the inputs (float or double)
+ * - OUT_TYPE: the data type for the outputs (float or double - for aux wave)
+ * - ACC_TYPE: the data type used for internal accumulation
+ */
+
+
 #include <cassert>
 
-extern "C" __global__ void full_reduce(const DTYPE* in, DTYPE* out, int size)
+extern "C" __global__ void full_reduce(const IN_TYPE* in, OUT_TYPE* out, int size)
 {
   assert(gridDim.x == 1);
   int tx = threadIdx.x;
 
-  __shared__ DTYPE smem[BDIM_X];
+  __shared__ ACC_TYPE smem[BDIM_X];
 
-  auto sum = DTYPE();
+  auto sum = ACC_TYPE();
   for (int ix = tx; ix < size; ix += blockDim.x)
   {
-    sum = sum + in[ix];
+    sum = sum + ACC_TYPE(in[ix]);
   }
   smem[tx] = sum;
   __syncthreads();
@@ -30,6 +39,6 @@ extern "C" __global__ void full_reduce(const DTYPE* in, DTYPE* out, int size)
 
   if (tx == 0)
   {
-    out[0] = smem[0];
+    out[0] = OUT_TYPE(smem[0]);
   }
 }

--- a/ptypy/accelerate/cuda_pycuda/cuda/gd_main.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/gd_main.cu
@@ -1,11 +1,19 @@
+/** gd_main kernel.
+ *
+ * Data types:
+ * - IN_TYPE: the data type for the inputs (float or double)
+ * - OUT_TYPE: the data type for the outputs (float or double - for aux wave)
+ * - MATH_TYPE: the data type used for computation 
+ */
+
 #include <thrust/complex.h>
 using thrust::complex;
 
-extern "C" __global__ void gd_main(const FTYPE* Imodel,
-                                   const FTYPE* I,
-                                   const FTYPE* w,
-                                   FTYPE* err,
-                                   CTYPE* aux,
+extern "C" __global__ void gd_main(const IN_TYPE* Imodel,
+                                   const IN_TYPE* I,
+                                   const IN_TYPE* w,
+                                   OUT_TYPE* err,
+                                   complex<OUT_TYPE>* aux,
                                    int z,
                                    int modes,
                                    int x)
@@ -16,8 +24,8 @@ extern "C" __global__ void gd_main(const FTYPE* Imodel,
   if (iz >= z || ix >= x)
     return;
 
-  auto DI = Imodel[iz * x + ix] - I[iz * x + ix];
-  auto tmp = w[iz * x + ix] * DI;
+  auto DI = MATH_TYPE(Imodel[iz * x + ix]) - MATH_TYPE(I[iz * x + ix]);
+  auto tmp = MATH_TYPE(w[iz * x + ix]) * MATH_TYPE(DI);
   err[iz * x + ix] = tmp * DI;
 
   // now set this for all modes (promote)

--- a/ptypy/accelerate/cuda_pycuda/cuda/make_a012.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/make_a012.cu
@@ -1,14 +1,23 @@
+/** fmag_all_update.
+ *
+ * Data types:
+ * - IN_TYPE: the data type for the inputs (float or double)
+ * - OUT_TYPE: the data type for the outputs (float or double)
+ * - MATH_TYPE: the data type used for computation 
+ * - ACC_TYPE: data type used for accumulation
+ */
+
 #include <thrust/complex.h>
 using thrust::complex;
 
-extern "C" __global__ void make_a012(const CTYPE* f,
-                                     const CTYPE* a,
-                                     const CTYPE* b,
-                                     const FTYPE* I,
-                                     const FTYPE* fic,
-                                     FTYPE* A0,
-                                     FTYPE* A1,
-                                     FTYPE* A2,
+extern "C" __global__ void make_a012(const complex<IN_TYPE>* f,
+                                     const complex<IN_TYPE>* a,
+                                     const complex<IN_TYPE>* b,
+                                     const IN_TYPE* I,
+                                     const IN_TYPE* fic,
+                                     OUT_TYPE* A0,
+                                     OUT_TYPE* A1,
+                                     OUT_TYPE* A2,
                                      int z,
                                      int y,
                                      int x,
@@ -22,37 +31,37 @@ extern "C" __global__ void make_a012(const CTYPE* f,
 
   if (iz >= maxz)
   {
-    A0[iz * x + ix] = FTYPE(0);  // make sure it's the right type (double/float)
-    A1[iz * x + ix] = FTYPE(0);
-    A2[iz * x + ix] = FTYPE(0);
+    A0[iz * x + ix] = OUT_TYPE(0);  // make sure it's the right type (double/float)
+    A1[iz * x + ix] = OUT_TYPE(0);
+    A2[iz * x + ix] = OUT_TYPE(0);
     return;
   }
 
   // we sum across y directly, as this is the number of modes,
   // which is typically small
-  auto sumtf0 = FTYPE(0);
-  auto sumtf1 = FTYPE(0);
-  auto sumtf2 = FTYPE(0);
+  auto sumtf0 = ACC_TYPE(0);
+  auto sumtf1 = ACC_TYPE(0);
+  auto sumtf2 = ACC_TYPE(0);
   for (auto iy = 0; iy < y; ++iy)
   {
-    auto fv = f[iz * y * x + iy * x + ix];
+    complex<MATH_TYPE> fv = f[iz * y * x + iy * x + ix];
     sumtf0 += fv.real() * fv.real() + fv.imag() * fv.imag();
 
-    auto av = a[iz * y * x + iy * x + ix];
+    complex<MATH_TYPE> av = a[iz * y * x + iy * x + ix];
     // 2 * real(f * conj(a))
-    sumtf1 += FTYPE(2) * (fv.real() * av.real() + fv.imag() * av.imag());
+    sumtf1 += MATH_TYPE(2) * (fv.real() * av.real() + fv.imag() * av.imag());
 
     // use FTYPE(2) to make sure double creeps into a float calculation
     // as 2.0 * would make everything double.
-    auto bv = b[iz * y * x + iy * x + ix];
+    complex<MATH_TYPE> bv = b[iz * y * x + iy * x + ix];
     // 2 * real(f * conj(b)) + abs(a)^2
-    sumtf2 += FTYPE(2) * (fv.real() * bv.real() + fv.imag() * bv.imag()) +
+    sumtf2 += MATH_TYPE(2) * (fv.real() * bv.real() + fv.imag() * bv.imag()) +
               (av.real() * av.real() + av.imag() * av.imag());
   }
 
-  auto Iv = I[iz * x + ix];
-  auto ficv = fic[iz];
-  A0[iz * x + ix] = sumtf0 * ficv - Iv;
-  A1[iz * x + ix] = sumtf1 * ficv;
-  A2[iz * x + ix] = sumtf2 * ficv;
+  MATH_TYPE Iv = I[iz * x + ix];
+  MATH_TYPE ficv = fic[iz];
+  A0[iz * x + ix] = OUT_TYPE(sumtf0 * ficv - Iv);
+  A1[iz * x + ix] = OUT_TYPE(sumtf1 * ficv);
+  A2[iz * x + ix] = OUT_TYPE(sumtf2 * ficv);
 }

--- a/ptypy/accelerate/cuda_pycuda/cuda/make_model.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/make_model.cu
@@ -1,8 +1,16 @@
+/** make_model - with 2 steps as separate kernels.
+ *
+ * Data types:
+ * - IN_TYPE: the data type for the inputs (float or double)
+ * - OUT_TYPE: the data type for the outputs (float or double)
+ * - MATH_TYPE: the data type used for computation 
+ */
+
 #include <thrust/complex.h>
 using thrust::complex;
 
 extern "C" __global__ void make_model(
-    const CTYPE* in, FTYPE* out, int z, int y, int x)
+    const complex<IN_TYPE>* in, OUT_TYPE* out, int z, int y, int x)
 {
   int ix = threadIdx.x + blockIdx.x * blockDim.x;
   int iz = blockIdx.z;
@@ -12,11 +20,11 @@ extern "C" __global__ void make_model(
 
   // we sum accross y directly, as this is the number of modes,
   // which is typically small
-  auto sum = FTYPE();
+  auto sum = MATH_TYPE();
   for (auto iy = 0; iy < y; ++iy)
   {
-    auto v = in[iz * y * x + iy * x + ix];
+    complex<MATH_TYPE> v = in[iz * y * x + iy * x + ix];
     sum += v.real() * v.real() + v.imag() * v.imag();
   }
-  out[iz * x + ix] = sum;
+  out[iz * x + ix] = OUT_TYPE(sum);
 }

--- a/ptypy/accelerate/cuda_pycuda/cuda/ob_update.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/ob_update.cu
@@ -1,24 +1,40 @@
+/** ob_update.
+ *
+ * Data types:
+ * - IN_TYPE: the data type for the inputs (float or double)
+ * - OUT_TYPE: the data type for the outputs (float or double)
+ * - MATH_TYPE: the data type used for computation
+ * - DENOM_TYPE: data type for the denominator (double,float,complex<double>,complex<float>)
+ */
+
 #include <thrust/complex.h>
 using thrust::complex;
 
 template <class T>
-__device__ inline void atomicAdd(complex<T>* x, complex<T> y)
+__device__ inline void atomicAdd(complex<T>* x, const complex<T>& y)
 {
   auto xf = reinterpret_cast<T*>(x);
   atomicAdd(xf, y.real());
   atomicAdd(xf + 1, y.imag());
 }
 
+// return a pointer to the real part of the argument
+template <class T>
+__device__ inline T* get_denom_real_ptr(complex<T>* den)
+{
+  return reinterpret_cast<T*>(den);
+}
+
 extern "C" __global__ void ob_update(
-    const complex<float>* __restrict__ exit_wave,
+    const complex<IN_TYPE>* __restrict__ exit_wave,
     int A,
     int B,
     int C,
-    const complex<float>* __restrict__ probe,
+    const complex<IN_TYPE>* __restrict__ probe,
     int D,
     int E,
     int F,
-    complex<float>* obj,
+    complex<OUT_TYPE>* obj,
     int G,
     int H,
     int I,
@@ -46,12 +62,16 @@ extern "C" __global__ void ob_update(
   {
     for (int c = tx; c < C; c += blockDim.x)
     {
-      auto probe_val = probe[b * F + c];
-      atomicAdd(&obj[b * I + c], conj(probe_val) * exit_wave[b * C + c]);
-      auto denomreal = reinterpret_cast<float*>(&denominator[b * I + c]);
+      complex<MATH_TYPE> probe_val = probe[b * F + c];
+      complex<MATH_TYPE> exit_val = exit_wave[b * C + c];
+      auto add_val_m = conj(probe_val) * exit_val;
+      complex<OUT_TYPE> add_val = add_val_m;
+      atomicAdd(&obj[b * I + c], add_val);
+
+      auto denomreal_ptr = get_denom_real_ptr(&denominator[b * I + c]);
       auto upd_probe = probe_val.real() * probe_val.real() +
                        probe_val.imag() * probe_val.imag();
-      atomicAdd(denomreal, upd_probe);
+      atomicAdd(denomreal_ptr, upd_probe);
     }
   }
 }

--- a/ptypy/accelerate/cuda_pycuda/cuda/ob_update2.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/ob_update2.cu
@@ -4,6 +4,7 @@
  * - IN_TYPE: the data type for the inputs (float or double)
  * - OUT_TYPE: the data type for the outputs (float or double)
  * - MATH_TYPE: the data type used for computation
+ * - ACC_TYPE: accumulator type for the local ob accumulation
  * - DENOM_TYPE: type for the denominator (can be real/complex float/double)
  */
 
@@ -59,8 +60,8 @@ extern "C" __global__ void ob_update2(
   int dy = ob_sh;
   int z = blockIdx.x * BDIM_X + threadIdx.x;
   int dz = ob_sh;
-  complex<MATH_TYPE> ob[NUM_MODES];
-  MATH_TYPE obn[NUM_MODES];
+  complex<ACC_TYPE> ob[NUM_MODES];
+  ACC_TYPE obn[NUM_MODES];
 
   int txy = threadIdx.y * BDIM_X + threadIdx.x;
   assert(ob_modes <= NUM_MODES);
@@ -123,10 +124,9 @@ extern "C" __global__ void ob_update2(
         auto exidx = ad[1] * pr_sh * pr_sh + v1 * pr_sh + v2;
         assert(exidx < ex_0 * ex_1 * ex_2);
         complex<MATH_TYPE> t_ex_g = ex_g[exidx];
-        ob[idx] += cpr * t_ex_g;
-        auto rr = obn[idx];
-        rr += pr.real() * pr.real() + pr.imag() * pr.imag();
-        obn[idx] = rr;
+        complex<ACC_TYPE> add_val = cpr * t_ex_g;
+        ob[idx] += add_val;
+        obn[idx] += pr.real() * pr.real() + pr.imag() * pr.imag();
       }
     }
   }

--- a/ptypy/accelerate/cuda_pycuda/cuda/ob_update2.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/ob_update2.cu
@@ -18,13 +18,13 @@ using thrust::complex;
 #define obj_roi_row(k) addr[4 * num_pods + (k)]
 #define obj_roi_column(k) addr[5 * num_pods + (k)]
 
-template <class T>
-__device__ inline void set_real(complex<T>& v, T r)
+template <class T, class U>
+__device__ inline void set_real(complex<T>& v, U r)
 {
-  v.real(r);
+  v.real(T(r));
 }
-template <class T>
-__device__ inline void set_real(T& v, T r)
+template <class T, class U>
+__device__ inline void set_real(T& v, U r)
 {
   v = r;
 }

--- a/ptypy/accelerate/cuda_pycuda/cuda/ob_update2.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/ob_update2.cu
@@ -6,6 +6,13 @@
  * - MATH_TYPE: the data type used for computation
  * - ACC_TYPE: accumulator type for the local ob accumulation
  * - DENOM_TYPE: type for the denominator (can be real/complex float/double)
+ * 
+ * NOTE: This version of ob_update goes over all tiles that need to be accumulated
+ * in a single thread block to avoid global atomic additions (as in ob_update.cu).
+ * This requires a local array of NUM_MODES size to store the local updates.
+ * GPU registers per thread are limited (255 32bit registers on V100), 
+ * and at some point the registers will spill into shared or global memory
+ * and the kernel will get considerably slower.
  */
 
 

--- a/ptypy/accelerate/cuda_pycuda/cuda/ob_update2_ML.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/ob_update2_ML.cu
@@ -4,6 +4,7 @@
  * - IN_TYPE: the data type for the inputs (float or double)
  * - OUT_TYPE: the data type for the outputs (float or double)
  * - MATH_TYPE: the data type used for computation
+ * - ACC_TYPE: accumulator for the ob field
  */
 
 
@@ -36,7 +37,7 @@ extern "C" __global__ void ob_update2_ML(int pr_sh,
   int z = blockIdx.x * BDIM_X + threadIdx.x;
   int dz = ob_sh;
   MATH_TYPE fac = fac_;
-  complex<MATH_TYPE> ob[NUM_MODES];
+  complex<ACC_TYPE> ob[NUM_MODES];
 
 
   int txy = threadIdx.y * BDIM_X + threadIdx.x;
@@ -99,7 +100,8 @@ extern "C" __global__ void ob_update2_ML(int pr_sh,
         auto exidx = ad[1] * pr_sh * pr_sh + v1 * pr_sh + v2;
         assert(exidx < ex_0 * ex_1 * ex_2);
         complex<MATH_TYPE> t_ex_g = ex_g[exidx];
-        ob[idx] += cpr * t_ex_g * fac;
+        complex<ACC_TYPE> add_val = cpr * t_ex_g * fac;
+        ob[idx] += add_val;
       }
     }
   }

--- a/ptypy/accelerate/cuda_pycuda/cuda/ob_update2_ML.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/ob_update2_ML.cu
@@ -5,6 +5,13 @@
  * - OUT_TYPE: the data type for the outputs (float or double)
  * - MATH_TYPE: the data type used for computation
  * - ACC_TYPE: accumulator for the ob field
+ * 
+ * NOTE: This version of ob_update goes over all tiles that need to be accumulated
+ * in a single thread block to avoid global atomic additions (as in ob_update_ML.cu).
+ * This requires a local array of NUM_MODES size to store the local updates.
+ * GPU registers per thread are limited (255 32bit registers on V100), 
+ * and at some point the registers will spill into shared or global memory
+ * and the kernel will get considerably slower.
  */
 
 

--- a/ptypy/accelerate/cuda_pycuda/cuda/ob_update_ML.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/ob_update_ML.cu
@@ -1,8 +1,16 @@
+/** ob_update_ML.
+ *
+ * Data types:
+ * - IN_TYPE: the data type for the inputs (float or double)
+ * - OUT_TYPE: the data type for the outputs (float or double)
+ * - MATH_TYPE: the data type used for computation
+ */
+
 #include <thrust/complex.h>
 using thrust::complex;
 
 template <class T>
-__device__ inline void atomicAdd(complex<T>* x, complex<T> y)
+__device__ inline void atomicAdd(complex<T>* x, const complex<T>& y)
 {
   auto xf = reinterpret_cast<T*>(x);
   atomicAdd(xf, y.real());
@@ -11,25 +19,26 @@ __device__ inline void atomicAdd(complex<T>* x, complex<T> y)
 
 extern "C"
 {
-  __global__ void ob_update_ML(const CTYPE* __restrict__ exit_wave,
+  __global__ void ob_update_ML(const complex<IN_TYPE>* __restrict__ exit_wave,
                                int A,
                                int B,
                                int C,
-                               const CTYPE* __restrict__ probe,
+                               const complex<IN_TYPE>* __restrict__ probe,
                                int D,
                                int E,
                                int F,
-                               CTYPE* obj,
+                               complex<OUT_TYPE>* obj,
                                int G,
                                int H,
                                int I,
                                const int* __restrict__ addr,
-                               FTYPE fac)
+                               IN_TYPE fac_)
   {
     const int bid = blockIdx.x;
     const int tx = threadIdx.x;
     const int ty = threadIdx.y;
     const int addr_stride = 15;
+    MATH_TYPE fac = fac_;
 
     const int* oa = addr + 3 + bid * addr_stride;
     const int* pa = addr + bid * addr_stride;
@@ -46,9 +55,12 @@ extern "C"
     {
       for (int c = tx; c < C; c += blockDim.x)
       {
-        auto probe_val = probe[b * F + c];
-        atomicAdd(&obj[b * I + c],
-                  conj(probe_val) * exit_wave[b * C + c] * fac);
+        complex<MATH_TYPE> probe_val = probe[b * F + c];
+        complex<MATH_TYPE> exit_val = exit_wave[b * C + c];
+        complex<MATH_TYPE> add_val_m = conj(probe_val) * exit_val * fac;
+        complex<OUT_TYPE> add_val(add_val_m);
+
+        atomicAdd(&obj[b * I + c], add_val);
       }
     }
   }

--- a/ptypy/accelerate/cuda_pycuda/cuda/pr_update2.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/pr_update2.cu
@@ -1,4 +1,4 @@
-/** ob_update.
+/** pr_update.
  *
  * Data types:
  * - IN_TYPE: the data type for the inputs (float or double)

--- a/ptypy/accelerate/cuda_pycuda/cuda/pr_update2.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/pr_update2.cu
@@ -5,6 +5,7 @@
  * - OUT_TYPE: the data type for the outputs (float or double)
  * - MATH_TYPE: the data type used for computation
  * - DENOM_TYPE: data type for the denominator (double,float,complex<double>,complex<float>)
+ * - ACC_TYPE: accumulator type for local pr array
  */
 
 #include <cassert>
@@ -59,8 +60,8 @@ extern "C" __global__ void pr_update2(int pr_sh,
   int dy = pr_sh;
   int z = blockIdx.x * BDIM_X + threadIdx.x;
   int dz = pr_sh;
-  complex<MATH_TYPE> pr[NUM_MODES];
-  MATH_TYPE prn[NUM_MODES];
+  complex<ACC_TYPE> pr[NUM_MODES];
+  ACC_TYPE prn[NUM_MODES];
 
   int txy = threadIdx.y * BDIM_X + threadIdx.x;
   assert(pr_modes <= NUM_MODES);
@@ -122,7 +123,8 @@ extern "C" __global__ void pr_update2(int pr_sh,
         assert(idx < NUM_MODES);
         auto cob = conj(ob);
         complex<MATH_TYPE> ex_val = ex_g[ad[1] * pr_sh * pr_sh + y * pr_sh + z];
-        pr[idx] += cob * ex_val;
+        complex<ACC_TYPE> add_val = cob * ex_val;
+        pr[idx] += add_val;
         prn[idx] += ob.real() * ob.real() + ob.imag() * ob.imag();
       }
     }

--- a/ptypy/accelerate/cuda_pycuda/cuda/pr_update2.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/pr_update2.cu
@@ -6,6 +6,13 @@
  * - MATH_TYPE: the data type used for computation
  * - DENOM_TYPE: data type for the denominator (double,float,complex<double>,complex<float>)
  * - ACC_TYPE: accumulator type for local pr array
+ * 
+ * NOTE: This version of ob_update goes over all tiles that need to be accumulated
+ * in a single thread block to avoid global atomic additions (as in pr_update.cu).
+ * This requires a local array of NUM_MODES size to store the local updates.
+ * GPU registers per thread are limited (255 32bit registers on V100), 
+ * and at some point the registers will spill into shared or global memory
+ * and the kernel will get considerably slower.
  */
 
 #include <cassert>

--- a/ptypy/accelerate/cuda_pycuda/cuda/pr_update2_ML.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/pr_update2_ML.cu
@@ -4,6 +4,7 @@
  * - IN_TYPE: the data type for the inputs (float or double)
  * - OUT_TYPE: the data type for the outputs (float or double)
  * - MATH_TYPE: the data type used for computation
+ * - ACC_TYPE: accumulator type for local pr array
  */
 
 #include <cassert>
@@ -35,7 +36,7 @@ extern "C" __global__ void pr_update2_ML(int pr_sh,
   int z = blockIdx.x * BDIM_X + threadIdx.x;
   int dz = pr_sh;
   MATH_TYPE fac = fac_;
-  complex<MATH_TYPE> pr[NUM_MODES];
+  complex<ACC_TYPE> pr[NUM_MODES];
 
   int txy = threadIdx.y * BDIM_X + threadIdx.x;
   assert(pr_modes <= NUM_MODES);
@@ -96,7 +97,8 @@ extern "C" __global__ void pr_update2_ML(int pr_sh,
         assert(idx < NUM_MODES);
         auto cob = conj(ob);
         complex<MATH_TYPE> ex_val = ex_g[ad[1] * pr_sh * pr_sh + y * pr_sh + z];
-        complex<MATH_TYPE> add_val = cob * ex_val * fac;
+        complex<MATH_TYPE> add_val_m = cob * ex_val * fac;
+        complex<ACC_TYPE> add_val = add_val_m;
         pr[idx] += add_val;
       }
     }

--- a/ptypy/accelerate/cuda_pycuda/cuda/pr_update2_ML.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/pr_update2_ML.cu
@@ -5,6 +5,13 @@
  * - OUT_TYPE: the data type for the outputs (float or double)
  * - MATH_TYPE: the data type used for computation
  * - ACC_TYPE: accumulator type for local pr array
+ * 
+ * NOTE: This version of ob_update goes over all tiles that need to be accumulated
+ * in a single thread block to avoid global atomic additions (as in pr_update_ML.cu).
+ * This requires a local array of NUM_MODES size to store the local updates.
+ * GPU registers per thread are limited (255 32bit registers on V100), 
+ * and at some point the registers will spill into shared or global memory
+ * and the kernel will get considerably slower.
  */
 
 #include <cassert>

--- a/ptypy/accelerate/cuda_pycuda/cuda/pr_update_ML.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/pr_update_ML.cu
@@ -1,28 +1,37 @@
+/** pr_update_ML.
+ *
+ * Data types:
+ * - IN_TYPE: the data type for the inputs (float or double)
+ * - OUT_TYPE: the data type for the outputs (float or double)
+ * - MATH_TYPE: the data type used for computation
+ */
+
+
 #include <thrust/complex.h>
 using thrust::complex;
 
 template <class T>
-__device__ inline void atomicAdd(complex<T>* x, complex<T> y)
+__device__ inline void atomicAdd(complex<T>* x, const complex<T>& y)
 {
   auto xf = reinterpret_cast<T*>(x);
   atomicAdd(xf, y.real());
   atomicAdd(xf + 1, y.imag());
 }
 
-extern "C" __global__ void pr_update_ML(const CTYPE* __restrict__ exit_wave,
+extern "C" __global__ void pr_update_ML(const complex<IN_TYPE>* __restrict__ exit_wave,
                                         int A,
                                         int B,
                                         int C,
-                                        CTYPE* probe,
+                                        complex<OUT_TYPE>* probe,
                                         int D,
                                         int E,
                                         int F,
-                                        const CTYPE* __restrict__ obj,
+                                        const complex<IN_TYPE>* __restrict__ obj,
                                         int G,
                                         int H,
                                         int I,
                                         const int* __restrict__ addr,
-                                        FTYPE fac)
+                                        IN_TYPE fac_)
 {
   assert(B == E);  // prsh[1]
   assert(C == F);  // prsh[2]
@@ -30,6 +39,7 @@ extern "C" __global__ void pr_update_ML(const CTYPE* __restrict__ exit_wave,
   const int tx = threadIdx.x;
   const int ty = threadIdx.y;
   const int addr_stride = 15;
+  MATH_TYPE fac = fac_;
 
   const int* oa = addr + 3 + bid * addr_stride;
   const int* pa = addr + bid * addr_stride;
@@ -46,8 +56,11 @@ extern "C" __global__ void pr_update_ML(const CTYPE* __restrict__ exit_wave,
   {
     for (int c = tx; c < C; c += blockDim.x)
     {
-      auto obj_val = obj[b * I + c];
-      atomicAdd(&probe[b * F + c], conj(obj_val) * exit_wave[b * C + c] * fac);
+      complex<MATH_TYPE> obj_val = obj[b * I + c];
+      complex<MATH_TYPE> exit_val = exit_wave[b * C + c];
+      complex<MATH_TYPE> add_val_m = conj(obj_val) * exit_val * fac;
+      complex<OUT_TYPE> add_val = add_val_m;
+      atomicAdd(&probe[b * F + c], add_val);
     }
   }
 }

--- a/ptypy/accelerate/cuda_pycuda/cuda/transpose.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/transpose.cu
@@ -5,6 +5,11 @@
  * and shared memory access has no bank conflicts.
  */
 
+/**
+ * Data types:
+ * - DTYPE - any pod type
+ */
+
 #include <thrust/complex.h>
 using thrust::complex;
 

--- a/ptypy/accelerate/cuda_pycuda/cuda/update_addr_error_state.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/update_addr_error_state.cu
@@ -1,11 +1,18 @@
+/** update_addr_error_state kernel.
+ *
+ * Data types:
+ * - IN_TYPE: the data type for the inputs (float or double)
+ * - OUT_TYPE: the data type for the outputs (float or double)
+ */
+
 #include <cassert>
 #include <thrust/complex.h>
 using thrust::complex;
 
-extern "C" __global__ void update_addr_error_state(int* addr,
-                                                   const int* mangled_addr,
-                                                   float* error_state,
-                                                   const float* error_sum,
+extern "C" __global__ void update_addr_error_state(int* __restrict addr,
+                                                   const int* __restrict mangled_addr,
+                                                   OUT_TYPE* error_state,
+                                                   const IN_TYPE* __restrict error_sum,
                                                    int nmodes)
 {
   int tx = threadIdx.x;
@@ -23,7 +30,7 @@ extern "C" __global__ void update_addr_error_state(int* addr,
 
   if (err_sum < err_st)
   {
-    for (int i = tx; i < nmodes * 15; i += blockDim.x)
+    for (int i = tx, e = nmodes * 15; i < e; i += blockDim.x)
     {
       addr[i] = mangled_addr[i];
     }

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -639,8 +639,9 @@ class PoUpdateKernel(ab.PoUpdateKernel):
         })
         self.ob_update2_ML_cuda = None
         self.pr_update_ML_cuda = load_kernel("pr_update_ML", {
-            'CTYPE': 'complex<float>',
-            'FTYPE': 'float'
+            'IN_TYPE': 'float',
+            'OUT_TYPE': 'float',
+            'MATH_TYPE': self.math_type
         })
         self.pr_update2_ML_cuda = None
 

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -119,7 +119,11 @@ class FourierUpdateKernel(ab.FourierUpdateKernel):
             'ACC_TYPE': self.accumulate_type
         })
         self.fourier_update_cuda = None
-        self.log_likelihood_cuda = load_kernel("log_likelihood")
+        self.log_likelihood_cuda = load_kernel("log_likelihood", {
+            'IN_TYPE': 'float',
+            'OUT_TYPE': 'float',
+            'MATH_TYPE': self.math_type
+        })
         self.exit_error_cuda = load_kernel("exit_error", {
             'IN_TYPE': 'float',
             'OUT_TYPE': 'float',

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -739,8 +739,9 @@ class PoUpdateKernel(ab.PoUpdateKernel):
                     "NUM_MODES": obsh[0],
                     "BDIM_X": 16,
                     "BDIM_Y": 16,
-                    'CTYPE': 'complex<float>',
-                    'FTYPE': 'float'
+                    'IN_TYPE': 'float',
+                    'OUT_TYPE': 'float',
+                    'MATH_TYPE': self.math_type
                 })
             grid = [int((x+15)//16) for x in ob.shape[-2:]]
             grid = (grid[0], grid[1], int(1))

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -398,9 +398,6 @@ class GradientDescentKernel(ab.GradientDescentKernel):
         self.gpu.Imodel = None
 
         subs = {
-            # temporarily until all kernels are ported to be flexible with unified naming
-            'CTYPE': 'complex<float>' if self.ctype == np.complex64 else 'complex<double>',
-            'FTYPE': 'float' if self.ftype == np.float32 else 'double',
             'IN_TYPE': 'float' if self.ftype == np.float32 else 'double',
             'OUT_TYPE': 'float' if self.ftype == np.float32 else 'double',
             'ACC_TYPE': self.accumulate_type,

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -711,7 +711,10 @@ class PoUpdateKernel(ab.PoUpdateKernel):
                     "NUM_MODES": prsh[0],
                     "BDIM_X": 16,
                     "BDIM_Y": 16,
-                    'DENOM_TYPE': self.dtype
+                    'DENOM_TYPE': self.dtype,
+                    'IN_TYPE': 'float',
+                    'OUT_TYPE': 'float',
+                    'MATH_TYPE': self.math_type
                 })
 
             grid = [int((x+15)//16) for x in pr.shape[-2:]]

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -102,7 +102,11 @@ class FourierUpdateKernel(ab.FourierUpdateKernel):
         self.accumulate_type = accumulate_type
         self.math_type = math_type
         self.queue = queue_thread
-        self.fmag_all_update_cuda = load_kernel("fmag_all_update")
+        self.fmag_all_update_cuda = load_kernel("fmag_all_update", {
+            'IN_TYPE': 'float',
+            'OUT_TYPE': 'float',
+            'MATH_TYPE': self.math_type
+        })
         self.fourier_error_cuda = load_kernel("fourier_error")
         self.fourier_error2_cuda = None
         self.error_reduce_cuda = load_kernel("error_reduce", {

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -398,6 +398,7 @@ class GradientDescentKernel(ab.GradientDescentKernel):
             'CTYPE': 'complex<float>' if self.ctype == np.complex64 else 'complex<double>',
             'FTYPE': 'float' if self.ftype == np.float32 else 'double',
             'IN_TYPE': 'float' if self.ftype == np.float32 else 'double',
+            'OUT_TYPE': 'float' if self.ftype == np.float32 else 'double',
             'ACC_TYPE': self.accumulate_type,
             'MATH_TYPE': self.math_type
         }

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -599,7 +599,8 @@ class GradientDescentKernel(ab.GradientDescentKernel):
 
 class PoUpdateKernel(ab.PoUpdateKernel):
 
-    def __init__(self, queue_thread=None, denom_type=np.complex64, math_type='float'):
+    def __init__(self, queue_thread=None, denom_type=np.complex64, 
+        math_type='float', accumulator_type='float'):
         super(PoUpdateKernel, self).__init__()
         # and now initialise the cuda
         if denom_type == np.complex64:
@@ -614,8 +615,11 @@ class PoUpdateKernel(ab.PoUpdateKernel):
             raise ValueError('invalid type for denominator')
         if math_type not in ['double', 'float']:
             raise ValueError('only float and double are supported for math_type')
+        if accumulator_type not in ['double', 'float']:
+            raise ValueError('only float and double are supported for accumulator_type')
         
         self.math_type = math_type
+        self.accumulator_type = accumulator_type
         self.dtype = dtype
         self.queue = queue_thread
         self.ob_update_cuda = load_kernel("ob_update", {
@@ -671,7 +675,8 @@ class PoUpdateKernel(ab.PoUpdateKernel):
                     'DENOM_TYPE': self.dtype,
                     'IN_TYPE': 'float',
                     'OUT_TYPE': 'float',
-                    'MATH_TYPE': self.math_type
+                    'MATH_TYPE': self.math_type,
+                    'ACC_TYPE': self.accumulator_type
                 })
 
             grid = [int((x+15)//16) for x in ob.shape[-2:]]
@@ -711,7 +716,8 @@ class PoUpdateKernel(ab.PoUpdateKernel):
                     'DENOM_TYPE': self.dtype,
                     'IN_TYPE': 'float',
                     'OUT_TYPE': 'float',
-                    'MATH_TYPE': self.math_type
+                    'MATH_TYPE': self.math_type,
+                    'ACC_TYPE': self.accumulator_type
                 })
 
             grid = [int((x+15)//16) for x in pr.shape[-2:]]
@@ -748,7 +754,8 @@ class PoUpdateKernel(ab.PoUpdateKernel):
                     "BDIM_Y": 16,
                     'IN_TYPE': 'float',
                     'OUT_TYPE': 'float',
-                    'MATH_TYPE': self.math_type
+                    'MATH_TYPE': self.math_type,
+                    'ACC_TYPE': self.accumulator_type
                 })
             grid = [int((x+15)//16) for x in ob.shape[-2:]]
             grid = (grid[0], grid[1], int(1))
@@ -784,7 +791,8 @@ class PoUpdateKernel(ab.PoUpdateKernel):
                     "BDIM_Y": 16,
                     'IN_TYPE': 'float',
                     'OUT_TYPE': 'float',
-                    'MATH_TYPE': self.math_type
+                    'MATH_TYPE': self.math_type,
+                    'ACC_TYPE': self.accumulator_type
                 })
 
             grid = [int((x+15)//16) for x in pr.shape[-2:]]

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -803,7 +803,10 @@ class PositionCorrectionKernel(ab.PositionCorrectionKernel):
             'OUT_TYPE': 'float',
             'MATH_TYPE': self.math_type
         })
-        self.update_addr_and_error_state_cuda = load_kernel("update_addr_error_state")
+        self.update_addr_and_error_state_cuda = load_kernel("update_addr_error_state", {
+            'IN_TYPE': 'float',
+            'OUT_TYPE': 'float'
+        })
 
         self.gpu = Adict()
         self.gpu.fdev = None

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -92,12 +92,15 @@ class PropagationKernel:
 
 class FourierUpdateKernel(ab.FourierUpdateKernel):
 
-    def __init__(self, aux, nmodes=1, queue_thread=None, accumulate_type='float'):
+    def __init__(self, aux, nmodes=1, queue_thread=None, accumulate_type='float', math_type='float'):
         super(FourierUpdateKernel, self).__init__(aux,  nmodes=nmodes)
 
         if accumulate_type not in ['float', 'double']:
             raise ValueError('Only float or double types are supported')
+        if math_type not in ['float', 'double']:
+            raise ValueError('Only float or double types are supported')
         self.accumulate_type = accumulate_type
+        self.math_type = math_type
         self.queue = queue_thread
         self.fmag_all_update_cuda = load_kernel("fmag_all_update")
         self.fourier_error_cuda = load_kernel("fourier_error")
@@ -109,7 +112,11 @@ class FourierUpdateKernel(ab.FourierUpdateKernel):
         })
         self.fourier_update_cuda = None
         self.log_likelihood_cuda = load_kernel("log_likelihood")
-        self.exit_error_cuda = load_kernel("exit_error")
+        self.exit_error_cuda = load_kernel("exit_error", {
+            'IN_TYPE': 'float',
+            'OUT_TYPE': 'float',
+            'MATH_TYPE': self.math_type
+        })
 
         self.gpu = Adict()
         self.gpu.fdev = None

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -782,8 +782,9 @@ class PoUpdateKernel(ab.PoUpdateKernel):
                     "NUM_MODES": prsh[0],
                     "BDIM_X": 16,
                     "BDIM_Y": 16,
-                    'CTYPE': 'complex<float>',
-                    'FTYPE': 'float'
+                    'IN_TYPE': 'float',
+                    'OUT_TYPE': 'float',
+                    'MATH_TYPE': self.math_type
                 })
 
             grid = [int((x+15)//16) for x in pr.shape[-2:]]

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -667,7 +667,10 @@ class PoUpdateKernel(ab.PoUpdateKernel):
                     "NUM_MODES": obsh[0],
                     "BDIM_X": 16,
                     "BDIM_Y": 16,
-                    'DENOM_TYPE': self.dtype
+                    'DENOM_TYPE': self.dtype,
+                    'IN_TYPE': 'float',
+                    'OUT_TYPE': 'float',
+                    'MATH_TYPE': self.math_type
                 })
 
             grid = [int((x+15)//16) for x in ob.shape[-2:]]

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -602,7 +602,7 @@ class GradientDescentKernel(ab.GradientDescentKernel):
 
 class PoUpdateKernel(ab.PoUpdateKernel):
 
-    def __init__(self, queue_thread=None, denom_type=np.complex64):
+    def __init__(self, queue_thread=None, denom_type=np.complex64, math_type='float'):
         super(PoUpdateKernel, self).__init__()
         # and now initialise the cuda
         if denom_type == np.complex64:
@@ -611,6 +611,10 @@ class PoUpdateKernel(ab.PoUpdateKernel):
             dtype = 'float'
         else:
             raise ValueError('only complex64 and float32 types supported')
+        if math_type not in ['double', 'float']:
+            raise ValueError('only float and double are supported for math_type')
+        
+        self.math_type = math_type
         self.dtype = dtype
         self.queue = queue_thread
         self.ob_update_cuda = load_kernel("ob_update", {
@@ -622,8 +626,9 @@ class PoUpdateKernel(ab.PoUpdateKernel):
         })
         self.pr_update2_cuda = None
         self.ob_update_ML_cuda = load_kernel("ob_update_ML", {
-            'CTYPE': 'complex<float>',
-            'FTYPE': 'float'
+            'IN_TYPE': 'float',
+            'OUT_TYPE': 'float',
+            'MATH_TYPE': self.math_type
         })
         self.ob_update2_ML_cuda = None
         self.pr_update_ML_cuda = load_kernel("pr_update_ML", {

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -107,7 +107,11 @@ class FourierUpdateKernel(ab.FourierUpdateKernel):
             'OUT_TYPE': 'float',
             'MATH_TYPE': self.math_type
         })
-        self.fourier_error_cuda = load_kernel("fourier_error")
+        self.fourier_error_cuda = load_kernel("fourier_error", {
+            'IN_TYPE': 'float',
+            'OUT_TYPE': 'float',
+            'MATH_TYPE': self.math_type
+        })
         self.fourier_error2_cuda = None
         self.error_reduce_cuda = load_kernel("error_reduce", {
             'IN_TYPE': 'float',
@@ -779,7 +783,11 @@ class PositionCorrectionKernel(ab.PositionCorrectionKernel):
         self.queue = queue_thread
         self._ob_shape = None
         self._ob_id = None
-        self.fourier_error_cuda = load_kernel("fourier_error")
+        self.fourier_error_cuda = load_kernel("fourier_error",{
+            'IN_TYPE': 'float',
+            'OUT_TYPE': 'float',
+            'MATH_TYPE': self.math_type
+        })
         self.error_reduce_cuda = load_kernel("error_reduce", {
             'IN_TYPE': 'float',
             'OUT_TYPE': 'float',

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -629,7 +629,10 @@ class PoUpdateKernel(ab.PoUpdateKernel):
         })
         self.ob_update2_cuda = None  # load_kernel("ob_update2")
         self.pr_update_cuda = load_kernel("pr_update", {
-            'DENOM_TYPE': dtype
+            'DENOM_TYPE': dtype,
+            'IN_TYPE': 'float',
+            'OUT_TYPE': 'float',
+            'MATH_TYPE': self.math_type
         })
         self.pr_update2_cuda = None
         self.ob_update_ML_cuda = load_kernel("ob_update_ML", {

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -275,7 +275,11 @@ class AuxiliaryWaveKernel(ab.AuxiliaryWaveKernel):
             'OUT_TYPE': 'float',
             'MATH_TYPE': self.math_type
         })
-        self.build_exit_cuda = load_kernel("build_exit")
+        self.build_exit_cuda = load_kernel("build_exit", {
+            'IN_TYPE': 'float',
+            'OUT_TYPE': 'float',
+            'MATH_TYPE': self.math_type
+        })
         self.build_aux_no_ex_cuda = load_kernel("build_aux_no_ex", {
             'IN_TYPE': 'float',
             'OUT_TYPE': 'float',

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -609,8 +609,12 @@ class PoUpdateKernel(ab.PoUpdateKernel):
             dtype = 'complex<float>'
         elif denom_type == np.float32:
             dtype = 'float'
+        elif denom_type == np.complex128:
+            dtype = 'complex<double>'
+        elif denom_type == np.float64:
+            dtype = 'double'
         else:
-            raise ValueError('only complex64 and float32 types supported')
+            raise ValueError('invalid type for denominator')
         if math_type not in ['double', 'float']:
             raise ValueError('only float and double are supported for math_type')
         
@@ -618,7 +622,10 @@ class PoUpdateKernel(ab.PoUpdateKernel):
         self.dtype = dtype
         self.queue = queue_thread
         self.ob_update_cuda = load_kernel("ob_update", {
-            'DENOM_TYPE': dtype
+            'DENOM_TYPE': dtype,
+            'IN_TYPE': 'float',
+            'OUT_TYPE': 'float',
+            'MATH_TYPE': self.math_type
         })
         self.ob_update2_cuda = None  # load_kernel("ob_update2")
         self.pr_update_cuda = load_kernel("pr_update", {

--- a/test/accelerate_tests/cuda_pycuda_tests/fourier_update_kernel_test.py
+++ b/test/accelerate_tests/cuda_pycuda_tests/fourier_update_kernel_test.py
@@ -109,7 +109,7 @@ class FourierUpdateKernelTest(PyCudaTest):
         nFUK.fmag_all_update(f, addr, fmag, mask, err_fmag, pbound=pbound_set)
         expected_f = f
         measured_f = f_d.get()
-        np.testing.assert_array_equal(expected_f, measured_f, err_msg="Numpy f "
+        np.testing.assert_allclose(expected_f, measured_f, rtol=1e-6, err_msg="Numpy f "
                                                                       "is \n%s, \nbut gpu f is \n %s, \n mask is:\n %s \n" %  (repr(expected_f),
                                                                                                                                repr(measured_f),
                                                                                                                                repr(mask)))

--- a/test/accelerate_tests/cuda_pycuda_tests/fourier_update_kernel_test.py
+++ b/test/accelerate_tests/cuda_pycuda_tests/fourier_update_kernel_test.py
@@ -191,7 +191,7 @@ class FourierUpdateKernelTest(PyCudaTest):
 
         expected_fdev = nFUK.npy.fdev
         measured_fdev = FUK.gpu.fdev.get()
-        np.testing.assert_array_equal(expected_fdev, measured_fdev, err_msg="Numpy fdev "
+        np.testing.assert_allclose(expected_fdev, measured_fdev, rtol=1e-6, err_msg="Numpy fdev "
                                                                             "is \n%s, \nbut gpu fdev is \n %s, \n " % (
                                                                             repr(expected_fdev),
                                                                             repr(measured_fdev)))


### PR DESCRIPTION
All used kernels are transformed to allow flexibility in the data types they use, in order to control/test precision issues.

Note that since there is a common math_type in Python added to the kernel classes, setting this has a cross effect on other GPU kernels. We can refine that once we've determined the best / sufficient data types for all kernels in the tests.