### PR TITLE
patch to fix github actions and update installation instructions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: ptypy tests
+name: Tests
 
 on:
   # Trigger the workflow on push or pull request,
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - dev
+      - hotfixes
   # Also trigger on page_build, as well as release created events
   page_build:
   release:
@@ -20,26 +21,38 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 5
+      max-parallel: 10
+      fail-fast: false
       matrix:
         python-version: ['3.7','3.8','3.9','3.10']
-
+        mpi: ['mpich', 'openmpi']
+    name: Testing with ${{ matrix.mpi }} and Python ${{ matrix.python-version }} 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set up MPI
+      uses: mpi4py/setup-mpi@v1
+      with:
+        mpi: ${{ matrix.mpi }}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version:  ${{ matrix.python-version }}
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH
+        conda update -n base conda
+        conda --version
     - name: Install dependencies
       run: |
+        # replace python version in core dependencies
+        sed -i 's/python=3.9/python=${{ matrix.python-version }}/' dependencies_core.yml
         conda env update --file dependencies_core.yml --name base
+        conda list	
     - name: Prepare ptypy
       run: |
-        # Dry install to create ptypy/version.py
+        # Install ptypy
         pip install .
     - name: Lint with flake8
       run: |

--- a/dependencies_core.yml
+++ b/dependencies_core.yml
@@ -1,6 +1,4 @@
 name: ptypy_core
-channels:
-  - conda-forge
 dependencies:
   - python=3.9
   - numpy

--- a/doc/rst_templates/getting_started.tmp
+++ b/doc/rst_templates/getting_started.tmp
@@ -96,7 +96,7 @@ GPUs based on our own kernels and the
 Install the dependencies for this version like so.
 ::
 
-    $ conda env create -f accelerate/cuda_pycuda/dependencies.yml
+    $ conda env create -f ptypy/accelerate/cuda_pycuda/dependencies.yml
     $ conda activate ptypy_pycuda
     (ptypy_pycuda)$ pip install .
 


### PR DESCRIPTION
A few quick fixes to github actions and making sure ptypy works with latest packages available on conda-forge
- [x] In actions: use python version from the matrix instead of default python=3.9 from the dependencies file
- [x] fix typo in documentation #437 
- [x] use conda defaults instead of conda-forge
- [x] test with different MPI environments 