### PR TITLE
fix to the problem register_cmap() got an unexpected keyword argument lut

### DIFF
--- a/ptypy/utils/plot_utils.py
+++ b/ptypy/utils/plot_utils.py
@@ -413,7 +413,7 @@ franzmap_cm = {'red':   ((0.000,   0,    0),
                                                       (0.650,   0,    0),
                                                       (1.000,   0,    0))}
                                                       
-mpl.cm.register_cmap(cmap=LinearSegmentedColormap(name='franzmap', segmentdata=franzmap_cm), lut=256)
+mpl.cm.register_cmap(cmap=LinearSegmentedColormap(name='franzmap', segmentdata=franzmap_cm, N=256))
 
 def franzmap():
     """\


### PR DESCRIPTION
A small fix to the the problem register_cmap() got an unexpected keyword argument lut. Replace `lut` by `N` in link to the issue #318.