### PR TITLE
Gpu hackathon: intensity kernel fix

### DIFF
--- a/ptypy/accelerate/base/engines/ML_serial.py
+++ b/ptypy/accelerate/base/engines/ML_serial.py
@@ -395,6 +395,7 @@ class GaussianModel(BaseModelSerial):
                     f["addr"] = addr
                     f["I"] = I
                     f["fic"] = fic
+                    f["Imodel"] = GDK.npy.Imodel
 
             if self.p.floating_intensities:
                 GDK.floating_intensity(addr, w, I, fic)

--- a/ptypy/accelerate/cuda_pycuda/cuda/error_reduce.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/error_reduce.cu
@@ -14,7 +14,7 @@ extern "C" __global__ void error_reduce(const IN_TYPE* ferr,
   int tx = threadIdx.x;
   int ty = threadIdx.y;
   int batch = blockIdx.x;
-  extern __shared__ ACC_TYPE sum_v[1024];
+  __shared__ ACC_TYPE sum_v[BDIM_X*BDIM_Y];
 
   int shidx =
       ty * blockDim.x + tx;  // shidx: index in shared memory for this block
@@ -35,7 +35,7 @@ extern "C" __global__ void error_reduce(const IN_TYPE* ferr,
 
   __syncthreads();
 
-  int nt = blockDim.x * blockDim.y;
+  int nt = BDIM_X * BDIM_Y;
   int c = nt;
 
   while (c > 1)

--- a/ptypy/accelerate/cuda_pycuda/cuda/intens_renorm.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/intens_renorm.cu
@@ -10,40 +10,57 @@
 using thrust::complex;
 
 extern "C" __global__ void step1(const IN_TYPE* Imodel,
-                                   const IN_TYPE* I,
-                                   const IN_TYPE* w,
-                                   OUT_TYPE* num,
-                                   OUT_TYPE* den,
-                                   int z,
-                                   int x)
+                                 const IN_TYPE* I,
+                                 const IN_TYPE* w,
+                                 OUT_TYPE* num,
+                                 OUT_TYPE* den,
+                                 int n)
 {
-  int iz = blockIdx.z;
-  int ix = threadIdx.x + blockIdx.x * blockDim.x;
+  int i = threadIdx.x + blockIdx.x * blockDim.x;
 
-  if (iz >= z || ix >= x)
+  if (i >= n)
     return;
 
-  auto tmp = MATH_TYPE(w[iz * x + ix]) * MATH_TYPE(Imodel[iz * x + ix]);
-  num[iz * x + ix] = tmp * MATH_TYPE(I[iz * x + ix]);
-  den[iz * x + ix] = tmp * MATH_TYPE(Imodel[iz * x + ix]);
+  auto tmp = MATH_TYPE(w[i]) * MATH_TYPE(Imodel[i]);
+  num[i] = tmp * MATH_TYPE(I[i]);
+  den[i] = tmp * MATH_TYPE(Imodel[i]);
 }
 
 extern "C" __global__ void step2(const IN_TYPE* fic_tmp,
                                  OUT_TYPE* fic,
                                  OUT_TYPE* Imodel,
-                                 int z,
-                                 int x)
+                                 int X,
+                                 int Y)
 {
   int iz = blockIdx.z;
-  int ix = threadIdx.x + blockIdx.x * blockDim.x;
+  int tx = threadIdx.x;
+  int ty = threadIdx.y;
+  
+  // one thread block per fic data point - we want the first thread to read this
+  // into shared memory and then sync the block, so we don't get into data races
+  // with writing it back to global memory in the end (and we read the value only
+  // once)
+  //
+  __shared__ MATH_TYPE shfic[1];
+  if (tx == 0 && ty == 0) {
+    shfic[0] = MATH_TYPE(fic[iz]) / MATH_TYPE(fic_tmp[iz]);
+  } 
+  __syncthreads();
 
-  if (iz >= z || ix >= x)
-    return;
-  //probably not so clever having all threads read from the same locations
-  auto tmp = MATH_TYPE(fic[iz]) / MATH_TYPE(fic_tmp[iz]);
-  Imodel[iz * x + ix] *= tmp;
+  // now all threads can access that value
+  auto tmp = shfic[0];
+
+  // offset Imodel for current z
+  Imodel += iz * X * Y;
+  
+  for (int iy = ty; iy < Y; iy += blockDim.y) {
+    #pragma unroll(4)
+    for (int ix = tx; ix < X; ix += blockDim.x) {
+      Imodel[iy * X + ix] *= tmp;
+    }
+  }
+    
   // race condition if write is not restricted to one thread
-  // learned this the hard way
-  if (ix==0)
+  if (tx==0 && ty == 0)
     fic[iz] = tmp;
 }

--- a/test/accelerate_tests/cuda_pycuda_tests/dls_tests/dls_gradient_descent_kernel_test.py
+++ b/test/accelerate_tests/cuda_pycuda_tests/dls_tests/dls_gradient_descent_kernel_test.py
@@ -59,13 +59,14 @@ class DlsGradientDescentKernelTest(PyCudaTest):
         ["floating", 0],
     ])
     def test_floating_intensity_UNITY(self, name, iter):
-
+        
         # Load data
         with h5py.File(self.datadir %name + "floating_intensities_%04d.h5" %iter, "r") as f:
             w = f["w"][:]
             addr = f["addr"][:]
             I = f["I"][:]
             fic = f["fic"][:]
+            Imodel = f["Imodel"][:]
         with h5py.File(self.datadir %name + "make_model_%04d.h5" %iter, "r") as f:
             aux = f["aux"][:]
         
@@ -75,22 +76,39 @@ class DlsGradientDescentKernelTest(PyCudaTest):
         addr_dev = gpuarray.to_gpu(addr)
         I_dev = gpuarray.to_gpu(I)
         fic_dev = gpuarray.to_gpu(fic)
+        Imodel_dev = gpuarray.to_gpu(np.ascontiguousarray(Imodel))
 
         # CPU Kernel
         BGDK = BaseGradientDescentKernel(aux, addr.shape[1])
         BGDK.allocate()
+        BGDK.npy.Imodel = Imodel
         BGDK.floating_intensity(addr, w, I, fic)
 
         # GPU kernel
         GDK = GradientDescentKernel(aux_dev, addr.shape[1])
         GDK.allocate()
+        GDK.gpu.Imodel = Imodel_dev
         GDK.floating_intensity(addr_dev, w_dev, I_dev, fic_dev)
 
         ## Assert
-        np.testing.assert_allclose(BGDK.npy.Imodel, GDK.gpu.Imodel.get(), atol=self.atol, rtol=self.rtol, 
-            err_msg="`Imodel` buffer has not been updated as expected")
+        np.testing.assert_allclose(BGDK.npy.LLerr, GDK.gpu.LLerr.get(), atol=self.atol, rtol=self.rtol, 
+            verbose=False, equal_nan=False,
+            err_msg="`LLerr` buffer has not been updated as expected")
+        np.testing.assert_allclose(BGDK.npy.LLden, GDK.gpu.LLden.get(), atol=self.atol, rtol=self.rtol, 
+            verbose=False, equal_nan=False,
+            err_msg="`LLden` buffer has not been updated as expected")
+        np.testing.assert_allclose(BGDK.npy.fic_tmp, GDK.gpu.fic_tmp.get(), atol=self.atol, rtol=self.rtol, 
+            verbose=False, equal_nan=False,
+            err_msg="`fic_tmp` buffer has not been updated as expected")
+
         np.testing.assert_allclose(fic, fic_dev.get(), atol=self.atol, rtol=self.rtol, 
+            verbose=False, equal_nan=False, 
             err_msg="floating intensity coeff (fic) has not been updated as expected")
+
+        np.testing.assert_allclose(BGDK.npy.Imodel, GDK.gpu.Imodel.get(), atol=self.atol, rtol=self.rtol, 
+            verbose=False, equal_nan=False,
+            err_msg="`Imodel` buffer has not been updated as expected")
+        
 
     @parameterized.expand([
         ["base", 10],


### PR DESCRIPTION
This fixes a race condition with the floating intensity kernels in case multiple threads read after the global memory has been written back for the fic coefficients. Now using one thread block per z dimension, shared memory for caching, and a barrier to avoid write-before-read race. 