### PR TITLE
Use primary context when setting up pycuda-related tests

### DIFF
--- a/test/accelerate_tests/cuda_pycuda_tests/__init__.py
+++ b/test/accelerate_tests/cuda_pycuda_tests/__init__.py
@@ -43,7 +43,7 @@ class PyCudaTest(unittest.TestCase):
     def tearDown(self):
         np.set_printoptions()
         self.ctx.pop()
-        self.ctx.detach()
+        self.ctx = None
         if not 'perf' in self._testMethodName:
            cuda_pycuda.debug_options = self.opts_old
 

--- a/test/accelerate_tests/cuda_pycuda_tests/__init__.py
+++ b/test/accelerate_tests/cuda_pycuda_tests/__init__.py
@@ -26,7 +26,13 @@ class PyCudaTest(unittest.TestCase):
     def setUp(self):
         import sys
         np.set_printoptions(threshold=sys.maxsize, linewidth=np.inf)
-        self.ctx = make_default_context()
+
+        def _retain_primary_context(dev):
+            ctx = dev.retain_primary_context()
+            ctx.push()
+            return ctx
+        self.ctx = make_default_context(_retain_primary_context)
+
         self.stream = cuda.Stream()
         # enable assertions in CUDA kernels for testing
         if not 'perf' in self._testMethodName:


### PR DESCRIPTION
This PR fixes the issue of running Reikna tests after running cufft tests in [fft_scaling_test.py](https://github.com/ptycho/ptypy/blob/master/test/accelerate_tests/cuda_pycuda_tests/fft_scaling_test.py). An example (cufft then reikna)
```
pytest fft_scaling_test.py::FftScalingTest::test_fwd_noscale_cufft fft_scaling_test.py::FftScalingTest::test_fwd_noscale_reikna
```
will result in
```
pycuda._driver.LogicError: cuLaunchKernel failed: invalid resource handle
```
But (reikna then cufft)
```
pytest fft_scaling_test.py::FftScalingTest::test_fwd_noscale_reikna fft_scaling_test.py::FftScalingTest::test_fwd_noscale_cufft
```
does not result in error.

The issue could be related to CUDA runtime in cufft and the primary context should be retained as stated in [this discussion](https://github.com/inducer/pycuda/discussions/356). The change is adapted from [this commit](https://github.com/inducer/pycuda/pull/270/commits/08b53a7ec11fb8c37e41fb5e88468aa10583a428).

After doing this, there is no error by running the above two tests and `pytest fft_scaling_test.py::FftScalingTest` works fine.

The same primary context is also applied to [multi_gpu_test.py](https://github.com/ptycho/ptypy/blob/master/test/accelerate_tests/cuda_pycuda_tests/multi_gpu_test.py), and the MPI tests with multiple GPUs is now working on a CUDA-aware MPI.

Note that it is essential to set context to `None` when tearing down.
