### PR TITLE
bugfix: rescale size of aux when using MPI

### DIFF
--- a/ptypy/accelerate/base/engines/DM_serial.py
+++ b/ptypy/accelerate/base/engines/DM_serial.py
@@ -166,6 +166,9 @@ class DM_serial(DM.DM):
             # TODO: make this part of the engine rather than scan
             fpc = self.ptycho.frames_per_block
 
+            # When using MPI, the nr. of frames per block is smaller
+            fpc = fpc // parallel.size
+
             # TODO : make this more foolproof
             try:
                 nmodes = scan.p.coherence.num_probe_modes * \

--- a/ptypy/accelerate/base/engines/ML_serial.py
+++ b/ptypy/accelerate/base/engines/ML_serial.py
@@ -77,6 +77,9 @@ class ML_serial(ML):
             # TODO: make this part of the engine rather than scan
             fpc = self.ptycho.frames_per_block
 
+            # When using MPI, the nr. of frames per block is smaller
+            fpc = fpc // parallel.size
+
             # TODO : make this more foolproof
             try:
                 nmodes = scan.p.coherence.num_probe_modes

--- a/ptypy/accelerate/cuda_pycuda/engines/DM_pycuda.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/DM_pycuda.py
@@ -99,6 +99,9 @@ class DM_pycuda(DM_serial.DM_serial):
             # TODO: make this part of the engine rather than scan
             fpc = self.ptycho.frames_per_block
 
+            # When using MPI, the nr. of frames per block is smaller
+            fpc = fpc // parallel.size
+
             # TODO : make this more foolproof
             try:
                 nmodes = scan.p.coherence.num_probe_modes * \
@@ -222,7 +225,7 @@ class DM_pycuda(DM_serial.DM_serial):
                 ob = self.ob.S[oID].gpu
                 pr = self.pr.S[pID].gpu
                 ex = self.ex.S[eID].gpu
-
+                
                 ## compute log-likelihood
                 if self.p.compute_log_likelihood:
                     AWK.build_aux_no_ex(aux, addr, ob, pr)

--- a/ptypy/accelerate/cuda_pycuda/engines/ML_pycuda.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/ML_pycuda.py
@@ -183,6 +183,9 @@ class ML_pycuda(ML_serial):
             # TODO: make this part of the engine rather than scan
             fpc = self.ptycho.frames_per_block
 
+            # When using MPI, the nr. of frames per block is smaller
+            fpc = fpc // parallel.size
+
             # TODO : make this more foolproof
             try:
                 nmodes = scan.p.coherence.num_probe_modes * \


### PR DESCRIPTION
With running ptypy with more than a single process, and when using the new BlockScanModel, the data loader will distribute the diffraction data from a single block across all available MPI processes. So, if `frames_per_block` is 1000 and we are using 4 MPI processes, the effective data frames in a block is 250. But in our pycuda engines, we are still allocating the `aux` arrays with the full size of 1000 and we therefore significantly over-allocate `aux`. This actually makes a big and noticable difference in performance.  