### PR TITLE
Catch initialization error for cupy.nccl

### DIFF
--- a/ptypy/accelerate/cuda_pycuda/multi_gpu.py
+++ b/ptypy/accelerate/cuda_pycuda/multi_gpu.py
@@ -158,6 +158,9 @@ def get_multi_gpu_communicator(use_nccl=True, use_cuda_mpi=True):
             return comm
         except RuntimeError:
             pass
+        except AttributeError:
+            # see issue #323
+            pass
     if have_cuda_mpi and use_cuda_mpi:
         try:
             comm = MultiGpuCommunicatorCudaMpi()


### PR DESCRIPTION
This is a quick fix for when the nccl library in cupy comes back as `_UnavailableModule`. Alternatively this could be put catched the __init__ bits of `MultiGpuCommunicatorNccl` where it raises a `RuntimeError` then.