### PR TITLE
reversing the order of the support constraints

### DIFF
--- a/ptypy/accelerate/cuda_pycuda/engines/DM_pycuda.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/DM_pycuda.py
@@ -450,14 +450,6 @@ class DM_pycuda(DM_serial.DM_serial):
             for s in self.pr.storages.values():
                 self.support_constraint(s)
 
-        # Real space
-        support = self._probe_support.get(storage.ID)
-        if support is not None:
-            if storage.ID not in self.RSK:
-                self.RSK[storage.ID] = RealSupportKernel(support.astype(np.complex64))
-                self.RSK[storage.ID].allocate()
-            self.RSK[storage.ID].apply_real_support(storage.gpu)
-
         # Fourier space
         support = self._probe_fourier_support.get(storage.ID)
         if support is not None:
@@ -466,6 +458,14 @@ class DM_pycuda(DM_serial.DM_serial):
                 self.FSK[storage.ID] = FourierSupportKernel(supp, self.queue, self.p.fft_lib)
                 self.FSK[storage.ID].allocate()
             self.FSK[storage.ID].apply_fourier_support(storage.gpu)
+
+        # Real space
+        support = self._probe_support.get(storage.ID)
+        if support is not None:
+            if storage.ID not in self.RSK:
+                self.RSK[storage.ID] = RealSupportKernel(support.astype(np.complex64))
+                self.RSK[storage.ID].allocate()
+            self.RSK[storage.ID].apply_real_support(storage.gpu)
 
     def clip_object(self, ob):
         """

--- a/ptypy/engines/base.py
+++ b/ptypy/engines/base.py
@@ -145,6 +145,14 @@ class BaseEngine(object):
             if not pod_.model.__class__ in self.SUPPORTED_MODELS:
                 raise Exception('Model %s not supported by engine' % pod_.model.__class__)
 
+        supp = self.p.probe_fourier_support
+        if supp is not None:
+            for s in self.pr.storages.values():
+                sh = s.data.shape
+                ll, xx, yy = u.grids(sh, center='fft',FFTlike=True)
+                support = (np.pi * (xx**2 + yy**2) < supp * sh[1] * sh[2])
+                self._probe_fourier_support[s.ID] = support
+
         # Calculate probe support
         # an individual support for each storage is calculated in saved
         # in the dict self.probe_support
@@ -155,14 +163,6 @@ class BaseEngine(object):
                 ll, xx, yy = u.grids(sh, FFTlike=False)
                 support = (np.pi * (xx**2 + yy**2) < supp * sh[1] * sh[2])
                 self._probe_support[s.ID] = support
-
-        supp = self.p.probe_fourier_support
-        if supp is not None:
-            for s in self.pr.storages.values():
-                sh = s.data.shape
-                ll, xx, yy = u.grids(sh, center='fft',FFTlike=True)
-                support = (np.pi * (xx**2 + yy**2) < supp * sh[1] * sh[2])
-                self._probe_fourier_support[s.ID] = support
 
         # Call engine specific preparation
         self.engine_prepare()


### PR DESCRIPTION
I believe it makes more sense to first apply the fourier probe constraint and then the real space probe contraint (if both are used). 