### PR TITLE
Reset estimated photon count when loading probe from file

### DIFF
--- a/ptypy/core/illumination.py
+++ b/ptypy/core/illumination.py
@@ -376,6 +376,7 @@ def init_storage(storage, pars, energy=None, **kwargs):
             'Attempt to load layer `%s` of probe storage with ID `%s` from `%s`'
             % (str(layer), str(ID), p.recon.rfile))
         model = u.load_from_ptyr(p.recon.rfile, 'probe', ID, layer)
+        p.photons = None
         # This could be more sophisticated,
         # i.e. matching the real space grids etc.
     elif str(p.model) == 'stxm':


### PR DESCRIPTION
This is a bugfix to avoid to current behaviour that when loading an illumination from a previous .ptyr reconstruction, the power of the illumination is being rescaled by photon count estimated from the data. Instead, the power of the illumination should remain as it has been loaded from the file. To achieve this, we can simple reset `photons = None` after loading from the .ptyr which will then correclty escape this code in `_process`:

```
    # apply photon count
    if photons is not None:
        model *= np.sqrt(photons / u.norm2(model))
```