### PR TITLE
Fix how frames_per_block is defined

### DIFF
--- a/ptypy/accelerate/base/engines/ML_serial.py
+++ b/ptypy/accelerate/base/engines/ML_serial.py
@@ -74,11 +74,7 @@ class ML_serial(ML):
             geo = scan.geometries[0]
 
             # Get info to shape buffer arrays
-            # TODO: make this part of the engine rather than scan
-            fpc = self.ptycho.frames_per_block
-
-            # When using MPI, the nr. of frames per block is smaller
-            fpc = fpc // parallel.size
+            fpc = scan.max_frames_per_block
 
             # TODO : make this more foolproof
             try:

--- a/ptypy/accelerate/base/engines/projectional_serial.py
+++ b/ptypy/accelerate/base/engines/projectional_serial.py
@@ -163,11 +163,7 @@ class _ProjectionEngine_serial(_ProjectionEngine):
             geo = scan.geometries[0]
 
             # Get info to shape buffer arrays
-            # TODO: make this part of the engine rather than scan
-            fpc = self.ptycho.frames_per_block
-
-            # When using MPI, the nr. of frames per block is smaller
-            fpc = fpc // parallel.size
+            fpc = scan.max_frames_per_block
 
             # TODO : make this more foolproof
             try:

--- a/ptypy/accelerate/base/engines/stochastic.py
+++ b/ptypy/accelerate/base/engines/stochastic.py
@@ -95,10 +95,6 @@ class _StochasticEngineSerial(_StochasticEngine):
             # TODO: needs to be adapted for broad bandwidth
             geo = scan.geometries[0]
 
-            # Get info to shape buffer arrays
-            # TODO: make this part of the engine rather than scan
-            fpc = self.ptycho.frames_per_block
-
             # TODO : make this more foolproof
             try:
                 nmodes = scan.p.coherence.num_probe_modes * \
@@ -107,7 +103,7 @@ class _StochasticEngineSerial(_StochasticEngine):
                 nmodes = 1
 
             # create buffer arrays
-            ash = (1 * nmodes,) + tuple(geo.shape)
+            ash = (nmodes,) + tuple(geo.shape)
             aux = np.zeros(ash, dtype=np.complex64)
             kern.aux = aux
 

--- a/ptypy/accelerate/cuda_pycuda/engines/ML_pycuda.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/ML_pycuda.py
@@ -192,11 +192,7 @@ class ML_pycuda(ML_serial):
             geo = scan.geometries[0]
 
             # Get info to shape buffer arrays
-            # TODO: make this part of the engine rather than scan
-            fpc = self.ptycho.frames_per_block
-
-            # When using MPI, the nr. of frames per block is smaller
-            fpc = fpc // parallel.size
+            fpc = scan.max_frames_per_block
 
             # TODO : make this more foolproof
             try:

--- a/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda.py
@@ -96,11 +96,7 @@ class _ProjectionEngine_pycuda(projectional_serial._ProjectionEngine_serial):
             geo = scan.geometries[0]
 
             # Get info to shape buffer arrays
-            # TODO: make this part of the engine rather than scan
-            fpc = self.ptycho.frames_per_block
-
-            # When using MPI, the nr. of frames per block is smaller
-            fpc = fpc // parallel.size
+            fpc = scan.max_frames_per_block
 
             # TODO : make this more foolproof
             try:

--- a/ptypy/accelerate/ocl_pyopencl/engines/DM_ocl.py
+++ b/ptypy/accelerate/ocl_pyopencl/engines/DM_ocl.py
@@ -91,8 +91,7 @@ class DM_ocl(DM_serial.DM_serial):
             geo = scan.geometries[0]
 
             # Get info to shape buffer arrays
-            # TODO: make this part of the engine rather than scan
-            fpc = self.ptycho.frames_per_block
+            fpc = scan.max_frames_per_block
 
             # TODO : make this more foolproof
             try:

--- a/ptypy/core/manager.py
+++ b/ptypy/core/manager.py
@@ -547,7 +547,7 @@ class BlockScanModel(ScanModel):
                                       fill=0.0, layermap=indices_node)
         mask = self.Cmask.new_storage(shape=sh, psize=self.psize, padonly=True,
                                       fill=1.0, layermap=indices_node)
-        print(sh, diff.shape, diff.nlayers)
+
         # Prepare for View generation
         AR_diff = DEFAULT_ACCESSRULE.copy()
         AR_diff.shape = self.diff_shape # this is None due to init

--- a/ptypy/core/manager.py
+++ b/ptypy/core/manager.py
@@ -1632,9 +1632,10 @@ class ModelManager(object):
 
         logger.info('Processing new data.')
 
-        # Attempt to get new data
-        _nframes = self.ptycho.frames_per_block
+        # making sure frames_per_block is defined per rank
+        _nframes = self.ptycho.frames_per_block * parallel.size
 
+        # Attempt to get new data
         new_data = []
         for label, scan in self.scans.items():
             if not scan.data_available:

--- a/templates/minimal_prep_and_run_DM_pycuda_stream.py
+++ b/templates/minimal_prep_and_run_DM_pycuda_stream.py
@@ -17,6 +17,7 @@ p.io = u.Param()
 p.io.home = "~/dumps/ptypy/"
 p.io.autosave = u.Param(active=True)
 p.io.autoplot = u.Param(active=False)
+p.io.interaction = u.Param(active=False)
 # max 200 frames (128x128px) of diffraction data
 p.scans = u.Param()
 p.scans.MF = u.Param()


### PR DESCRIPTION
In an attempt to fix #254, I made the following changes:

- New variable `max_frames_per_block` in `ScanModel` and `BlockScanModel` which dynamically defines the maximum size of a block (never groing larger than the actual size of the data)
- Access the block size in the engines via the new scan model parameter `max_frames_per_block`

This makes sure that we never allocate more GPU memory than we need and it also makes all pycuda engines compatible with the `Full` scan class irrespective of what the user might specify as `p.frames_per_block`.