### PR TITLE
Gpu hackathon: crop pad

### DIFF
--- a/ptypy/accelerate/cuda_pycuda/__init__.py
+++ b/ptypy/accelerate/cuda_pycuda/__init__.py
@@ -4,7 +4,13 @@ import numpy as np
 import os
 # debug_options = []
 #debug_options = ['-O0', '-G', '-g', '-std=c++11', '--keep']
-debug_options = ['-O3', '-DNDEBUG', '-std=c++11', '-lineinfo'] # release mode flags
+debug_options = ['-O3', '-DNDEBUG', '-lineinfo'] # release mode flags
+
+# C++14 support was added with CUDA 9, so we only enable the flag there
+if cuda.get_version()[0] >= 9:
+    debug_options += ['-std=c++14']
+else:
+    debug_options += ['-std=c++11']
 
 context = None
 queue = None

--- a/ptypy/accelerate/cuda_pycuda/array_utils.py
+++ b/ptypy/accelerate/cuda_pycuda/array_utils.py
@@ -25,6 +25,8 @@ class ArrayUtilsKernel:
             'DTYPE': 'int',
             'BDIM': 16
         })
+        # we lazy-load this depending on the data types we get
+        self.fill3D_cuda = {}
         self.Ctmp = None
         
     def dot(self, A, B, out=None):
@@ -84,6 +86,100 @@ class ArrayUtilsKernel:
 
     def norm2(self, A, out=None):
         return self.dot(A, A, out)
+
+    def fill3D(self, A, B, offset=[0, 0, 0]):
+        """
+        Fill 3-dimensional array A with B.
+        """
+        if A.ndim < 3 or B.ndim < 3:
+            raise ValueError('Input arrays must each be at least 3D')
+        assert A.ndim == B.ndim, "Input and Output must have the same number of dimensions."
+        ash = A.shape
+        bsh = B.shape
+        misfit = np.array(bsh) - np.array(ash)
+        assert not misfit[:-3].any(), "Input and Output must have the same shape everywhere but the last three axes."
+
+        Alim = np.array(A.shape[-3:])
+        Blim = np.array(B.shape[-3:])
+        off = np.array(offset)
+        Ao = off.copy()
+        Ao[Ao < 0] = 0
+        Bo = -off.copy()
+        Bo[Bo < 0] = 0
+        assert (Bo < Blim).all() and (Ao < Alim).all(), "At least one dimension lacks overlap"
+        Ao = Ao.astype(np.int32)
+        Bo =     Bo.astype(np.int32)
+        lengths = np.array([
+            min(off[0] + Blim[0], Alim[0]) - Ao[0],
+            min(off[1] + Blim[1], Alim[1]) - Ao[1],
+            min(off[2] + Blim[2], Alim[2]) - Ao[2],
+        ], dtype=np.int32)
+        lengths2 = np.array([
+            min(Alim[0] - off[0], Blim[0]) - Bo[0],
+            min(Alim[1] - off[1], Blim[1]) - Bo[1],
+            min(Alim[2] - off[2], Blim[2]) - Bo[2],
+        ], dtype=np.int32)
+        assert (lengths == lengths2).all(), "left and right lenghts are not matching"
+        batch = int(np.prod(A.shape[:-3]))
+        
+        # lazy loading depending on data type
+        
+        def map_type(dt):
+            if dt == np.float32:
+                return 'float'
+            elif dt == np.float64: 
+                return 'double'
+            elif dt == np.complex64: 
+                return 'complex<float>'
+            elif dt == np.complex128: 
+                return 'complex<double>'
+            elif dt == np.int32:
+                return 'int'
+            elif dt == np.int64:
+                return 'long long'
+            else:
+                raise ValueError('No mapping for {}'.format(dt))
+
+        version = '{},{}'.format(map_type(B.dtype), map_type(A.dtype))
+        if version not in self.fill3D_cuda:
+            self.fill3D_cuda[version] = load_kernel("fill3D", {
+              'IN_TYPE': map_type(B.dtype),
+              'OUT_TYPE': map_type(A.dtype)
+            })
+        bx = by = 32
+        self.fill3D_cuda[version](
+            A, B, 
+            np.int32(A.shape[-3]), np.int32(A.shape[-2]), np.int32(A.shape[-1]),
+            np.int32(B.shape[-3]), np.int32(B.shape[-2]), np.int32(B.shape[-1]),
+            Ao[0], Ao[1], Ao[2],
+            Bo[0], Bo[1], Bo[2],
+            lengths[0], lengths[1], lengths[2],
+            block=(int(bx), int(by), int(1)),
+            grid=(
+                int((lengths[2] + bx - 1)//bx),
+                int((lengths[1] + by - 1)//by),
+                int(batch)),
+            stream=self.queue
+        )
+
+
+    def crop_pad_2d_simple(self, A, B):
+        """
+        Places B in A centered around the last two axis. A and B must be of the same shape
+        anywhere but the last two dims.
+        """
+        assert A.ndim >= 2, "Arrays must have more than 2 dimensions."
+        assert A.ndim == B.ndim, "Input and Output must have the same number of dimensions."
+        misfit = np.array(A.shape) - np.array(B.shape)
+        assert not misfit[:-2].any(), "Input and Output must have the same shape everywhere but the last two axes."
+        if A.ndim == 2:
+            A = A.reshape((1,) + A.shape)
+        if B.ndim == 2:
+            B = B.reshape((1,) + B.shape)
+        a1, a2 = A.shape[-2:]
+        b1, b2 = B.shape[-2:]
+        offset = [0, a1 // 2 - b1 // 2, a2 // 2 - b2 // 2]
+        self.fill3D(A, B, offset)
 
 
 class DerivativesKernel:

--- a/ptypy/accelerate/cuda_pycuda/cuda/fill3D.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/fill3D.cu
@@ -1,0 +1,60 @@
+/** fill3D kernel.
+ * 
+ * Data types:
+ * - IN_TYPE: the data type for the inputs
+ * - OUT_TYPE: data type for outputs 
+ */
+
+#include <cmath>
+#include <thrust/complex.h>
+using thrust::complex;
+
+extern "C" __global__ void fill3D(
+    OUT_TYPE* A,
+    const IN_TYPE* B,
+    // final dimensions of A/B in [z, y, x]
+    int A_Z,
+    int A_Y,
+    int A_X,
+    int B_Z,
+    int B_Y,
+    int B_X,
+    // offsets to start reading/writing
+    int Ao_z,
+    int Ao_y,
+    int Ao_x,
+    int Bo_z,
+    int Bo_y,
+    int Bo_x,
+    // lengths to copy
+    int len_z,
+    int len_y,
+    int len_x
+    )
+{
+    // We use the following strategy:
+    // - BlockIdx.z for the batch (first dims combined if 4D+)
+    // - blockDim.z = 1
+    // - multiple blocks are used across y and x dimensions
+    // - we loop over z dimension within the thread block
+    int batch = blockIdx.z;
+    int ix = threadIdx.x + blockIdx.x * blockDim.x;
+    int iy = threadIdx.y + blockIdx.y * blockDim.y;
+
+    if (ix >= len_x || iy >= len_y)
+        return;
+
+    // offset for current batch (4D+ dimension)
+    A += batch * A_X * A_Y * A_Z;
+    B += batch * B_X * B_Y * B_Z;
+
+    // offset for start position in each dimension of the last 3
+    A += Ao_z * A_Y * A_X + Ao_y * A_X + Ao_x;
+    B += Bo_z * B_Y * B_X + Bo_y * B_X + Bo_x;
+
+    // copy data
+    for (int iz = 0; iz < len_z; ++iz) {
+        A[iz * A_Y * A_X + iy * A_X + ix] = 
+            B[iz * B_Y * B_X + iy * B_X + ix];
+    }
+}

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -145,7 +145,9 @@ class FourierUpdateKernel(ab.FourierUpdateKernel):
         self.error_reduce_cuda = load_kernel("error_reduce", {
             'IN_TYPE': 'float',
             'OUT_TYPE': 'float',
-            'ACC_TYPE': self.accumulate_type
+            'ACC_TYPE': self.accumulate_type,
+            'BDIM_X': 32,
+            'BDIM_Y': 32,
         })
         self.fourier_update_cuda = None
         self.log_likelihood_cuda = load_kernel("log_likelihood", {
@@ -843,6 +845,8 @@ class PositionCorrectionKernel(ab.PositionCorrectionKernel):
         self.error_reduce_cuda = load_kernel("error_reduce", {
             'IN_TYPE': 'float',
             'OUT_TYPE': 'float',
+            'BDIM_X': 32,
+            'BDIM_Y': 32,
             'ACC_TYPE': self.accumulate_type
         })
         self.build_aux_pc_cuda = load_kernel("build_aux_position_correction", {

--- a/ptypy/accelerate/cuda_pycuda/kernels.py
+++ b/ptypy/accelerate/cuda_pycuda/kernels.py
@@ -3,7 +3,7 @@ from inspect import getfullargspec
 from pycuda import gpuarray
 from ptypy.utils.verbose import log, logger
 from . import load_kernel
-from .array_utils import ArrayUtilsKernel
+from .array_utils import CropPadKernel
 from ..base import kernels as ab
 from ..base.kernels import Adict
 
@@ -44,7 +44,7 @@ class PropagationKernel:
             self._do_crop_pad = (self._p.crop_pad != 0).any()
             if self._do_crop_pad:
                 self._tmp = np.zeros(aux.shape + self._p.crop_pad, dtype=aux.dtype)
-                self._AUK = ArrayUtilsKernel(queue=self._queue) 
+                self._CPK = CropPadKernel(queue=self._queue)
             else:
                 self._tmp = aux
 
@@ -63,17 +63,17 @@ class PropagationKernel:
 
             def _fw(x,y):
                 if self._do_crop_pad:
-                    self._AUK.crop_pad_2d_simple(self._tmp, x)
+                    self._CPK.crop_pad_2d_simple(self._tmp, x)
                     self._fft1.ft(self._tmp, self._tmp)
-                    self._AUK.crop_pad_2d_simple(y, self._tmp)
+                    self._CPK.crop_pad_2d_simple(y, self._tmp)
                 else:
                     self._fft1.ft(x,y)
 
             def _bw(x,y):
                 if self._do_crop_pad:
-                    self._AUK.crop_pad_2d_simple(self._tmp, x)
+                    self._CPK.crop_pad_2d_simple(self._tmp, x)
                     self._fft2.ift(self._tmp, self._tmp)
-                    self._AUK.crop_pad_2d_simple(y, self._tmp)
+                    self._CPK.crop_pad_2d_simple(y, self._tmp)
                 else:
                     self._fft2.ift(x,y)
             

--- a/test/accelerate_tests/cuda_pycuda_tests/array_utils_test.py
+++ b/test/accelerate_tests/cuda_pycuda_tests/array_utils_test.py
@@ -279,10 +279,11 @@ class ArrayUtilsTest(PyCudaTest):
 
         # Act
         au.crop_pad_2d_simple(A, B)
-        gau.crop_pad_2d_simple(A_dev, B_dev)
+        k = gau.ArrayUtilsKernel(queue=self.stream)
+        k.crop_pad_2d_simple(A_dev, B_dev)
 
         # Assert
-        np.testing.assert_all_close(A_dev.get(), A, rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(A, A_dev.get(), rtol=1e-6, atol=1e-6)
 
     def test_crop_pad_simple_2(self):
         # crop, float, 3D
@@ -293,10 +294,12 @@ class ArrayUtilsTest(PyCudaTest):
 
         # Act
         au.crop_pad_2d_simple(A, B)
-        gau.crop_pad_2d_simple(A_dev, B_dev)
+        k = gau.ArrayUtilsKernel(queue=self.stream)
+        k.crop_pad_2d_simple(A_dev, B_dev)
+
 
         # Assert
-        np.testing.assert_all_close(A_dev.get(), A, rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(A, A_dev.get(), rtol=1e-6, atol=1e-6)
 
     def test_crop_pad_simple_3(self):
         # crop/pad, complex, 3D
@@ -308,7 +311,24 @@ class ArrayUtilsTest(PyCudaTest):
 
         # Act
         au.crop_pad_2d_simple(A, B)
-        gau.crop_pad_2d_simple(A_dev, B_dev)
+        k = gau.ArrayUtilsKernel(queue=self.stream)
+        k.crop_pad_2d_simple(A_dev, B_dev)
 
         # Assert
-        np.testing.assert_all_close(A_dev.get(), A, rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(A, A_dev.get(), rtol=1e-6, atol=1e-6)
+
+    def test_crop_pad_simple_4(self):
+        # crop/pad, 4D
+        B = np.indices((2, 4, 3), dtype=np.float32)
+        A = np.ones((3, 2, 2, 5), dtype=B.dtype)
+        print('{} vs {}'.format(B.shape, A.shape))
+        B_dev = gpuarray.to_gpu(B)
+        A_dev = gpuarray.to_gpu(A)
+
+        # Act
+        au.crop_pad_2d_simple(A, B)
+        k = gau.ArrayUtilsKernel(queue=self.stream)
+        k.crop_pad_2d_simple(A_dev, B_dev)
+
+        # Assert
+        np.testing.assert_allclose(A, A_dev.get(), rtol=1e-6, atol=1e-6)

--- a/test/accelerate_tests/cuda_pycuda_tests/array_utils_test.py
+++ b/test/accelerate_tests/cuda_pycuda_tests/array_utils_test.py
@@ -321,7 +321,6 @@ class ArrayUtilsTest(PyCudaTest):
         # crop/pad, 4D
         B = np.indices((2, 4, 3), dtype=np.float32)
         A = np.ones((3, 2, 2, 5), dtype=B.dtype)
-        print('{} vs {}'.format(B.shape, A.shape))
         B_dev = gpuarray.to_gpu(B)
         A_dev = gpuarray.to_gpu(A)
 

--- a/test/accelerate_tests/cuda_pycuda_tests/propagation_kernel_test.py
+++ b/test/accelerate_tests/cuda_pycuda_tests/propagation_kernel_test.py
@@ -63,7 +63,7 @@ class PropagationKernelTest(PyCudaTest):
 
         # test
         aux = geo.propagator.fw(aux)
-        PropK = PropagationKernel(aux_d, geo.propagator, queue_thread=self.stream, fft='cuda')
+        PropK = PropagationKernel(aux_d, geo.propagator, queue_thread=self.stream)
         PropK.allocate()
         PropK.fw(aux_d, aux_d)
 
@@ -80,7 +80,7 @@ class PropagationKernelTest(PyCudaTest):
 
         # test
         aux = geo.propagator.bw(aux)
-        PropK = PropagationKernel(aux_d, geo.propagator, queue_thread=self.stream, fft='cuda')
+        PropK = PropagationKernel(aux_d, geo.propagator, queue_thread=self.stream)
         PropK.allocate()
         PropK.bw(aux_d, aux_d)
 
@@ -116,7 +116,7 @@ class PropagationKernelTest(PyCudaTest):
 
         # test
         aux = geo.propagator.bw(aux)
-        PropK = PropagationKernel(aux_d, geo.propagator, queue_thread=self.stream, fft='cuda')
+        PropK = PropagationKernel(aux_d, geo.propagator, queue_thread=self.stream)
         PropK.allocate()
         PropK.bw(aux_d, aux_d)
 

--- a/test/accelerate_tests/cuda_pycuda_tests/propagation_kernel_test.py
+++ b/test/accelerate_tests/cuda_pycuda_tests/propagation_kernel_test.py
@@ -23,7 +23,7 @@ INT_TYPE = np.int32
 
 class PropagationKernelTest(PyCudaTest):
 
-    def set_up_farfield(self,shape):
+    def set_up_farfield(self,shape, resolution=None):
         P = Base()
         P.CType = COMPLEX_TYPE
         P.Ftype = FLOAT_TYPE
@@ -34,6 +34,8 @@ class PropagationKernelTest(PyCudaTest):
         g.psize = 24e-6
         g.shape = shape
         g.propagation = "farfield"
+        if resolution is not None:
+            g.resolution = resolution
         G = geometry.Geo(owner=P, pars=g)
         return G
 
@@ -61,11 +63,12 @@ class PropagationKernelTest(PyCudaTest):
 
         # test
         aux = geo.propagator.fw(aux)
-        PropK = PropagationKernel(aux_d, geo.propagator, queue_thread=self.stream)
+        PropK = PropagationKernel(aux_d, geo.propagator, queue_thread=self.stream, fft='cuda')
         PropK.allocate()
         PropK.fw(aux_d, aux_d)
 
-        np.testing.assert_allclose(aux, aux_d.get(), atol=1e-06, rtol=5e-5, err_msg="Numpy aux is \n%s, \nbut gpu aux is \n %s, \n " % (repr(aux), repr(aux_d.get())))
+        np.testing.assert_allclose(aux_d.get(), aux, atol=1e-06, rtol=5e-5, 
+            err_msg="Numpy aux is \n%s, \nbut gpu aux is \n %s, \n " % (repr(aux), repr(aux_d.get())))
 
     def test_farfield_propagator_backward_UNITY(self):
         # setup
@@ -77,11 +80,48 @@ class PropagationKernelTest(PyCudaTest):
 
         # test
         aux = geo.propagator.bw(aux)
-        PropK = PropagationKernel(aux_d, geo.propagator, queue_thread=self.stream)
+        PropK = PropagationKernel(aux_d, geo.propagator, queue_thread=self.stream, fft='cuda')
         PropK.allocate()
         PropK.bw(aux_d, aux_d)
 
-        np.testing.assert_allclose(aux, aux_d.get(), atol=1e-06, rtol=5e-5, err_msg="Numpy aux is \n%s, \nbut gpu aux is \n %s, \n " % (repr(aux), repr(aux_d.get())))
+        np.testing.assert_allclose(aux_d.get(), aux, atol=1e-06, rtol=5e-5, 
+            err_msg="Numpy aux is \n%s, \nbut gpu aux is \n %s, \n " % (repr(aux), repr(aux_d.get())))
+
+    def test_farfield_propagator_forward_crop_pad_UNITY(self):
+        # setup
+        SH = (16,16)
+        aux = np.zeros((SH), dtype=COMPLEX_TYPE)
+        aux[5:11,5:11] = 1. + 2j
+        aux_d = gpuarray.to_gpu(aux)
+        geo = self.set_up_farfield(SH)
+        geo = self.set_up_farfield(SH, resolution=0.5*geo.resolution)
+
+        # test
+        aux = geo.propagator.fw(aux)
+        PropK = PropagationKernel(aux_d, geo.propagator, queue_thread=self.stream)
+        PropK.allocate()
+        PropK.fw(aux_d, aux_d)
+
+        np.testing.assert_allclose(aux_d.get(), aux, atol=1e-06, rtol=5e-5, 
+            err_msg="Numpy aux is \n%s, \nbut gpu aux is \n %s, \n " % (repr(aux), repr(aux_d.get())))
+
+    def test_farfield_propagator_backward_crop_pad_UNITY(self):
+        # setup
+        SH = (16,16)
+        aux = np.zeros((SH), dtype=COMPLEX_TYPE)
+        aux[5:11,5:11] = 1. + 2j
+        aux_d = gpuarray.to_gpu(aux)
+        geo = self.set_up_farfield(SH)
+        geo = self.set_up_farfield(SH, resolution=0.5*geo.resolution)
+
+        # test
+        aux = geo.propagator.bw(aux)
+        PropK = PropagationKernel(aux_d, geo.propagator, queue_thread=self.stream, fft='cuda')
+        PropK.allocate()
+        PropK.bw(aux_d, aux_d)
+
+        np.testing.assert_allclose(aux_d.get(), aux, atol=1e-06, rtol=5e-5, 
+            err_msg="Numpy aux is \n%s, \nbut gpu aux is \n %s, \n " % (repr(aux), repr(aux_d.get())))
 
     def test_nearfield_propagator_forward_UNITY(self):
         # setup
@@ -97,7 +137,8 @@ class PropagationKernelTest(PyCudaTest):
         PropK.allocate()
         PropK.fw(aux_d, aux_d)
 
-        np.testing.assert_allclose(aux, aux_d.get(), atol=1e-06, rtol=5e-5, err_msg="Numpy aux is \n%s, \nbut gpu aux is \n %s, \n " % (repr(aux), repr(aux_d.get())))
+        np.testing.assert_allclose(aux_d.get(), aux, atol=1e-06, rtol=5e-5, 
+            err_msg="Numpy aux is \n%s, \nbut gpu aux is \n %s, \n " % (repr(aux), repr(aux_d.get())))
 
     def test_nearfield_propagator_backward_UNITY(self):
         # setup
@@ -113,4 +154,5 @@ class PropagationKernelTest(PyCudaTest):
         PropK.allocate()
         PropK.bw(aux_d, aux_d)
 
-        np.testing.assert_allclose(aux, aux_d.get(), atol=1e-06, rtol=5e-5, err_msg="Numpy aux is \n%s, \nbut gpu aux is \n %s, \n " % (repr(aux), repr(aux_d.get())))
+        np.testing.assert_allclose(aux_d.get(), aux, atol=1e-06, rtol=5e-5, 
+            err_msg="Numpy aux is \n%s, \nbut gpu aux is \n %s, \n " % (repr(aux), repr(aux_d.get())))


### PR DESCRIPTION
This GPU implementation makes all tests pass for crop/pad. However, I feel the tests should be extended to cover the following corner cases / special cases:
- higher dimensionality, like 5D or 6D
- larger arrays, possibly random, where A is not just filled with zeros initially (also to use multiple thread blocks on the GPU and make sure that behaves fine)

We should also add a performance test (skipped by default) with something large, to run a profile and make sure the implementation is efficient.

Note that this kernel is the full fill3D, not just the simplified version - tests for that case should also be added to verify if that's working fine.