### PR TITLE
Path to default sphinx layout has changed

### DIFF
--- a/doc/html_templates/ptypysphinx/layout.html
+++ b/doc/html_templates/ptypysphinx/layout.html
@@ -1,4 +1,4 @@
-{% extends "!sphinxdoc/layout.html" %}
+{% extends "!layout.html" %}
 
 {# load free fonts #}
 {% block extrahead %}


### PR DESCRIPTION
According to the Sphinx documentation on [templating](https://www.sphinx-doc.org/en/master/templating.html) we should extend from ```"!layout.html"```