### PR TITLE
Allow running multiple ML engines

### DIFF
--- a/ptypy/engines/ML.py
+++ b/ptypy/engines/ML.py
@@ -342,6 +342,9 @@ class ML(PositionCorrectionEngine):
         # Save floating intensities into runtime
         self.ptycho.runtime["float_intens"] = parallel.gather_dict(self.ML_model.float_intens_coeff)
 
+        # Delete model
+        del self.ML_model
+
 class BaseModel(object):
     """
     Base class for log-likelihood models.


### PR DESCRIPTION
ML model object needs to be deleted in `engine_finalize` to allow running multiple ML engines within the same reconstruction. 