### PR TITLE
Fix in context initialisation to raise an exception

### DIFF
--- a/ptypy/accelerate/cuda_pycuda/__init__.py
+++ b/ptypy/accelerate/cuda_pycuda/__init__.py
@@ -27,13 +27,18 @@ def get_context(new_context=False, new_queue=False):
         if parallel.rank_local < cuda.Device.count():
             context = cuda.Device(parallel.rank_local).make_context()
             context.push()
-        # print("made context %s on rank %s" % (str(context), str(parallel.rank)))
-        # print("The cuda device count on %s is:%s" % (str(parallel.rank),
-        #                                              str(cuda.Device.count())))
-        # print("parallel.rank:%s, parallel.rank_local:%s" % (str(parallel.rank),
-        #                                                     str(parallel.rank_local)))
-    if queue is None or new_queue:
-        queue = cuda.Stream()
+            # print("made context %s on rank %s" % (str(context), str(parallel.rank)))
+            # print("The cuda device count on %s is:%s" % (str(parallel.rank),
+            #                                              str(cuda.Device.count())))
+            # print("parallel.rank:%s, parallel.rank_local:%s" % (str(parallel.rank),
+            #                                                     str(parallel.rank_local)))
+            if queue is None or new_queue:
+                queue = cuda.Stream()
+        else:
+            raise Exception('Could not create cuda context, rank={}, rank_local={}, device_count={}'.format(
+                parallel.rank, parallel.rank_local, cuda.Device.count()
+            ))
+    
     return context, queue
 
 

--- a/ptypy/accelerate/cuda_pycuda/__init__.py
+++ b/ptypy/accelerate/cuda_pycuda/__init__.py
@@ -25,7 +25,7 @@ def get_context(new_context=False, new_queue=False):
     if context is None or new_context:
         cuda.init()
         if parallel.rank_local >= cuda.Device.count():
-            raise Exception('Local rank cannot be larger than total device count, \
+            raise Exception('Local rank must be smaller than total device count, \
                 rank={}, rank_local={}, device_count={}'.format(
                 parallel.rank, parallel.rank_local, cuda.Device.count()
             ))

--- a/ptypy/accelerate/cuda_pycuda/__init__.py
+++ b/ptypy/accelerate/cuda_pycuda/__init__.py
@@ -24,20 +24,20 @@ def get_context(new_context=False, new_queue=False):
 
     if context is None or new_context:
         cuda.init()
-        if parallel.rank_local < cuda.Device.count():
-            context = cuda.Device(parallel.rank_local).make_context()
-            context.push()
-            # print("made context %s on rank %s" % (str(context), str(parallel.rank)))
-            # print("The cuda device count on %s is:%s" % (str(parallel.rank),
-            #                                              str(cuda.Device.count())))
-            # print("parallel.rank:%s, parallel.rank_local:%s" % (str(parallel.rank),
-            #                                                     str(parallel.rank_local)))
-            if queue is None or new_queue:
-                queue = cuda.Stream()
-        else:
-            raise Exception('Could not create cuda context, rank={}, rank_local={}, device_count={}'.format(
+        if parallel.rank_local >= cuda.Device.count():
+            raise Exception('Local rank cannot be larger than total device count, \
+                rank={}, rank_local={}, device_count={}'.format(
                 parallel.rank, parallel.rank_local, cuda.Device.count()
             ))
+        context = cuda.Device(parallel.rank_local).make_context()
+        context.push()
+        # print("made context %s on rank %s" % (str(context), str(parallel.rank)))
+        # print("The cuda device count on %s is:%s" % (str(parallel.rank),
+        #                                              str(cuda.Device.count())))
+        # print("parallel.rank:%s, parallel.rank_local:%s" % (str(parallel.rank),
+        #                                                     str(parallel.rank_local)))
+    if queue is None or new_queue:
+        queue = cuda.Stream()
     
     return context, queue
 


### PR DESCRIPTION
In case more processes are launched than GPUs, the context creation doesn't work and the cuda engines won't work anyway. So I'm proposing to raise an exception in this case.