### PR TITLE
Change installation instructions for GPU

### DIFF
--- a/doc/rst_templates/getting_started.tmp
+++ b/doc/rst_templates/getting_started.tmp
@@ -96,7 +96,7 @@ GPUs based on our own kernels and the
 Install the dependencies for this version like so.
 ::
 
-    $ conda env create -f accelerate/cuda_pycuda/dependencies.yml
+    $ conda env create -f ptypy/accelerate/cuda_pycuda/dependencies.yml
     $ conda activate ptypy_pycuda
     (ptypy_pycuda)$ pip install .
 


### PR DESCRIPTION
Installation instructions previously incompatible with the existing file structure of the repository. PyCUDA installation previously directed to:
accelerate/cuda_pycude/dependencies.yml
Now directs to:
ptypy/accelerate/cuda_pycude/dependencies.yml