### PR TITLE
gather_dict/bcast_dict can create issues with multinode MPI

### DIFF
--- a/ptypy/core/data.py
+++ b/ptypy/core/data.py
@@ -979,8 +979,8 @@ class PtyScan(object):
                 pos = {}
                 weights = {}
             # Distribute raw data across nodes according to indices
-            raw = parallel.bcast_dict_with_keys(raw, indices.node)
-            weights = parallel.bcast_dict_with_keys(weights, indices.node)
+            raw = parallel.bcast_dict(raw, indices.node)
+            weights = parallel.bcast_dict(weights, indices.node)
 
         # (re)distribute position information - every node should now be
         # aware of all positions

--- a/ptypy/core/data.py
+++ b/ptypy/core/data.py
@@ -979,12 +979,12 @@ class PtyScan(object):
                 pos = {}
                 weights = {}
             # Distribute raw data across nodes according to indices
-            raw = parallel.bcast_dict(raw, indices.node)
-            weights = parallel.bcast_dict(weights, indices.node)
+            raw = parallel.bcast_dict_with_keys(raw, indices.node)
+            weights = parallel.bcast_dict_with_keys(weights, indices.node)
 
         # (re)distribute position information - every node should now be
         # aware of all positions
-        parallel.bcast_dict(pos)
+        pos = parallel.bcast_dict(pos)
 
         # Prepare data across nodes
         data, weights = self.correct(raw, weights, self.common)
@@ -1419,7 +1419,7 @@ class PtydScan(PtyScan):
         parallel.barrier()
         self._ch_frame_ind = parallel.bcast(self._ch_frame_ind)
         parallel.barrier()
-        parallel.bcast_dict(self._checked)
+        self._checked = parallel.bcast_dict(self._checked)
 
         # Get the coordinates in the chunks
         coords = self._ch_frame_ind[indices]

--- a/ptypy/engines/DM.py
+++ b/ptypy/engines/DM.py
@@ -239,8 +239,7 @@ class DM(PositionCorrectionEngine):
         logger.info('Time spent in Fourier update: %.2f' % tf)
         logger.info('Time spent in Overlap update: %.2f' % to)
         logger.info('Time spent in Position update: %.2f' % tp)
-        error = parallel.gather_dict(error_dct)
-        return error
+        return error_dct
 
     def engine_finalize(self):
         """

--- a/ptypy/engines/DM_simple.py
+++ b/ptypy/engines/DM_simple.py
@@ -136,8 +136,7 @@ class DM_simple(BaseEngine):
 
         logger.info('Time spent in Fourier update: %.2f' % tf)
         logger.info('Time spent in Overlap update: %.2f' % to)
-        error = parallel.gather_dict(error_dct)
-        return error
+        return error_dct
 
     def engine_finalize(self):
         """

--- a/ptypy/engines/ePIE.py
+++ b/ptypy/engines/ePIE.py
@@ -341,8 +341,7 @@ class EPIE(BaseEngine):
         # and that Ptycho expects. In DM, that dict is overwritten on
         # every iteration, so we only gather the dicts corresponding to
         # the last iteration of each contiguous block.
-        error = parallel.gather_dict(error_dct)
-        return error
+        return error_dct
 
     def engine_finalize(self):
         """

--- a/ptypy/utils/parallel.py
+++ b/ptypy/utils/parallel.py
@@ -564,6 +564,32 @@ def gather_dict(dct, target=0):
             out.update(d)
     return out
 
+    # for r in range(size):
+    #     if r == target:
+    #         if rank == target:
+    #             #print rank,dct
+    #             out.update(dct)
+    #         continue
+
+    #     if rank == target:
+    #         l = comm.recv(source=r,tag=9999)
+    #         for i in range(l):
+    #             #k = receive(r)
+    #             k = comm.recv(source=r,tag=9999)
+    #             v = receive(r)
+    #             #print rank,str(k),v
+    #             out[k] = v
+    #     elif r == rank:
+    #         # your turn to send
+    #         l = len(dct)
+    #         comm.send(l, dest=target,tag=9999)
+    #         for k,v in dct.items():
+    #             #print rank,str(k),v
+    #             #send(k, dest=target)
+    #             comm.send(k, dest=target,tag=9999)
+    #             send(v, dest=target)
+    #     barrier()
+    # return out
 
 def _send(data, dest=0, tag=0):
     """

--- a/ptypy/utils/parallel.py
+++ b/ptypy/utils/parallel.py
@@ -558,34 +558,12 @@ def gather_dict(dct, target=0):
     if not MPIenabled:
         out.update(dct)
         return out
-
-    for r in range(size):
-        if r == target:
-            if rank == target:
-                #print rank,dct
-                out.update(dct)
-            continue
-
-        if rank == target:
-            l = comm.recv(source=r,tag=9999)
-            for i in range(l):
-                #k = receive(r)
-                k = comm.recv(source=r,tag=9999)
-                v = receive(r)
-                #print rank,str(k),v
-                out[k] = v
-        elif r == rank:
-            # your turn to send
-            l = len(dct)
-            comm.send(l, dest=target,tag=9999)
-            for k,v in dct.items():
-                #print rank,str(k),v
-                #send(k, dest=target)
-                comm.send(k, dest=target,tag=9999)
-                send(v, dest=target)
-        barrier()
-
+    ret = comm.gather(dct, root=target)
+    if rank == target:
+        for d in ret:
+            out.update(d)
     return out
+
 
 def _send(data, dest=0, tag=0):
     """


### PR DESCRIPTION
When running ptypy with multiple nodes at Diamond, I am either getting errors or extremely poor perfomance. I have identified that `parallel.gather_dict` is the cause of these issues. Replacing the current implementation of `parallel.gather_dict` with a much more simple implementation making use of `comm.gather` from mpi4py solves these issues for me. 

@bjoernenders  I would be curious to know why there is this long, quite complicated implementation in the first place?