### PR TITLE
Shift object and exit waves during centring probe

### DIFF
--- a/ptypy/accelerate/base/engines/projectional_serial.py
+++ b/ptypy/accelerate/base/engines/projectional_serial.py
@@ -322,6 +322,10 @@ class _ProjectionEngine_serial(_ProjectionEngine):
 
             sync = (self.curiter % 1 == 0)
             self.overlap_update(MPI=True)
+
+            # Recenter the probe
+            self.center_probe()
+
             parallel.barrier()
 
             self.position_update()
@@ -420,9 +424,6 @@ class _ProjectionEngine_serial(_ProjectionEngine):
             log(4, prestr + '----- probe update -----', True)
             change = self.probe_update(MPI=(parallel.size > 1 and MPI))
             log(4, prestr + 'change in probe is %.3f' % change, True)
-
-            # Recenter the probe
-            self.center_probe()
 
             # stop iteration if probe change is small
             if change < self.p.overlap_converge_factor: break

--- a/ptypy/accelerate/base/engines/stochastic.py
+++ b/ptypy/accelerate/base/engines/stochastic.py
@@ -154,7 +154,7 @@ class _StochasticEngineSerial(_StochasticEngine):
             prep.err_phot = np.zeros_like(prep.ma_sum)
             prep.err_fourier = np.zeros_like(prep.ma_sum)
             prep.err_exit = np.zeros_like(prep.ma_sum)
-            
+
         # Unfortunately this needs to be done for all pods, since
         # the shape of the probe / object was modified.
         # TODO: possible scaling issue, remove the need for padding
@@ -186,7 +186,7 @@ class _StochasticEngineSerial(_StochasticEngine):
         """
         Compute one iteration.
         """
-        for it in range(num):   
+        for it in range(num):
 
             error_dct = {}
 
@@ -299,11 +299,15 @@ class _StochasticEngineSerial(_StochasticEngine):
                         FUK.log_likelihood(aux, addr, mag, ma, err_phot)
                         self.benchmark.F_LLerror += time.time() - t1
 
+
                 # update errors
-                errs = np.ascontiguousarray(np.vstack([np.hstack(prep.err_fourier), 
-                                                       np.hstack(prep.err_phot), 
+                errs = np.ascontiguousarray(np.vstack([np.hstack(prep.err_fourier),
+                                                       np.hstack(prep.err_phot),
                                                        np.hstack(prep.err_exit)]).T)
                 error_dct.update(zip(prep.view_IDs, errs))
+
+            # Re-center the probe
+            self.center_probe()
 
             self.curiter += 1
 
@@ -322,7 +326,7 @@ class _StochasticEngineSerial(_StochasticEngine):
         # Update positions
         if do_update_pos:
             """
-            Iterates through all positions and refines them by a given algorithm. 
+            Iterates through all positions and refines them by a given algorithm.
             """
             #log(4, "----------- START POS REF -------------")
             pID, oID, eID = prep.poe_IDs
@@ -345,7 +349,7 @@ class _StochasticEngineSerial(_StochasticEngine):
             max_oby = ob.shape[-2] - aux.shape[-2] - 1
             max_obx = ob.shape[-1] - aux.shape[-1] - 1
 
-            # We first need to calculate the current error 
+            # We first need to calculate the current error
             PCK.build_aux(aux, addr, ob, pr)
             aux[:] = FW(aux)
             if self.p.position_refinement.metric == "fourier":
@@ -403,7 +407,7 @@ class _StochasticEngineSerial(_StochasticEngine):
                 for i,view in enumerate(d.views):
                     for j,(pname, pod) in enumerate(view.pods.items()):
                         delta = (prep.original_addr[i][j][1][1:] - prep.addr[i][j][1][1:]) * res
-                        pod.ob_view.coord += delta 
+                        pod.ob_view.coord += delta
                         pod.ob_view.storage.update_views(pod.ob_view)
 
 

--- a/ptypy/accelerate/cuda_pycuda/array_utils.py
+++ b/ptypy/accelerate/cuda_pycuda/array_utils.py
@@ -8,11 +8,11 @@ import numpy as np
 def map2ctype(dt):
     if dt == np.float32:
         return 'float'
-    elif dt == np.float64: 
+    elif dt == np.float64:
         return 'double'
-    elif dt == np.complex64: 
+    elif dt == np.complex64:
         return 'complex<float>'
-    elif dt == np.complex128: 
+    elif dt == np.complex128:
         return 'complex<double>'
     elif dt == np.int32:
         return 'int'
@@ -41,11 +41,11 @@ class ArrayUtilsKernel:
             'BDIM_X': 1024
         })
         self.Ctmp = None
-        
+
     def dot(self, A, B, out=None):
         assert A.dtype == B.dtype, "Input arrays must be of same data type"
         assert A.size == B.size, "Input arrays must be of the same size"
-        
+
         if out is None:
             out = gpuarray.zeros((1,), dtype=self.acc_dtype)
 
@@ -62,7 +62,7 @@ class ArrayUtilsKernel:
             Ctmp = out
         if np.iscomplexobj(B):
             self.cdot_cuda(A, B, np.int32(A.size), Ctmp,
-                block=block, grid=grid, 
+                block=block, grid=grid,
                 shared=1024 * elsize,
                 stream=self.queue)
         else:
@@ -71,10 +71,10 @@ class ArrayUtilsKernel:
                 shared=1024 * elsize,
                 stream=self.queue)
         if grid[0] > 1:
-            self.full_reduce_cuda(self.Ctmp, out, np.int32(grid[0]), 
+            self.full_reduce_cuda(self.Ctmp, out, np.int32(grid[0]),
                 block=(1024, 1, 1), grid=(1,1,1), shared=elsize*1024,
                 stream=self.queue)
-        
+
         return out
 
     def norm2(self, A, out=None):
@@ -97,7 +97,7 @@ class TransposeKernel:
             raise ValueError("Input/Output must be of flipped shape")
         if input.dtype != np.int32 or output.dtype != np.int32:
             raise ValueError("Only int types are supported at the moment")
-        
+
         width = input.shape[1]
         height = input.shape[0]
         blk = (16, 16, 1)
@@ -127,7 +127,7 @@ class MaxAbs2Kernel:
         version = '{},{},{}'.format(map2ctype(X.dtype), map2ctype(out.dtype), gy)
         if version not in self.max_abs2_cuda:
             step1, step2 = load_kernel(
-                    ("max_abs2_step1", "max_abs2_step2"), 
+                    ("max_abs2_step1", "max_abs2_step2"),
                     {
                         'IN_TYPE': map2ctype(X.dtype),
                         'OUT_TYPE': map2ctype(out.dtype),
@@ -144,7 +144,7 @@ class MaxAbs2Kernel:
         #     self.max_abs2_cuda[version]['scratchmem'] =
         scratch = self.max_abs2_cuda[version]['scratchmem']
 
-        
+
         self.max_abs2_cuda[version]['step1'](X, firstdims, rows, cols, scratch,
             block=(bx, 1, 1), grid=(1, gy, 1),
             stream=self.queue)
@@ -152,7 +152,7 @@ class MaxAbs2Kernel:
             block=(bx, 1, 1), grid=(1, 1, 1),
             stream=self.queue
         )
-    
+
 
 class CropPadKernel:
 
@@ -195,7 +195,7 @@ class CropPadKernel:
         ], dtype=np.int32)
         assert (lengths == lengths2).all(), "left and right lenghts are not matching"
         batch = int(np.prod(A.shape[:-3]))
-        
+
         # lazy loading depending on data type
         version = '{},{}'.format(map2ctype(B.dtype), map2ctype(A.dtype))
         if version not in self.fill3D_cuda:
@@ -205,7 +205,7 @@ class CropPadKernel:
             })
         bx = by = 32
         self.fill3D_cuda[version](
-            A, B, 
+            A, B,
             np.int32(A.shape[-3]), np.int32(A.shape[-2]), np.int32(A.shape[-1]),
             np.int32(B.shape[-3]), np.int32(B.shape[-2]), np.int32(B.shape[-1]),
             Ao[0], Ao[1], Ao[2],
@@ -255,8 +255,8 @@ class DerivativesKernel:
         self.mid_axis_block = (256, 4, 1)
 
         self.delxf_last, self.delxf_mid = load_kernel(
-            ("delx_last", "delx_mid"), 
-            file="delx.cu", 
+            ("delx_last", "delx_mid"),
+            file="delx.cu",
             subs={
                 'IS_FORWARD': 'true',
                 'BDIM_X': str(self.last_axis_block[0]),
@@ -265,8 +265,8 @@ class DerivativesKernel:
                 'OUT_TYPE': stype
             })
         self.delxb_last, self.delxb_mid  = load_kernel(
-            ("delx_last", "delx_mid"), 
-            file="delx.cu", 
+            ("delx_last", "delx_mid"),
+            file="delx.cu",
             subs={
                 'IS_FORWARD': 'false',
                 'BDIM_X': str(self.last_axis_block[0]),
@@ -274,7 +274,7 @@ class DerivativesKernel:
                 'IN_TYPE': stype,
                 'OUT_TYPE': stype
             })
-        
+
 
     def delxf(self, input, out, axis=-1):
         if input.dtype != self.dtype:
@@ -351,9 +351,9 @@ class GaussianSmoothingKernel:
         self.blockdim_x = 4
         self.blockdim_y = 16
 
-        
+
         # At least 2 blocks per SM
-        self.max_shared_per_block = 48 * 1024 // 2 
+        self.max_shared_per_block = 48 * 1024 // 2
         self.max_shared_per_block_complex = self.max_shared_per_block / 2 * np.dtype(np.float32).itemsize
         self.max_kernel_radius = int(self.max_shared_per_block_complex / self.blockdim_y)
 
@@ -378,7 +378,7 @@ class GaussianSmoothingKernel:
         self.r = 0
         self.std = 0
 
-    
+
     def convolution(self, data, mfs, tmp=None):
         """
         Calculates a stacked 2D convolution for smoothing, with the standard deviations
@@ -394,7 +394,7 @@ class GaussianSmoothingKernel:
             tmp = gpuarray.empty(shape, dtype=data.dtype)
         assert shape == tmp.shape and data.dtype == tmp.dtype
 
-        # Check input dimensions        
+        # Check input dimensions
         if ndims == 3:
             batches,y,x = shape
             stdy, stdx = mfs
@@ -429,19 +429,19 @@ class GaussianSmoothingKernel:
 
             bx = self.blockdim_x
             by = self.blockdim_y
-            
+
             shared = (bx + 2*r) * by * np.dtype(np.complex64).itemsize
             if shared > self.max_shared_per_block:
                 raise MemoryError("Cannot run kernel in shared memory")
 
             blk = (bx, by, 1)
             grd = (int((y + bx -1)// bx), int((x + by-1)// by), batches)
-            self.convolution_row(input, output, np.int32(y), np.int32(x), self.kernel_gpu, np.int32(r), 
+            self.convolution_row(input, output, np.int32(y), np.int32(x), self.kernel_gpu, np.int32(r),
                                  block=blk, grid=grd, shared=shared, stream=self.queue)
 
             input = output
             output = data
-        
+
         # Column convolution kernel
         # TODO: is this threshold acceptable in all cases?
         if stdy > 0.1:
@@ -456,20 +456,20 @@ class GaussianSmoothingKernel:
                 self.kernel_gpu[:r+1] = k[:]
                 self.r = r
                 self.std = stdy
-                
+
 
             bx = self.blockdim_y
             by = self.blockdim_x
-            
+
             shared = (by + 2*r) * bx * np.dtype(np.complex64).itemsize
             if shared > self.max_shared_per_block:
                 raise MemoryError("Cannot run kernel in shared memory")
 
             blk = (bx, by, 1)
             grd = (int((y + bx -1)// bx), int((x + by-1)// by), batches)
-            self.convolution_col(input, output, np.int32(y), np.int32(x), self.kernel_gpu, np.int32(r), 
+            self.convolution_col(input, output, np.int32(y), np.int32(x), self.kernel_gpu, np.int32(r),
                                  block=blk, grid=grd, shared=shared, stream=self.queue)
-            
+
         # TODO: is this threshold acceptable in all cases?
         if (stdx <= 0.1 and stdy <= 0.1):
             return   # nothing to do
@@ -499,3 +499,76 @@ class ClipMagnitudesKernel:
                 block=(bx, 1, 1),
                 grid=(gx, 1, 1),
                 stream=self.queue)
+
+class MassCenterKernel:
+
+    def __init__(self, queue=None):
+        self.queue = queue
+
+        self.indexed_sum_middim_cuda = load_kernel("indexed_sum_middim",
+                file="mass_center.cu", subs={
+                    'IN_TYPE': 'float',
+                    'BDIM_X' : 256,
+                    'BDIM_Y' : 1,
+                    }
+                )
+
+        self.indexed_sum_lastdim_cuda = load_kernel("indexed_sum_lastdim",
+                file="mass_center.cu", subs={
+                    'IN_TYPE': 'float',
+                    'BDIM_X' : 32,
+                    'BDIM_Y' : 32,
+                    }
+                )
+
+        self.final_sums_cuda = load_kernel("final_sums",
+                file="mass_center.cu", subs={
+                    'IN_TYPE': 'float',
+                    'BDIM_X' : 256,
+                    'BDIM_Y' : 1,
+                    }
+                )
+
+
+    def mass_center(self, array):
+        i = np.int32(array.shape[0])
+        m = np.int32(array.shape[1])
+        n = np.int32(1)
+
+        sc = 1. / gpuarray.sum(array, dtype=np.float32)
+
+        i_sum = gpuarray.zeros(i, dtype=np.float32)
+        m_sum = gpuarray.zeros(m, dtype=np.float32)
+        n_sum = gpuarray.zeros(n, dtype=np.float32)
+        out = gpuarray.empty(2, dtype=np.float32)
+
+        block_ = (256, 1, 1)
+        grid_ = (int(i), 1, 1)
+        self.indexed_sum_middim_cuda(array, i_sum, np.int32(1), i, n*m, sc,
+                block=block_,
+                grid=grid_,
+                stream=self.queue,
+                shared=256*4)
+
+        print('m sum before ', m_sum)
+        block_ = (32, 32, 1)
+        grid_ = (int(m + 32 - 1) // 32, 1)
+        self.indexed_sum_lastdim_cuda(array, m_sum, i, m, sc,
+                block=block_,
+                grid=grid_,
+                stream=self.queue,
+                shared=32*32*4)
+        print('m sum after ', m_sum)
+
+
+        block_ = (2, 1, 1)
+        grid_ = (256, 1, 1)
+        self.final_sums_cuda(i_sum, i, m_sum, m, n_sum, n, out,
+                block=block_,
+                grid=grid_,
+                stream=self.queue,
+                shared=256*4)
+
+
+        return out
+

--- a/ptypy/accelerate/cuda_pycuda/array_utils.py
+++ b/ptypy/accelerate/cuda_pycuda/array_utils.py
@@ -588,8 +588,8 @@ class MassCenterKernel:
                     stream=self.queue,
                     shared=32*32*4)
 
-        block_ = (3 if n>1 else 2, 1, 1)
-        grid_ = (256, 1, 1)
+        block_ = (256, 1, 1)
+        grid_ = (3 if n>1 else 2, 1, 1)
         self.final_sums_cuda(i_sum, i, m_sum, m, n_sum, n, out,
                 block=block_,
                 grid=grid_,

--- a/ptypy/accelerate/cuda_pycuda/cuda/abs2sum.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/abs2sum.cu
@@ -1,0 +1,29 @@
+/** abs2sum kernel, calculating the sum of abs(x)**2 value in the first dimension
+ *
+ * Data types:
+ * - IN_TYPE: can be float/double or complex<float>/complex<double>
+ * - OUT_TYPE: can be float/double
+ */
+
+#include <thrust/complex.h>
+using thrust::complex;
+
+extern "C" __global__ void abs2sum(const IN_TYPE* a,
+                                   const int n,
+                                   const int rows,
+                                   const int cols,
+                                   OUT_TYPE* out)
+{
+    int tx = threadIdx.x;
+    const int iy = blockIdx.y;
+
+    for (int ix = tx; ix < cols; ix += BDIM_X) {
+        OUT_TYPE acc = OUT_TYPE(0);
+        for (int in = 0; in < n; ++in) {
+            OUT_TYPE tmp = abs(a[in * rows * cols + iy * cols + ix]);
+            acc += tmp * tmp;
+        }
+        out[iy * cols + ix] = acc;
+    }
+}
+

--- a/ptypy/accelerate/cuda_pycuda/cuda/interpolated_shift.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/interpolated_shift.cu
@@ -249,7 +249,7 @@ extern "C" __global__ void linear_interpolate_kernel(const IN_TYPE* in,
 
   __syncthreads();
 
-  if (gx >= columns || gy >= rows)
+  if (gx >= rows || gy >= columns)
   {
     return;
   }

--- a/ptypy/accelerate/cuda_pycuda/cuda/interpolated_shift.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/interpolated_shift.cu
@@ -1,0 +1,243 @@
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <thrust/complex.h>
+using thrust::complex;
+
+__device__ inline complex<float>& ascomplex(float2& f2)
+{
+  return reinterpret_cast<complex<float>&>(f2);
+}
+
+__device__ inline void calcWeights(float* weights, float fraction)
+{
+  if (fraction < 0.0)
+  {
+    weights[2] = -fraction;
+    weights[1] = 1.0f + fraction;
+    weights[0] = 0.0f;
+  }
+  else
+  {
+    weights[2] = 0.0f;
+    weights[1] = 1.0f - fraction;
+    weights[0] = fraction;
+  }
+}
+
+extern "C" __global__ void integer_shift_kernel(const IN_TYPE* in,
+                                                OUT_TYPE* out,
+                                                int rows,
+                                                int columns,
+                                                int rowOffset,
+                                                int colOffset)
+{
+  int tx = threadIdx.x + blockIdx.x * BDIM_X;
+  int ty = threadIdx.y + blockIdx.y * BDIM_Y;
+  if (tx >= rows || ty >= columns)
+    return;
+
+  int item = blockIdx.z;
+  in += item * rows * columns;
+  out += item * rows * columns;
+
+  int gid_old = tx * columns + ty;
+  assert(gid_old < columns * rows);
+  assert(gid_old >= 0);
+
+  auto val = in[gid_old];
+
+  int gid_new_x = tx + rowOffset;
+  int gid_new_y = ty + colOffset;
+
+  // write zero on the other end
+  while (gid_new_x >= rows)
+  {
+    val = complex<float>();
+    gid_new_x -= rows;
+  }
+  while (gid_new_x < 0)
+  {
+    val = complex<float>();
+    gid_new_x += rows;
+  }
+  while (gid_new_y >= columns)
+  {
+    val = complex<float>();
+    gid_new_y -= columns;
+  }
+  while (gid_new_y < 0)
+  {
+    val = complex<float>();
+    gid_new_y += columns;
+  }
+  // do we need to do something with the corners?
+
+  int gid_new = gid_new_x * columns + gid_new_y;
+  assert(gid_new < rows * columns);
+  assert(gid_new >= 0);
+
+  out[gid_new] = val;
+}
+
+extern "C" __global__ void linear_interpolate_kernel(const IN_TYPE* in,
+                                          OUT_TYPE* out,
+                                          int rows,
+                                          int columns,
+                                          float offsetRow,
+                                          float offsetColumn)
+{
+  int offsetRowInt = int(offsetRow);
+  int offsetColInt = int(offsetColumn);
+  float offsetRowFrac = offsetRow - offsetRowInt;  // positive or negative
+  float offsetColFrac = offsetColumn - offsetColInt;
+
+  // calculate convolutional weights
+  float wx[3];
+  calcWeights(wx, offsetRowFrac);
+  float wy[3];
+  calcWeights(wy, offsetColFrac);
+
+  // indices
+  int tx = threadIdx.x;
+  int ty = threadIdx.y;
+  int bx = blockIdx.x;
+  int by = blockIdx.y;
+  int gx = tx + bx * BDIM_X;
+  int gy = ty + by * BDIM_Y;
+  int gx_old = gx - offsetRowInt;
+  int gy_old = gy - offsetColInt;
+
+  // items index is blockIdx.z
+  // we just advance the data
+  int item = blockIdx.z;
+  in += item * rows * columns;
+  out += item * rows * columns;
+
+  __shared__ float2 shr[BDIM_X + 2][BDIM_Y + 2];
+
+  // read top Halo
+  if (tx == 0)
+  {
+    if (gx_old - 1 >= 0 && gx_old - 1 < rows && gy_old >= 0 && gy_old < columns)
+    {
+      ascomplex(shr[0][ty + 1]) = in[(gx_old - 1) * columns + gy_old];
+    }
+    else
+    {
+      ascomplex(shr[0][ty + 1]) = complex<float>();
+    }
+  }
+  // read bottom Halo
+  if (tx == BDIM_X - 1)
+  {
+    if (gx_old + 1 >= 0 && gx_old + 1 < rows && gy_old >= 0 && gy_old < columns)
+    {
+      ascomplex(shr[BDIM_X + 1][ty + 1]) = in[(gx_old + 1) * columns + gy_old];
+    }
+    else
+    {
+      ascomplex(shr[BDIM_X + 1][ty + 1]) = complex<float>();
+    }
+  }
+  // read left Halo
+  if (ty == 0)
+  {
+    if (gx_old >= 0 && gx_old < rows && gy_old - 1 >= 0 && gy_old - 1 < columns)
+    {
+      ascomplex(shr[tx + 1][0]) = in[gx_old * columns + gy_old - 1];
+    }
+    else
+    {
+      ascomplex(shr[tx + 1][0]) = complex<float>();
+    }
+  }
+  // read right Halo
+  if (ty == BDIM_Y - 1)
+  {
+    if (gx_old >= 0 && gx_old < rows && gy_old + 1 >= 0 && gy_old + 1 < columns)
+    {
+      ascomplex(shr[tx + 1][BDIM_Y + 1]) = in[gx_old * columns + gy_old + 1];
+    }
+    else
+    {
+      ascomplex(shr[tx + 1][BDIM_Y + 1]) = complex<float>();
+    }
+  }
+  // read the rest
+  if (gx_old >= 0 && gx_old < rows && gy_old >= 0 && gy_old < columns)
+  {
+    ascomplex(shr[tx + 1][ty + 1]) = in[gx_old * columns + gy_old];
+  }
+  else
+  {
+    ascomplex(shr[tx + 1][ty + 1]) = complex<float>();
+  }
+
+  // now we have a block + halos in shared memory - do the interpolation
+  __syncthreads();
+
+  // interpolate rows in x
+  __shared__ float2 shry[BDIM_X][BDIM_Y + 2];
+
+  ascomplex(shry[tx][ty + 1]) = wx[0] * ascomplex(shr[tx][ty + 1]) +
+                                wx[1] * ascomplex(shr[tx + 1][ty + 1]) +
+                                wx[2] * ascomplex(shr[tx + 2][ty + 1]);
+  if (ty == 0)
+  {
+    ascomplex(shry[tx][0]) = wx[0] * ascomplex(shr[tx][0]) +
+                             wx[1] * ascomplex(shr[tx + 1][0]) +
+                             wx[2] * ascomplex(shr[tx + 2][0]);
+        //printf("tx: %d\n", tx);
+        //printf("ty: %d\n", ty);
+  }
+  if (ty == BDIM_Y - 1)
+  {
+    ascomplex(shry[tx][BDIM_Y + 1]) =
+        wx[0] * ascomplex(shr[tx][BDIM_Y + 1]) +
+        wx[1] * ascomplex(shr[tx + 1][BDIM_Y + 1]) +
+        wx[2] * ascomplex(shr[tx + 2][BDIM_Y + 1]);
+  }
+
+  __syncthreads();
+
+  if (gx >= columns || gy >= rows)
+  {
+    return;
+  }
+
+  auto intv = wy[0] * ascomplex(shry[tx][ty]) +
+              wy[1] * ascomplex(shry[tx][ty + 1]) +
+              wy[2] * ascomplex(shry[tx][ty + 2]);
+
+  // write back
+
+  // if the point lies outside of the original frame and we're shifting in
+  // that direction, it gets a zero value in any case
+  // otherwise we take the interpolated value
+  bool rightzero = offsetColFrac < 0.0f;
+  bool leftzero = offsetColFrac > 0.0f;
+  bool topzero = offsetRowFrac > 0.0f;
+  bool bottomzero = offsetRowFrac < 0.0f;
+  if ((gx_old == 0 && topzero) || (gx_old == rows - 1 && bottomzero) ||
+      (gy_old == 0 && leftzero) || (gy_old == columns - 1 && rightzero))
+  {
+    out[gx * columns + gy] = complex<float>();
+  }
+  else
+  {
+    if ((gx*columns + gy) == 32*64) {
+        printf("gx: %d\n", gx);
+        printf("gy: %d\n", gy);
+        printf("tx: %d\n", tx);
+        printf("ty: %d\n", ty);
+        printf("bx: %d\n", bx);
+        printf("by: %d\n", by);
+        printf("intv: %f\n", complex<float>::real(intv));
+    }
+
+    out[gx * columns + gy] = intv;
+  }
+}

--- a/ptypy/accelerate/cuda_pycuda/cuda/interpolated_shift.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/interpolated_shift.cu
@@ -166,6 +166,54 @@ extern "C" __global__ void linear_interpolate_kernel(const IN_TYPE* in,
       ascomplex(shr[tx + 1][BDIM_Y + 1]) = complex<float>();
     }
   }
+  // read top-left Halo
+  if ((tx == 0) && (ty == 0))
+  {
+    if (gx_old - 1 >= 0 && gx_old - 1 < rows && gy_old - 1 >= 0 && gy_old - 1 < columns)
+    {
+      ascomplex(shr[0][0]) = in[(gx_old - 1) * columns + gy_old - 1];
+    }
+    else
+    {
+      ascomplex(shr[0][0]) = complex<float>();
+    }
+  }
+  // read bottom-right Halo
+  if ((tx == BDIM_X - 1) && (ty == BDIM_Y - 1))
+  {
+    if (gx_old + 1 >= 0 && gx_old + 1 < rows && gy_old + 1 >= 0 && gy_old + 1 < columns)
+    {
+      ascomplex(shr[BDIM_X + 1][BDIM_Y + 1]) = in[(gx_old + 1) * columns + gy_old + 1];
+    }
+    else
+    {
+      ascomplex(shr[BDIM_X + 1][BDIM_Y + 1]) = complex<float>();
+    }
+  }
+  // read bottom-left Halo
+  if ((ty == 0) && (tx == BDIM_X - 1))
+  {
+    if (gx_old + 1 >= 0 && gx_old + 1 < rows && gy_old - 1 >= 0 && gy_old - 1 < columns)
+    {
+      ascomplex(shr[BDIM_X + 1][0]) = in[(gx_old + 1) * columns + gy_old - 1];
+    }
+    else
+    {
+      ascomplex(shr[BDIM_X + 1][0]) = complex<float>();
+    }
+  }
+  // read top-right Halo
+  if ((ty == BDIM_Y - 1) && (tx == 0))
+  {
+    if (gx_old - 1 >= 0 && gx_old - 1 < rows && gy_old + 1 >= 0 && gy_old + 1 < columns)
+    {
+      ascomplex(shr[0][BDIM_Y + 1]) = in[(gx_old - 1) * columns + gy_old + 1];
+    }
+    else
+    {
+      ascomplex(shr[0][BDIM_Y + 1]) = complex<float>();
+    }
+  }
   // read the rest
   if (gx_old >= 0 && gx_old < rows && gy_old >= 0 && gy_old < columns)
   {
@@ -190,8 +238,6 @@ extern "C" __global__ void linear_interpolate_kernel(const IN_TYPE* in,
     ascomplex(shry[tx][0]) = wx[0] * ascomplex(shr[tx][0]) +
                              wx[1] * ascomplex(shr[tx + 1][0]) +
                              wx[2] * ascomplex(shr[tx + 2][0]);
-        //printf("tx: %d\n", tx);
-        //printf("ty: %d\n", ty);
   }
   if (ty == BDIM_Y - 1)
   {
@@ -228,16 +274,6 @@ extern "C" __global__ void linear_interpolate_kernel(const IN_TYPE* in,
   }
   else
   {
-    if ((gx*columns + gy) == 32*64) {
-        printf("gx: %d\n", gx);
-        printf("gy: %d\n", gy);
-        printf("tx: %d\n", tx);
-        printf("ty: %d\n", ty);
-        printf("bx: %d\n", bx);
-        printf("by: %d\n", by);
-        printf("intv: %f\n", complex<float>::real(intv));
-    }
-
     out[gx * columns + gy] = intv;
   }
 }

--- a/ptypy/accelerate/cuda_pycuda/cuda/mass_center.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/mass_center.cu
@@ -1,4 +1,3 @@
-//indexed_sum_middim<threadsPerBlock><<<i, threadsPerBlock>>>(arr, i_sum, 1, i, m, sc);
 extern "C" __global__ void indexed_sum_middim(
     const IN_TYPE* data,
     IN_TYPE* sums,
@@ -136,5 +135,4 @@ extern "C" __global__ void final_sums(const IN_TYPE* sum_i,
     output[bid] = shared[0];
   }
 }
-
 

--- a/ptypy/accelerate/cuda_pycuda/cuda/mass_center.cu
+++ b/ptypy/accelerate/cuda_pycuda/cuda/mass_center.cu
@@ -1,0 +1,140 @@
+//indexed_sum_middim<threadsPerBlock><<<i, threadsPerBlock>>>(arr, i_sum, 1, i, m, sc);
+extern "C" __global__ void indexed_sum_middim(
+    const IN_TYPE* data,
+    IN_TYPE* sums,
+    int i,
+    int m,  // dim we work on - 1 block per output
+    int n,
+    float scale)
+{
+  int bid = blockIdx.x;
+  int tid = threadIdx.x;
+
+  data += bid * n;
+
+  auto val = 0.0f;
+  for (int x = 0; x < i; ++x)
+  {
+    auto d_inner = data + x * n * m;
+    for (int z = tid; z < n; z += BDIM_X)
+    {
+      val += d_inner[z];
+    }
+  }
+
+  __shared__ float sumshr[BDIM_X];
+  sumshr[tid] = val;
+
+  __syncthreads();
+  int c = BDIM_X;
+  while (c > 1)
+  {
+    int half = c / 2;
+    if (tid < half)
+    {
+      sumshr[tid] += sumshr[c - tid - 1];
+    }
+    __syncthreads();
+    c = c - half;
+  }
+
+  if (tid == 0)
+  {
+    sums[bid] = sumshr[0] * float(bid) * scale;
+  }
+}
+
+
+extern "C" __global__ void indexed_sum_lastdim(
+    const IN_TYPE* data, IN_TYPE* sums, int n, int i, float scale)
+{
+  int ty = threadIdx.y + blockIdx.y * BDIM_Y;
+  int tx = threadIdx.x;
+
+  auto val = 0.0f;
+  if (ty < i)
+  {
+    data += ty;  // column to work on
+
+    // we collaborate along the x axis (columns) to get more threads in case i
+    // is small
+    for (int r = tx; r < n; r += BDIM_X)
+    {
+      val += data[r * i];
+    }
+  }
+
+  // reduce along X dimension in shared memory (column sum)
+  __shared__ float blocksums[BDIM_X][BDIM_Y];
+  blocksums[tx][threadIdx.y] = val;
+
+  __syncthreads();
+  int nt = blockDim.x;
+  int c = nt;
+  while (c > 1)
+  {
+    int half = c / 2;
+    if (tx < half)
+    {
+      blocksums[tx][threadIdx.y] += blocksums[c - tx - 1][threadIdx.y];
+    }
+    __syncthreads();
+    c = c - half;
+  }
+
+  if (ty >= i)
+  {
+    return;
+  }
+
+  if (tx == 0)
+  {
+    sums[ty] = blocksums[0][threadIdx.y] * float(ty) * scale;
+  }
+}
+
+
+extern "C" __global__ void final_sums(const IN_TYPE* sum_i,
+                           int i,
+                           const IN_TYPE* sum_m,
+                           int m,
+                           const IN_TYPE* sum_n,
+                           int n,
+                           IN_TYPE* output)
+{
+  int bid = blockIdx.x;
+  int tid = threadIdx.x;
+  // each block works on a single dimension
+  int nn = bid == 0 ? i : (bid == 1 ? m : n);
+  const float* data = bid == 0 ? sum_i : (bid == 1 ? sum_m : sum_n);
+
+  __shared__ float shared[BDIM_X];
+  auto val = 0.0f;
+  for (int i = tid; i < nn; i += blockDim.x)
+  {
+    val += data[i];
+  }
+  shared[tid] = val;
+
+  // now add up sumbuffer in shared memory
+  __syncthreads();
+  int nt = blockDim.x;
+  int c = nt;
+  while (c > 1)
+  {
+    int half = c / 2;
+    if (tid < half)
+    {
+      shared[tid] += shared[c - tid - 1];
+    }
+    __syncthreads();
+    c = c - half;
+  }
+
+  if (tid == 0)
+  {
+    output[bid] = shared[0];
+  }
+}
+
+

--- a/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda.py
@@ -268,6 +268,8 @@ class _ProjectionEngine_pycuda(projectional_serial._ProjectionEngine_serial):
             sync = (self.curiter % 1 == 0)
             self.overlap_update()
 
+            self.center_probe()
+
             parallel.barrier()
             self.position_update()
 

--- a/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda.py
@@ -22,7 +22,9 @@ from ptypy.accelerate.base.engines import projectional_serial
 from .. import get_context
 from ..kernels import FourierUpdateKernel, AuxiliaryWaveKernel, PoUpdateKernel, PositionCorrectionKernel
 from ..kernels import PropagationKernel, RealSupportKernel, FourierSupportKernel
-from ..array_utils import ArrayUtilsKernel, GaussianSmoothingKernel, TransposeKernel, ClipMagnitudesKernel
+from ..array_utils import ArrayUtilsKernel, GaussianSmoothingKernel,\
+TransposeKernel, ClipMagnitudesKernel, MassCenterKernel, Abs2SumKernel,\
+InterpolatedShiftKernel
 from ..mem_utils import make_pagelocked_paired_arrays as mppa
 from ..multi_gpu import get_multi_gpu_communicator
 
@@ -80,6 +82,15 @@ class _ProjectionEngine_pycuda(projectional_serial._ProjectionEngine_serial):
 
         # Clip Magnitudes Kernel
         self.CMK = ClipMagnitudesKernel(queue=self.queue)
+
+        # initialise kernels for centring probe if required
+        if self.p.probe_center_tol is not None:
+            # mass center kernel
+            self.MCK = MassCenterKernel(queue=self.queue)
+            # absolute sum kernel
+            self.A2SK = Abs2SumKernel(dtype=self.pr.dtype, queue=self.queue)
+            # interpolated shift kernel
+            self.ISK = InterpolatedShiftKernel(queue=self.queue)
 
         super().engine_initialize()
 
@@ -224,7 +235,7 @@ class _ProjectionEngine_pycuda(projectional_serial._ProjectionEngine_serial):
                 ob = self.ob.S[oID].gpu
                 pr = self.pr.S[pID].gpu
                 ex = self.ex.S[eID].gpu
-                
+
                 ## compute log-likelihood
                 if self.p.compute_log_likelihood:
                     AWK.build_aux_no_ex(aux, addr, ob, pr)
@@ -282,7 +293,7 @@ class _ProjectionEngine_pycuda(projectional_serial._ProjectionEngine_serial):
         return error
 
     def position_update(self):
-        """ 
+        """
         Position refinement
         """
         if not self.do_position_refinement or (not self.curiter):
@@ -322,7 +333,7 @@ class _ProjectionEngine_pycuda(projectional_serial._ProjectionEngine_serial):
                 max_oby = ob.shape[-2] - aux.shape[-2] - 1
                 max_obx = ob.shape[-1] - aux.shape[-1] - 1
 
-                # We need to re-calculate the current error 
+                # We need to re-calculate the current error
                 PCK.build_aux(aux, addr, ob, pr)
                 PROP.fw(aux, aux)
                 if self.p.position_refinement.metric == "fourier":
@@ -335,7 +346,7 @@ class _ProjectionEngine_pycuda(projectional_serial._ProjectionEngine_serial):
                                     size=err_fourier.nbytes)
 
                 PCK.mangler.setup_shifts(self.curiter, nframes=addr.shape[0])
-                                
+
                 log(4, 'Position refinement trial: iteration %s' % (self.curiter))
                 for i in range(PCK.mangler.nshifts):
                     PCK.mangler.get_address(i, addr, mangled_addr, max_oby, max_obx)
@@ -347,7 +358,7 @@ class _ProjectionEngine_pycuda(projectional_serial._ProjectionEngine_serial):
                     if self.p.position_refinement.metric == "photon":
                         PCK.log_likelihood(aux, mangled_addr, mag, ma, err_fourier)
                     PCK.update_addr_and_error_state(addr, error_state, mangled_addr, err_fourier)
-                
+
                 cuda.memcpy_dtod(dest=err_fourier.ptr,
                                     src=error_state.ptr,
                                     size=err_fourier.nbytes)
@@ -355,6 +366,33 @@ class _ProjectionEngine_pycuda(projectional_serial._ProjectionEngine_serial):
                     s1 = addr.shape[0] * addr.shape[1]
                     s2 = addr.shape[2] * addr.shape[3]
                     TK.transpose(addr.reshape(s1, s2), prep.addr2_gpu.reshape(s2, s1))
+
+
+    def center_probe(self):
+        if self.p.probe_center_tol is not None:
+            for name, pr_s in self.pr.storages.items():
+                psum_d = self.A2SK.abs2sum(pr_s.gpu)
+                c1 = self.MCK.mass_center(psum_d).get()
+                c2 = (np.asarray(pr_s.shape[-2:]) // 2).astype(c1.dtype)
+
+                shift = c2 - c1
+                # exit if the current center of mass is within the tolerance
+                if u.norm(shift) < self.p.probe_center_tol:
+                    break
+
+                # shift the probe
+                pr_s.gpu = self.ISK.interpolate_shift(pr_s.gpu, shift)
+
+                # shift the object
+                ob_s = self.ob.storages[name]
+                ob_s.gpu = self.ISK.interpolate_shift(ob_s.gpu, shift)
+
+                # shift the exit waves
+                for ex_s in self.ex.storages.values():
+                    ex_s.gpu = self.ISK.interpolate_shift(ex_s.gpu, shift)
+
+                log(4,'Probe recentered from %s to %s'
+                            % (str(tuple(c1)), str(tuple(c2))))
 
 
     ## object update
@@ -509,7 +547,7 @@ class _ProjectionEngine_pycuda(projectional_serial._ProjectionEngine_serial):
         for dID, prep in self.diff_info.items():
             prep.addr = prep.addr_gpu.get()
 
-        # copy data to cpu 
+        # copy data to cpu
         # this kills the pagelock memory (otherwise we get segfaults in h5py)
         for name, s in self.pr.S.items():
             s.data = np.copy(s.data)

--- a/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda.py
@@ -384,12 +384,16 @@ class _ProjectionEngine_pycuda(projectional_serial._ProjectionEngine_serial):
                 pr_s.gpu = self.ISK.interpolate_shift(pr_s.gpu, shift)
 
                 # shift the object
-                ob_s = self.ob.storages[name]
+                ob_s = pr_s.views[0].pod.ob_view.storage
                 ob_s.gpu = self.ISK.interpolate_shift(ob_s.gpu, shift)
 
                 # shift the exit waves
-                for ex_s in self.ex.storages.values():
-                    ex_s.gpu = self.ISK.interpolate_shift(ex_s.gpu, shift)
+                for dID in self.di.S.keys():
+                    prep = self.diff_info[dID]
+                    pID, oID, eID = prep.poe_IDs
+                    if pID == name:
+                        self.ex.S[eID].gpu = self.ISK.interpolate_shift(
+                                self.ex.S[eID].gpu, shift)
 
                 log(4,'Probe recentered from %s to %s'
                             % (str(tuple(c1)), str(tuple(c2))))

--- a/ptypy/accelerate/cuda_pycuda/engines/stochastic.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/stochastic.py
@@ -21,8 +21,11 @@ from ptypy.engines.stochastic import EPIEMixin, SDRMixin
 from ptypy.accelerate.base.engines.stochastic import _StochasticEngineSerial
 from ptypy.accelerate.base import address_manglers
 from .. import get_context
-from ..kernels import FourierUpdateKernel, AuxiliaryWaveKernel, PoUpdateKernel, PositionCorrectionKernel, PropagationKernel
-from ..array_utils import ArrayUtilsKernel, GaussianSmoothingKernel, TransposeKernel, MaxAbs2Kernel
+from ..kernels import FourierUpdateKernel, AuxiliaryWaveKernel, PoUpdateKernel,\
+        PositionCorrectionKernel, PropagationKernel
+from ..array_utils import ArrayUtilsKernel, GaussianSmoothingKernel,\
+        TransposeKernel, MaxAbs2Kernel, MassCenterKernel, Abs2SumKernel,\
+        InterpolatedShiftKernel
 from ..mem_utils import make_pagelocked_paired_arrays as mppa
 from ..mem_utils import GpuDataManager2
 
@@ -60,12 +63,22 @@ class _StochasticEnginePycuda(_StochasticEngineSerial):
         self.ma_data = None
         self.mag_data = None
         self.ex_data = None
-    
+
     def engine_initialize(self):
         """
         Prepare for reconstruction.
         """
         self.context, self.queue = get_context(new_context=True, new_queue=True)
+
+        # initialise kernels for centring probe if required
+        if self.p.probe_center_tol is not None:
+            # mass center kernel
+            self.MCK = MassCenterKernel(queue=self.queue)
+            # absolute sum kernel
+            self.A2SK = Abs2SumKernel(dtype=self.pr.dtype, queue=self.queue)
+            # interpolated shift kernel
+            self.ISK = InterpolatedShiftKernel(queue=self.queue)
+
         super().engine_initialize()
         self.qu_htod = cuda.Stream()
         self.qu_dtoh = cuda.Stream()
@@ -131,7 +144,7 @@ class _StochasticEnginePycuda(_StochasticEngineSerial):
                 log(4, "Setting up position correction")
                 kern.PCK = PositionCorrectionKernel(aux, nmodes, self.p.position_refinement, geo.resolution, queue_thread=self.queue)
                 kern.PCK.allocate()
-        
+
         ex_mem = 0
         mag_mem = 0
         fpc = self.ptycho.frames_per_block
@@ -208,7 +221,7 @@ class _StochasticEnginePycuda(_StochasticEngineSerial):
         self.dID_list = list(self.di.S.keys())
         error = {}
         for it in range(num):
-            
+
             for iblock, dID in enumerate(self.dID_list):
 
                 # find probe, object and exit ID in dependence of dID
@@ -222,7 +235,7 @@ class _StochasticEnginePycuda(_StochasticEngineSerial):
                 POK = kern.POK
                 MAK = kern.MAK
                 PROP = kern.PROP
-                
+
                 # get aux buffer
                 aux = kern.aux
 
@@ -321,6 +334,9 @@ class _StochasticEnginePycuda(_StochasticEngineSerial):
             # swap direction
             self.dID_list.reverse()
 
+            # Re-center probe
+            self.center_probe()
+
             self.curiter += 1
             self.ex_data.syncback = False
 
@@ -369,7 +385,7 @@ class _StochasticEnginePycuda(_StochasticEngineSerial):
             mangled_addr = prep.mangled_addr_gpu[i,None]
             err_fourier = prep.err_fourier_gpu[i,None]
             error_state = prep.error_state_gpu[i,None]
-            
+
             PCK = kern.PCK
             PROP = kern.PROP
 
@@ -377,12 +393,12 @@ class _StochasticEnginePycuda(_StochasticEngineSerial):
             max_oby = ob.shape[-2] - aux.shape[-2] - 1
             max_obx = ob.shape[-1] - aux.shape[-1] - 1
 
-            # We need to re-calculate the current error 
+            # We need to re-calculate the current error
             PCK.build_aux(aux, addr, ob, pr)
             PROP.fw(aux, aux)
             #self.queue.wait_for_event(ev_mag)
             #self.queue.wait_for_event(ev_ma)
-            
+
             if self.p.position_refinement.metric == "fourier":
                 PCK.fourier_error(aux, addr, mag, ma, ma_sum)
                 PCK.error_reduce(addr, err_fourier)
@@ -393,7 +409,7 @@ class _StochasticEnginePycuda(_StochasticEngineSerial):
                                     size=err_fourier.nbytes, stream=self.queue)
 
             PCK.mangler.setup_shifts(self.curiter, nframes=addr.shape[0])
-                            
+
             #log(4, 'Position refinement trial: iteration %s' % (self.curiter))
             for i in range(PCK.mangler.nshifts):
                 PCK.mangler.get_address(i, addr, mangled_addr, max_oby, max_obx)
@@ -405,10 +421,42 @@ class _StochasticEnginePycuda(_StochasticEngineSerial):
                 if self.p.position_refinement.metric == "photon":
                     PCK.log_likelihood(aux, mangled_addr, mag, ma, err_fourier)
                 PCK.update_addr_and_error_state(addr, error_state, mangled_addr, err_fourier)
-            
+
             cuda.memcpy_dtod_async(dest=err_fourier.ptr,
                                     src=error_state.ptr,
                                     size=err_fourier.nbytes, stream=self.queue)
+
+
+    def center_probe(self):
+        if self.p.probe_center_tol is not None:
+            for name, pr_s in self.pr.storages.items():
+                psum_d = self.A2SK.abs2sum(pr_s.gpu)
+                c1 = self.MCK.mass_center(psum_d).get()
+                c2 = (np.asarray(pr_s.shape[-2:]) // 2).astype(c1.dtype)
+
+                shift = c2 - c1
+                # exit if the current center of mass is within the tolerance
+                if u.norm(shift) < self.p.probe_center_tol:
+                    break
+
+                # shift the probe
+                pr_s.gpu = self.ISK.interpolate_shift(pr_s.gpu, shift)
+
+                # shift the object
+                ob_s = pr_s.views[0].pod.ob_view.storage
+                ob_s.gpu = self.ISK.interpolate_shift(ob_s.gpu, shift)
+
+                # shift the exit waves
+                for dID in self.di.S.keys():
+                    prep = self.diff_info[dID]
+                    pID, oID, eID = prep.poe_IDs
+                    if pID == name:
+                        prep.ex_full = self.ISK.interpolate_shift(prep.ex_full,
+                                shift)
+
+                log(4,'Probe recentered from %s to %s'
+                            % (str(tuple(c1)), str(tuple(c2))))
+
 
     def engine_finalize(self):
         """
@@ -425,7 +473,7 @@ class _StochasticEnginePycuda(_StochasticEngineSerial):
         for dID, prep in self.diff_info.items():
             prep.addr = prep.addr_gpu.get()
 
-        # copy data to cpu 
+        # copy data to cpu
         # this kills the pagelock memory (otherwise we get segfaults in h5py)
         for name, s in self.pr.S.items():
             s.data = np.copy(s.data)

--- a/ptypy/custom/ePIE_parallel.py
+++ b/ptypy/custom/ePIE_parallel.py
@@ -481,10 +481,10 @@ class EPIEParallel(BaseEngine):
                 ob_s.data[:] = u.shift_zoom(ob_s.data, (1.,)*3,
                         (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
-                # shift the exit waves
-                for ex_s in self.ex.storages.values():
-                    ex_s.data[:] = u.shift_zoom(ex_s.data, (1.,)*3,
-                            (0, c1[0], c1[1]), (0, c2[0], c2[1]))
+                # shift the exit waves, loop through different exit wave views
+                for pv in pr_s.views:
+                    pv.pod.exit = u.shift_zoom(pv.pod.exit, (1.,)*2,
+                            (c1[0], c1[1]), (c2[0], c2[1]))
 
                 logger.info('Probe recentered from %s to %s' %
                             (str(tuple(c1)), str(tuple(c2))))

--- a/ptypy/custom/ePIE_parallel.py
+++ b/ptypy/custom/ePIE_parallel.py
@@ -143,7 +143,7 @@ class EPIEParallel(BaseEngine):
         # Instance attributes
         self.ob_nodecover = None
         self.mean_power = None
-        
+
         self.ptycho.citations.add_article(
             title='An improved ptychographical phase retrieval algorithm for diffractive imaging',
             author='Maiden A. and Rodenburg J.',
@@ -190,7 +190,7 @@ class EPIEParallel(BaseEngine):
             mean_power += s.mean_power
         self.mean_power = mean_power / len(self.di.storages)
 
-        
+
         # DEBUGGING: show the actual domain decomposition
         # if self.curiter == 0:
         #     import matplotlib.pyplot as plt
@@ -263,7 +263,7 @@ class EPIEParallel(BaseEngine):
                 # scale probe such that its mean power equals the mean power of the diffraction data
                 # This stabilizes the ePIE algorithm and prevents the probe from growing too large.
                 pod.probe *= np.sqrt(self.mean_power / u.abs2(pod.probe).mean())
-                
+
                 # Object update:
                 logger.debug(pre_str + '----- ePIE object update -----')
                 pod.object += (self.p.alpha
@@ -466,14 +466,25 @@ class EPIEParallel(BaseEngine):
         Stolen in its entirety from the DM engine.
         """
         if self.p.probe_center_tol is not None:
-            for name, s in self.pr.S.items():
-                c1 = u.mass_center(u.abs2(s.data).sum(0))
+            for name, pr_s in self.pr.storages.items():
+                c1 = u.mass_center(u.abs2(pr_s.data).sum(0))
+                c2 = np.asarray(pr_s.shape[-2:]) // 2
                 # fft convention should however use geometry instead
-                c2 = np.asarray(s.shape[-2:]) // 2
                 if u.norm(c1 - c2) < self.p.probe_center_tol:
                     break
                 # SC: possible BUG here, wrong input parameter
-                s.data[:] = u.shift_zoom(
-                    s.data, (1.,) * 3, (0, c1[0], c1[1]), (0, c2[0], c2[1]))
+                pr_s.data[:] = u.shift_zoom(pr_s.data, (1.,)*3,
+                        (0, c1[0], c1[1]), (0, c2[0], c2[1]))
+
+                # shift the object
+                ob_s = self.ob.storages[name]
+                ob_s.data[:] = u.shift_zoom(ob_s.data, (1.,)*3,
+                        (0, c1[0], c1[1]), (0, c2[0], c2[1]))
+
+                # shift the exit waves
+                ex_s = pr_s.views[0].pod.ex_view.storage
+                ex_s.data[:] = u.shift_zoom(ex_s.data, (1.,)*3,
+                        (0, c1[0], c1[1]), (0, c2[0], c2[1]))
+
                 logger.info('Probe recentered from %s to %s' %
                             (str(tuple(c1)), str(tuple(c2))))

--- a/ptypy/custom/ePIE_parallel.py
+++ b/ptypy/custom/ePIE_parallel.py
@@ -477,7 +477,7 @@ class EPIEParallel(BaseEngine):
                         (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
                 # shift the object
-                ob_s = self.ob.storages[name]
+                ob_s = pr_s.views[0].pod.ob_view.storage
                 ob_s.data[:] = u.shift_zoom(ob_s.data, (1.,)*3,
                         (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 

--- a/ptypy/custom/ePIE_parallel.py
+++ b/ptypy/custom/ePIE_parallel.py
@@ -481,10 +481,10 @@ class EPIEParallel(BaseEngine):
                 ob_s.data[:] = u.shift_zoom(ob_s.data, (1.,)*3,
                         (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
-                # shift the exit waves, loop through different exit wave views
-                for pv in pr_s.views:
-                    pv.pod.exit = u.shift_zoom(pv.pod.exit, (1.,)*2,
-                            (c1[0], c1[1]), (c2[0], c2[1]))
+                # shift the exit waves
+                for ex_s in self.ex.storages.values():
+                    ex_s.data[:] = u.shift_zoom(ex_s.data, (1.,)*3,
+                            (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
                 logger.info('Probe recentered from %s to %s' %
                             (str(tuple(c1)), str(tuple(c2))))

--- a/ptypy/custom/ePIE_parallel.py
+++ b/ptypy/custom/ePIE_parallel.py
@@ -482,9 +482,9 @@ class EPIEParallel(BaseEngine):
                         (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
                 # shift the exit waves, loop through different exit wave views
-                for k, pv in enumerate(pr_s.views):
-                    pr_s.views[k].pod.exit[:]  = u.shift_zoom(pv.pod.exit,
-                            (1.,)*2, (c1[0], c1[1]), (c2[0], c2[1]))
+                for pv in pr_s.views:
+                    pv.pod.exit = u.shift_zoom(pv.pod.exit, (1.,)*2,
+                            (c1[0], c1[1]), (c2[0], c2[1]))
 
                 logger.info('Probe recentered from %s to %s' %
                             (str(tuple(c1)), str(tuple(c2))))

--- a/ptypy/custom/ePIE_parallel.py
+++ b/ptypy/custom/ePIE_parallel.py
@@ -481,10 +481,10 @@ class EPIEParallel(BaseEngine):
                 ob_s.data[:] = u.shift_zoom(ob_s.data, (1.,)*3,
                         (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
-                # shift the exit waves
-                ex_s = pr_s.views[0].pod.ex_view.storage
-                ex_s.data[:] = u.shift_zoom(ex_s.data, (1.,)*3,
-                        (0, c1[0], c1[1]), (0, c2[0], c2[1]))
+                # shift the exit waves, loop through different exit wave views
+                for k, pv in enumerate(pr_s.views):
+                    pr_s.views[k].pod.exit[:]  = u.shift_zoom(pv.pod.exit,
+                            (1.,)*2, (c1[0], c1[1]), (c2[0], c2[1]))
 
                 logger.info('Probe recentered from %s to %s' %
                             (str(tuple(c1)), str(tuple(c2))))

--- a/ptypy/engines/projectional.py
+++ b/ptypy/engines/projectional.py
@@ -330,9 +330,9 @@ class _ProjectionEngine(PositionCorrectionEngine):
                         (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
                 # shift the exit waves, loop through different exit wave views
-                for k, pv in enumerate(pr_s.views):
-                    pr_s.views[k].pod.exit[:]  = u.shift_zoom(pv.pod.exit,
-                            (1.,)*2, (c1[0], c1[1]), (c2[0], c2[1]))
+                for pv in pr_s.views:
+                    pv.pod.exit = u.shift_zoom(pv.pod.exit, (1.,)*2,
+                            (c1[0], c1[1]), (c2[0], c2[1]))
 
                 log(4,'Probe recentered from %s to %s'
                             % (str(tuple(c1)), str(tuple(c2))))

--- a/ptypy/engines/projectional.py
+++ b/ptypy/engines/projectional.py
@@ -201,6 +201,9 @@ class _ProjectionEngine(PositionCorrectionEngine):
             # Overlap update
             self.overlap_update()
 
+            # Recenter the probe
+            self.center_probe()
+
             t3 = time.time()
             to += t3 - t2
 
@@ -304,9 +307,6 @@ class _ProjectionEngine(PositionCorrectionEngine):
             log(4, pre_str + '----- probe update -----')
             change = self.probe_update()
             log(4, pre_str + 'change in probe is %.3f' % change)
-
-            # Recenter the probe
-            self.center_probe()
 
             # Stop iteration if probe change is small
             if change < self.p.overlap_converge_factor:

--- a/ptypy/engines/projectional.py
+++ b/ptypy/engines/projectional.py
@@ -329,10 +329,10 @@ class _ProjectionEngine(PositionCorrectionEngine):
                 ob_s.data[:] = u.shift_zoom(ob_s.data, (1.,)*3,
                         (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
-                # shift the exit waves, loop through different exit wave views
-                for pv in pr_s.views:
-                    pv.pod.exit = u.shift_zoom(pv.pod.exit, (1.,)*2,
-                            (c1[0], c1[1]), (c2[0], c2[1]))
+                # shift the exit waves
+                for ex_s in self.ex.storages.values():
+                    ex_s.data[:] = u.shift_zoom(ex_s.data, (1.,)*3,
+                            (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
                 log(4,'Probe recentered from %s to %s'
                             % (str(tuple(c1)), str(tuple(c2))))

--- a/ptypy/engines/projectional.py
+++ b/ptypy/engines/projectional.py
@@ -104,7 +104,7 @@ class _ProjectionEngine(PositionCorrectionEngine):
     [compute_log_likelihood]
     default = True
     type = bool
-    help = A switch for computing the log-likelihood error (this can impact the performance of the engine) 
+    help = A switch for computing the log-likelihood error (this can impact the performance of the engine)
 
     """
 
@@ -314,17 +314,25 @@ class _ProjectionEngine(PositionCorrectionEngine):
 
     def center_probe(self):
         if self.p.probe_center_tol is not None:
-            for name, s in self.pr.storages.items():
-                c1 = u.mass_center(u.abs2(s.data).sum(0))
-                c2 = np.asarray(s.shape[-2:]) // 2
+            for name, pr_s in self.pr.storages.items():
+                c1 = u.mass_center(u.abs2(pr_s.data).sum(0))
+                c2 = np.asarray(pr_s.shape[-2:]) // 2
                 # fft convention should however use geometry instead
                 if u.norm(c1 - c2) < self.p.probe_center_tol:
                     break
                 # SC: possible BUG here, wrong input parameter
-                s.data[:] = u.shift_zoom(s.data,
-                                         (1.,) * 3,
-                                         (0, c1[0], c1[1]),
-                                         (0, c2[0], c2[1]))
+                pr_s.data[:] = u.shift_zoom(pr_s.data, (1.,)*3,
+                        (0, c1[0], c1[1]), (0, c2[0], c2[1]))
+
+                # shift the object
+                ob_s = self.ob.storages[name]
+                ob_s.data[:] = u.shift_zoom(ob_s.data, (1.,)*3,
+                        (0, c1[0], c1[1]), (0, c2[0], c2[1]))
+
+                # shift the exit waves
+                ex_s = pr_s.views[0].pod.ex_view.storage
+                ex_s.data[:] = u.shift_zoom(ex_s.data, (1.,)*3,
+                        (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
                 log(4,'Probe recentered from %s to %s'
                             % (str(tuple(c1)), str(tuple(c2))))

--- a/ptypy/engines/projectional.py
+++ b/ptypy/engines/projectional.py
@@ -329,10 +329,10 @@ class _ProjectionEngine(PositionCorrectionEngine):
                 ob_s.data[:] = u.shift_zoom(ob_s.data, (1.,)*3,
                         (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
-                # shift the exit waves
-                ex_s = pr_s.views[0].pod.ex_view.storage
-                ex_s.data[:] = u.shift_zoom(ex_s.data, (1.,)*3,
-                        (0, c1[0], c1[1]), (0, c2[0], c2[1]))
+                # shift the exit waves, loop through different exit wave views
+                for k, pv in enumerate(pr_s.views):
+                    pr_s.views[k].pod.exit[:]  = u.shift_zoom(pv.pod.exit,
+                            (1.,)*2, (c1[0], c1[1]), (c2[0], c2[1]))
 
                 log(4,'Probe recentered from %s to %s'
                             % (str(tuple(c1)), str(tuple(c2))))

--- a/ptypy/engines/projectional.py
+++ b/ptypy/engines/projectional.py
@@ -325,7 +325,7 @@ class _ProjectionEngine(PositionCorrectionEngine):
                         (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
                 # shift the object
-                ob_s = self.ob.storages[name]
+                ob_s = pr_s.views[0].pod.ob_view.storage
                 ob_s.data[:] = u.shift_zoom(ob_s.data, (1.,)*3,
                         (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 

--- a/ptypy/engines/projectional.py
+++ b/ptypy/engines/projectional.py
@@ -329,10 +329,10 @@ class _ProjectionEngine(PositionCorrectionEngine):
                 ob_s.data[:] = u.shift_zoom(ob_s.data, (1.,)*3,
                         (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
-                # shift the exit waves
-                for ex_s in self.ex.storages.values():
-                    ex_s.data[:] = u.shift_zoom(ex_s.data, (1.,)*3,
-                            (0, c1[0], c1[1]), (0, c2[0], c2[1]))
+                # shift the exit waves, loop through different exit wave views
+                for pv in pr_s.views:
+                    pv.pod.exit = u.shift_zoom(pv.pod.exit, (1.,)*2,
+                            (c1[0], c1[1]), (c2[0], c2[1]))
 
                 log(4,'Probe recentered from %s to %s'
                             % (str(tuple(c1)), str(tuple(c2))))

--- a/ptypy/engines/stochastic.py
+++ b/ptypy/engines/stochastic.py
@@ -210,10 +210,10 @@ class _StochasticEngine(PositionCorrectionEngine):
                 ob_s.data[:] = u.shift_zoom(ob_s.data, (1.,)*3,
                         (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
-                # shift the exit waves
-                for ex_s in self.ex.storages.values():
-                    ex_s.data[:] = u.shift_zoom(ex_s.data, (1.,)*3,
-                            (0, c1[0], c1[1]), (0, c2[0], c2[1]))
+                # shift the exit waves, loop through different exit wave views
+                for pv in pr_s.views:
+                    pv.pod.exit = u.shift_zoom(pv.pod.exit, (1.,)*2,
+                            (c1[0], c1[1]), (c2[0], c2[1]))
 
                 log(4,'Probe recentered from %s to %s'
                             % (str(tuple(c1)), str(tuple(c2))))

--- a/ptypy/engines/stochastic.py
+++ b/ptypy/engines/stochastic.py
@@ -117,8 +117,8 @@ class _StochasticEngine(PositionCorrectionEngine):
                 # Probe update
                 self.probe_update(view, exit_wave)
 
-                # Recenter the probe
-                self.center_probe()
+            # Recenter the probe
+            self.center_probe()
 
             self.curiter += 1
 
@@ -206,7 +206,7 @@ class _StochasticEngine(PositionCorrectionEngine):
                         (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
                 # shift the object
-                ob_s = self.ob.storages[name]
+                ob_s = pr_s.views[0].pod.ob_view.storage
                 ob_s.data[:] = u.shift_zoom(ob_s.data, (1.,)*3,
                         (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 

--- a/ptypy/engines/stochastic.py
+++ b/ptypy/engines/stochastic.py
@@ -210,10 +210,10 @@ class _StochasticEngine(PositionCorrectionEngine):
                 ob_s.data[:] = u.shift_zoom(ob_s.data, (1.,)*3,
                         (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
-                # shift the exit waves, loop through different exit wave views
-                for pv in pr_s.views:
-                    pv.pod.exit = u.shift_zoom(pv.pod.exit, (1.,)*2,
-                            (c1[0], c1[1]), (c2[0], c2[1]))
+                # shift the exit waves
+                for ex_s in self.ex.storages.values():
+                    ex_s.data[:] = u.shift_zoom(ex_s.data, (1.,)*3,
+                            (0, c1[0], c1[1]), (0, c2[0], c2[1]))
 
                 log(4,'Probe recentered from %s to %s'
                             % (str(tuple(c1)), str(tuple(c2))))

--- a/test/accelerate_tests/cuda_pycuda_tests/array_utils_test.py
+++ b/test/accelerate_tests/cuda_pycuda_tests/array_utils_test.py
@@ -403,7 +403,7 @@ class ArrayUtilsTest(PyCudaTest):
             err_msg="The magnitudes of the array have not been clipped as expected")
 
 
-    def test_mass_center_UNITY(self):
+    def test_mass_center_2d_UNITY(self):
         np.random.seed(1987)
         A = np.random.random((128, 128)).astype(np.float32)
         A_gpu = gpuarray.to_gpu(A)
@@ -414,10 +414,21 @@ class ArrayUtilsTest(PyCudaTest):
         mc_d = MCK.mass_center(A_gpu)
         mc = mc_d.get()
 
-        print(out)
-        print(mc)
-
         np.testing.assert_allclose(out, mc, rtol=1e-6, atol=1e-6,
             err_msg="The centre of mass of the array have not been calculated as expected")
 
+
+    def test_mass_center_3d_UNITY(self):
+        np.random.seed(1987)
+        A = np.random.random((128, 128, 128)).astype(np.float32)
+        A_gpu = gpuarray.to_gpu(A)
+
+        out = au.mass_center(A)
+
+        MCK = gau.MassCenterKernel()
+        mc_d = MCK.mass_center(A_gpu)
+        mc = mc_d.get()
+
+        np.testing.assert_allclose(out, mc, rtol=1e-6, atol=1e-6,
+            err_msg="The centre of mass of the array have not been calculated as expected")
 

--- a/test/accelerate_tests/cuda_pycuda_tests/array_utils_test.py
+++ b/test/accelerate_tests/cuda_pycuda_tests/array_utils_test.py
@@ -41,7 +41,7 @@ class ArrayUtilsTest(PyCudaTest):
 
         ## Assert
         np.testing.assert_equal(out, 30333303.0)
-    
+
     def test_dot_complex_float(self):
         ## Arrange
         X,Y,Z = np.indices((3,3,1001), dtype=np.float32)
@@ -86,7 +86,7 @@ class ArrayUtilsTest(PyCudaTest):
         inp,_ = np.indices((5,3), dtype=np.int32)
         inp_dev = gpuarray.to_gpu(inp)
         out_dev = gpuarray.empty((3,5), dtype=np.int32)
-        
+
         ## Act
         AU = gau.TransposeKernel()
         AU.transpose(inp_dev, out_dev)
@@ -101,7 +101,7 @@ class ArrayUtilsTest(PyCudaTest):
         inp,_ = np.indices((137,61), dtype=np.int32)
         inp_dev = gpuarray.to_gpu(inp)
         out_dev = gpuarray.empty((61,137), dtype=np.int32)
-        
+
         ## Act
         AU = gau.TransposeKernel()
         AU.transpose(inp_dev, out_dev)
@@ -160,7 +160,7 @@ class ArrayUtilsTest(PyCudaTest):
         out = data_dev.get()
         np.testing.assert_allclose(out_exp, out, rtol=1e-5)
 
-    
+
     def test_complex_gaussian_filter_1d_more_blurring_UNITY(self):
         # Arrange
         data = np.zeros((11,), dtype=np.complex64)
@@ -266,7 +266,7 @@ class ArrayUtilsTest(PyCudaTest):
 
         # Assert
         out_exp = au.complex_gaussian_filter(data, mfs)
-        out = data_dev.get()        
+        out = data_dev.get()
         np.testing.assert_allclose(out_exp, out, rtol=1e-4)
 
 
@@ -367,14 +367,14 @@ class ArrayUtilsTest(PyCudaTest):
 
         MAK = gau.MaxAbs2Kernel(queue=self.stream)
         MAK.max_abs2(X_dev, out_dev)
-        
+
         np.testing.assert_allclose(out_dev.get(), out, rtol=1e-6, atol=1e-6,
             err_msg="The object norm array has not been updated as expected")
 
     def test_max_abs2_float_UNITY(self):
         np.random.seed(1983)
         X = np.random.randint(-1000, 1000, (3,100,200)).astype(np.float32)
-            
+
         out = np.zeros((1,), dtype=np.float32)
         X_dev = gpuarray.to_gpu(X)
         out_dev = gpuarray.to_gpu(out)
@@ -383,7 +383,7 @@ class ArrayUtilsTest(PyCudaTest):
 
         MAK = gau.MaxAbs2Kernel(queue=self.stream)
         MAK.max_abs2(X_dev, out_dev)
-        
+
         np.testing.assert_allclose(out_dev.get(), out, rtol=1e-6, atol=1e-6,
             err_msg="The object norm array has not been updated as expected")
 
@@ -401,5 +401,23 @@ class ArrayUtilsTest(PyCudaTest):
 
         np.testing.assert_allclose(B_gpu.get(), B, rtol=1e-6, atol=1e-6,
             err_msg="The magnitudes of the array have not been clipped as expected")
+
+
+    def test_mass_center_UNITY(self):
+        np.random.seed(1987)
+        A = np.random.random((128, 128)).astype(np.float32)
+        A_gpu = gpuarray.to_gpu(A)
+
+        out = au.mass_center(A)
+
+        MCK = gau.MassCenterKernel()
+        mc_d = MCK.mass_center(A_gpu)
+        mc = mc_d.get()
+
+        print(out)
+        print(mc)
+
+        np.testing.assert_allclose(out, mc, rtol=1e-6, atol=1e-6,
+            err_msg="The centre of mass of the array have not been calculated as expected")
 
 

--- a/test/accelerate_tests/cuda_pycuda_tests/array_utils_test.py
+++ b/test/accelerate_tests/cuda_pycuda_tests/array_utils_test.py
@@ -7,7 +7,6 @@ import unittest
 import numpy as np
 from . import perfrun, PyCudaTest, have_pycuda
 from ptypy.accelerate.base import array_utils as au
-from ptypy.utils import math_utils as mu
 
 if have_pycuda():
     from pycuda import gpuarray
@@ -439,7 +438,7 @@ class ArrayUtilsTest(PyCudaTest):
         B = A + A**2 * 1j
         B_gpu = gpuarray.to_gpu(B)
 
-        out = mu.abs2(B).sum(0)
+        out = au.abs2(B).sum(0)
 
         A2SK = gau.Abs2SumKernel(dtype=B_gpu.dtype)
         a2s_d = A2SK.abs2sum(B_gpu)
@@ -454,7 +453,7 @@ class ArrayUtilsTest(PyCudaTest):
         B = A + A**2 * 1j
         B_gpu = gpuarray.to_gpu(B)
 
-        out = mu.abs2(B).sum(0)
+        out = au.abs2(B).sum(0)
 
         A2SK = gau.Abs2SumKernel(dtype=B_gpu.dtype)
         a2s_d = A2SK.abs2sum(B_gpu)
@@ -463,34 +462,79 @@ class ArrayUtilsTest(PyCudaTest):
         np.testing.assert_allclose(out, a2s, rtol=1e-6, atol=1e-6,
             err_msg="The sum of absolute values along the first dimension has not been calculated as expected")
 
-    def test_interpolate_shift_UNITY(self):
+    def test_interpolate_shift_2D_UNITY(self):
         np.random.seed(1987)
-        A = np.random.random((256, 256)).astype(np.float32)
+        A = np.random.random((259, 252)).astype(np.float32)
         A = A + A**2 * 1j
         A_gpu = gpuarray.to_gpu(A)
 
-        # cen_old = np.array([100.123, 150.678])
-        # cen_new = np.array([128.5, 127.5])
-        cen_old = np.array([100, 100]).astype(np.float32)
-        cen_new = np.array([105.123, 150.983]).astype(np.float32)
-        # cen_new = np.array([100-5.123, 100-50.983]).astype(np.float32)
+        cen_old = np.array([100.123, 5.678]).astype(np.float32)
+        cen_new = np.array([128.5, 127.5]).astype(np.float32)
         shift = cen_new - cen_old
 
         out = au.interpolated_shift(A, shift, do_linear=True)
-        #out_z = aau.shift_zoom(A, (1,1), cen_old, cen_new)
 
         ISK = gau.InterpolatedShiftKernel()
         isk_d = ISK.interpolate_shift(A_gpu, shift)
         isk = isk_d.get()
 
-        idx = np.argwhere(~np.isclose(out, isk))
-        for i in idx:
-            print(i, out[i[0], i[1]], isk[i[0], i[1]])
+        np.testing.assert_allclose(out, isk, rtol=1e-6, atol=1e-6,
+            err_msg="The shifting of array has not been calculated as expected")
 
-        # print(out[96,64])
-        # print(isk[96,64])
+    def test_interpolate_shift_3D_UNITY(self):
+        np.random.seed(1987)
+        A = np.random.random((3, 200, 300)).astype(np.float32)
+        A = A + A**2 * 1j
+        A_gpu = gpuarray.to_gpu(A)
 
+        cen_old = np.array([0., 180.123, 5.678]).astype(np.float32)
+        cen_new = np.array([0., 128.5, 127.5]).astype(np.float32)
+        shift = cen_new - cen_old
 
+        out = au.interpolated_shift(A, shift, do_linear=True)
+
+        ISK = gau.InterpolatedShiftKernel()
+        isk_d = ISK.interpolate_shift(A_gpu, shift[1:])
+        isk = isk_d.get()
 
         np.testing.assert_allclose(out, isk, rtol=1e-6, atol=1e-6,
             err_msg="The shifting of array has not been calculated as expected")
+
+    def test_interpolate_shift_integer_UNITY(self):
+        np.random.seed(1987)
+        A = np.random.random((3, 200, 300)).astype(np.float32)
+        A = A + A**2 * 1j
+        A_gpu = gpuarray.to_gpu(A)
+
+        cen_old = np.array([0, 180, 5]).astype(np.float32)
+        cen_new = np.array([0, 128, 127]).astype(np.float32)
+        shift = cen_new - cen_old
+
+        out = au.interpolated_shift(A, shift, do_linear=True)
+
+        ISK = gau.InterpolatedShiftKernel()
+        isk_d = ISK.interpolate_shift(A_gpu, shift[1:])
+        isk = isk_d.get()
+
+        np.testing.assert_allclose(out, isk, rtol=1e-6, atol=1e-6,
+            err_msg="The shifting of array has not been calculated as expected")
+
+    def test_interpolate_shift_no_shift_UNITY(self):
+        np.random.seed(1987)
+        A = np.random.random((3, 200, 300)).astype(np.float32)
+        A = A + A**2 * 1j
+        A_gpu = gpuarray.to_gpu(A)
+
+        cen_old = np.array([0, 0, 0]).astype(np.float32)
+        cen_new = np.array([0, 0, 0]).astype(np.float32)
+        shift = cen_new - cen_old
+
+        out = au.interpolated_shift(A, shift, do_linear=True)
+
+        ISK = gau.InterpolatedShiftKernel()
+        isk_d = ISK.interpolate_shift(A_gpu, shift[1:])
+        isk = isk_d.get()
+
+        np.testing.assert_allclose(out, isk, rtol=1e-6, atol=1e-6,
+            err_msg="The shifting of array has not been calculated as expected")
+

--- a/test/accelerate_tests/cuda_pycuda_tests/array_utils_test.py
+++ b/test/accelerate_tests/cuda_pycuda_tests/array_utils_test.py
@@ -7,6 +7,7 @@ import unittest
 import numpy as np
 from . import perfrun, PyCudaTest, have_pycuda
 from ptypy.accelerate.base import array_utils as au
+from ptypy.utils import math_utils as mu
 
 if have_pycuda():
     from pycuda import gpuarray
@@ -415,7 +416,7 @@ class ArrayUtilsTest(PyCudaTest):
         mc = mc_d.get()
 
         np.testing.assert_allclose(out, mc, rtol=1e-6, atol=1e-6,
-            err_msg="The centre of mass of the array have not been calculated as expected")
+            err_msg="The centre of mass of the array has not been calculated as expected")
 
 
     def test_mass_center_3d_UNITY(self):
@@ -430,5 +431,35 @@ class ArrayUtilsTest(PyCudaTest):
         mc = mc_d.get()
 
         np.testing.assert_allclose(out, mc, rtol=1e-6, atol=1e-6,
-            err_msg="The centre of mass of the array have not been calculated as expected")
+            err_msg="The centre of mass of the array has not been calculated as expected")
+
+    def test_abs2sum_complex_float_UNITY(self):
+        np.random.seed(1987)
+        A = np.random.random((3, 321, 123)).astype(np.float32)
+        B = A + A**2 * 1j
+        B_gpu = gpuarray.to_gpu(B)
+
+        out = mu.abs2(B).sum(0)
+
+        A2SK = gau.Abs2SumKernel(dtype=B_gpu.dtype)
+        a2s_d = A2SK.abs2sum(B_gpu)
+        a2s = a2s_d.get()
+
+        np.testing.assert_allclose(out, a2s, rtol=1e-6, atol=1e-6,
+            err_msg="The sum of absolute values along the first dimension has not been calculated as expected")
+
+    def test_abs2sum_complex_double_UNITY(self):
+        np.random.seed(1987)
+        A = np.random.random((3, 321, 123)).astype(np.float64)
+        B = A + A**2 * 1j
+        B_gpu = gpuarray.to_gpu(B)
+
+        out = mu.abs2(B).sum(0)
+
+        A2SK = gau.Abs2SumKernel(dtype=B_gpu.dtype)
+        a2s_d = A2SK.abs2sum(B_gpu)
+        a2s = a2s_d.get()
+
+        np.testing.assert_allclose(out, a2s, rtol=1e-6, atol=1e-6,
+            err_msg="The sum of absolute values along the first dimension has not been calculated as expected")
 


### PR DESCRIPTION
Previously the object and exit waves are not shifted when the probe is shifted, resulting in incorrect results. After shifting the object and exit waves with the same amount of offset, it produces correct result.