### PR TITLE
Potential fix for floating intensity kernel

### DIFF
--- a/ptypy/accelerate/base/engines/ML_serial.py
+++ b/ptypy/accelerate/base/engines/ML_serial.py
@@ -395,6 +395,7 @@ class GaussianModel(BaseModelSerial):
                     f["addr"] = addr
                     f["I"] = I
                     f["fic"] = fic
+                    f["Imodel"] = GDK.npy.Imodel
 
             if self.p.floating_intensities:
                 GDK.floating_intensity(addr, w, I, fic)

--- a/ptypy/accelerate/base/kernels.py
+++ b/ptypy/accelerate/base/kernels.py
@@ -204,7 +204,8 @@ class GradientDescentKernel(BaseKernel):
         self.npy.LLerr = np.zeros(self.fshape, dtype=self.ftype)
         self.npy.Imodel = np.zeros(self.fshape, dtype=self.ftype)
 
-        self.npy.fic_tmp = np.ones((self.fshape[0],), dtype=self.ftype)
+        self.npy.fic_nom = np.ones((self.fshape[0],), dtype=self.ftype)
+        self.npy.fic_den = np.ones((self.fshape[0],), dtype=self.ftype)
 
     def make_model(self, b_aux, addr):
 
@@ -300,14 +301,15 @@ class GradientDescentKernel(BaseKernel):
         num = self.npy.LLerr[:maxz]
         den = self.npy.LLden[:maxz]
         Imodel = self.npy.Imodel[:maxz]
-        fic_tmp = self.npy.fic_tmp[:maxz]
+        fic_nom = self.npy.fic_nom[:maxz]
+        fic_den = self.npy.fic_den[:maxz]
 
         ## math ##
         num[:] = w * Imodel * I
         den[:] = w * Imodel ** 2
-        fic[:] = num.sum(-1).sum(-1)
-        fic_tmp[:]= den.sum(-1).sum(-1)
-        fic/=fic_tmp
+        fic_nom[:] = num.sum(-1).sum(-1)
+        fic_den[:] = den.sum(-1).sum(-1)
+        fic[:] = fic_nom / fic_den
         Imodel *= fic.reshape(Imodel.shape[0], 1, 1)
 
     def main(self, b_aux, addr, w, I):

--- a/ptypy/accelerate/cuda_pycuda/cuda/intens_renorm.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/intens_renorm.cu
@@ -28,7 +28,8 @@ extern "C" __global__ void step1(const IN_TYPE* Imodel,
   den[iz * x + ix] = tmp * MATH_TYPE(Imodel[iz * x + ix]);
 }
 
-extern "C" __global__ void step2(const IN_TYPE* fic_tmp,
+extern "C" __global__ void step2(const IN_TYPE* fic_nom,
+                                 const IN_TYPE* fic_den,
                                  OUT_TYPE* fic,
                                  OUT_TYPE* Imodel,
                                  int z,
@@ -40,7 +41,7 @@ extern "C" __global__ void step2(const IN_TYPE* fic_tmp,
   if (iz >= z || ix >= x)
     return;
   //probably not so clever having all threads read from the same locations
-  auto tmp = MATH_TYPE(fic[iz]) / MATH_TYPE(fic_tmp[iz]);
+  auto tmp = MATH_TYPE(fic_nom[iz]) / MATH_TYPE(fic_den[iz]);
   Imodel[iz * x + ix] *= tmp;
   // race condition if write is not restricted to one thread
   // learned this the hard way

--- a/test/accelerate_tests/cuda_pycuda_tests/dls_tests/dls_gradient_descent_kernel_test.py
+++ b/test/accelerate_tests/cuda_pycuda_tests/dls_tests/dls_gradient_descent_kernel_test.py
@@ -60,14 +60,17 @@ class DlsGradientDescentKernelTest(PyCudaTest):
     ])
     def test_floating_intensity_UNITY(self, name, iter):
 
+        maxz = 128
+
         # Load data
         with h5py.File(self.datadir %name + "floating_intensities_%04d.h5" %iter, "r") as f:
-            w = f["w"][:]
-            addr = f["addr"][:]
-            I = f["I"][:]
-            fic = f["fic"][:]
+            w = f["w"][:maxz]
+            addr = f["addr"][:maxz]
+            I = f["I"][:maxz]
+            fic = f["fic"][:maxz]
+            Imodel = f["Imodel"][:maxz]
         with h5py.File(self.datadir %name + "make_model_%04d.h5" %iter, "r") as f:
-            aux = f["aux"][:]
+            aux = f["aux"][:maxz]
         
         # Copy data to device
         aux_dev = gpuarray.to_gpu(aux)
@@ -75,21 +78,24 @@ class DlsGradientDescentKernelTest(PyCudaTest):
         addr_dev = gpuarray.to_gpu(addr)
         I_dev = gpuarray.to_gpu(I)
         fic_dev = gpuarray.to_gpu(fic)
+        Imodel_dev = gpuarray.to_gpu(Imodel)
 
         # CPU Kernel
         BGDK = BaseGradientDescentKernel(aux, addr.shape[1])
         BGDK.allocate()
+        BGDK.npy.Imodel = Imodel
         BGDK.floating_intensity(addr, w, I, fic)
 
         # GPU kernel
         GDK = GradientDescentKernel(aux_dev, addr.shape[1])
         GDK.allocate()
+        GDK.gpu.Imodel = Imodel_dev
         GDK.floating_intensity(addr_dev, w_dev, I_dev, fic_dev)
 
         ## Assert
-        np.testing.assert_allclose(BGDK.npy.Imodel, GDK.gpu.Imodel.get(), atol=self.atol, rtol=self.rtol, 
+        np.testing.assert_allclose(GDK.gpu.Imodel.get(), BGDK.npy.Imodel, atol=self.atol, rtol=self.rtol, 
             err_msg="`Imodel` buffer has not been updated as expected")
-        np.testing.assert_allclose(fic, fic_dev.get(), atol=self.atol, rtol=self.rtol, 
+        np.testing.assert_allclose(fic_dev.get(), fic, atol=self.atol, rtol=self.rtol, 
             err_msg="floating intensity coeff (fic) has not been updated as expected")
 
     @parameterized.expand([


### PR DESCRIPTION
It looks like we should not update fic in-place while it is still used to update Imodel. Have fixed this issue for now by introducing new array for the nominator (fic_nom) and renamed fic_tmp to fic_den, but certainly there must be a way to fix this without the extra memory...