### PR TITLE
Record new positions only if requested

### DIFF
--- a/ptypy/accelerate/base/engines/DM_serial.py
+++ b/ptypy/accelerate/base/engines/DM_serial.py
@@ -561,7 +561,7 @@ class DM_serial(DM.DM):
 
         self._reset_benchmarks()
 
-        if self.do_position_refinement:
+        if self.do_position_refinement and self.p.position_refinement.record:
             for label, d in self.di.storages.items():
                 prep = self.diff_info[d.ID]
                 res = self.kernels[prep.label].resolution
@@ -570,5 +570,6 @@ class DM_serial(DM.DM):
                         delta = (prep.addr[i][j][1][1:] - prep.original_addr[i][j][1][1:]) * res
                         pod.ob_view.coord += delta 
                         pod.ob_view.storage.update_views(pod.ob_view)
+            self.ptycho.record_positions = True
 
         super(DM_serial, self).engine_finalize()

--- a/ptypy/core/ptycho.py
+++ b/ptypy/core/ptycho.py
@@ -332,6 +332,7 @@ class Ptycho(Base):
         # Communication
         self.interactor = None
         self.plotter = None
+        self.record_positions = False
 
         # Early boot strapping
         self._configure()
@@ -918,10 +919,11 @@ class Ptycho(Base):
                 minimal.obj = {ID: S._to_dict()
                                for ID, S in self.obj.storages.items()}
 
-                minimal.positions = {}
-                for ID, S in self.obj.storages.items():
-                    minimal.obj[ID]['grids'] = S.grids()
-                    minimal.positions[ID] = np.array([v.coord for v in S.views if v.pod.pr_view.layer==0])
+                if self.record_positions:
+                    minimal.positions = {}
+                    for ID, S in self.obj.storages.items():
+                        minimal.obj[ID]['grids'] = S.grids()
+                        minimal.positions[ID] = np.array([v.coord for v in S.views if v.pod.pr_view.layer==0])
 
                 try:
                     defaults_tree['ptycho'].validate(self.p) # check the parameters are actually able to be read back in

--- a/ptypy/core/ptycho.py
+++ b/ptypy/core/ptycho.py
@@ -919,10 +919,12 @@ class Ptycho(Base):
                 minimal.obj = {ID: S._to_dict()
                                for ID, S in self.obj.storages.items()}
 
+                for ID, S in self.obj.storages.items():
+                    minimal.obj[ID]['grids'] = S.grids()
+
                 if self.record_positions:
                     minimal.positions = {}
                     for ID, S in self.obj.storages.items():
-                        minimal.obj[ID]['grids'] = S.grids()
                         minimal.positions[ID] = np.array([v.coord for v in S.views if v.pod.pr_view.layer==0])
 
                 try:

--- a/ptypy/engines/base.py
+++ b/ptypy/engines/base.py
@@ -446,6 +446,8 @@ class PositionCorrectionEngine(BaseEngine):
         """
         if self.do_position_refinement is False:
             return
+        if self.p.position_refinement.record is False:
+            return
 
         # Gather all new positions from each node
         coords = {}
@@ -460,6 +462,8 @@ class PositionCorrectionEngine(BaseEngine):
                 for v in S.views:
                     if v.pod.pr_view.layer == 0:
                         v.coord = coords[v.ID]
+
+        self.ptycho.record_positions = True
 
 
 class Base3dBraggEngine(BaseEngine):


### PR DESCRIPTION
We already have a parameter for this in the position refinement, but now we actually make the saving of the new scan positions conditional on this parameter being set to True.