### PR TITLE
patch to make numpy FFT C-contiguous and allow user to choose FFT type

### DIFF
--- a/ptypy/core/geometry.py
+++ b/ptypy/core/geometry.py
@@ -104,14 +104,16 @@ class Geo(Base):
     type = str
     default = farfield
     help = Propagation type
-    doc = Either "farfield" or "nearfield"
+    doc = Choose between "farfield" or "nearfield"
+    choices = 'farfield', 'nearfield'
     userlevel = 1
 
     [ffttype]
     type = str
-    default = numpy
+    default = scipy
     help = FFT library
-    doc = Either "numpy", "scipy" or "fftw"
+    doc = Choose which library to use for FFTs
+    choices = 'numpy', 'scipy', 'fftw'
     userlevel = 1
 
     [shape]
@@ -513,7 +515,7 @@ class BasicFarfieldPropagator(object):
     coordinates are rolled periodically, just like in the conventional fft case.
     """
 
-    def __init__(self, geo_pars=None, ffttype='numpy', **kwargs):
+    def __init__(self, geo_pars=None, ffttype='scipy', **kwargs):
         """
         Parameters
         ----------
@@ -692,7 +694,7 @@ class BasicNearfieldPropagator(object):
     Basic two step (i.e. two ffts) Nearfield Propagator.
     """
 
-    def __init__(self, geo_pars=None, ffttype='numpy', **kwargs):
+    def __init__(self, geo_pars=None, ffttype='scipy', **kwargs):
         """
         Parameters
         ----------

--- a/ptypy/core/manager.py
+++ b/ptypy/core/manager.py
@@ -73,6 +73,13 @@ class ScanModel(object):
     doc = Either "farfield" or "nearfield"
     userlevel = 1
 
+    [ffttype]
+    type = str
+    default = numpy
+    help = FFT library
+    doc = Choose from "numpy", "scipy" or "fftw"
+    userlevel = 1
+
     [data]
     default =
     type = @scandata.*
@@ -776,6 +783,7 @@ class _Vanilla(object):
         geo_pars.shape = probe_shape
         geo_pars.center = center
         geo_pars.propagation = self.p.propagation
+        geo_pars.ffttype = self.p.ffttype
         geo_pars.psize = psize
 
         # make a Geo instance and fix resolution
@@ -1065,6 +1073,7 @@ class _Full(object):
 
         # Add propagation info from this scan model
         geo_pars.propagation = self.p.propagation
+        geo_pars.ffttype = self.p.ffttype
 
         # The multispectral case will have multiple geometries
         for ii, fac in enumerate(self.p.coherence.energies):
@@ -1532,6 +1541,7 @@ class Bragg3dModel(Vanilla):
         get_keys = ['distance', 'center', 'energy']
         geo_pars = u.Param({key: common[key] for key in get_keys})
         geo_pars.propagation = self.p.propagation
+        geo_pars.ffttype = self.p.ffttype
         # take extra Bragg information into account
         psize = tuple(common['psize'])
         geo_pars.psize = (self.ptyscan.common.rocking_step,) + psize

--- a/ptypy/core/manager.py
+++ b/ptypy/core/manager.py
@@ -75,7 +75,7 @@ class ScanModel(object):
 
     [ffttype]
     type = str
-    default = numpy
+    default = scipy
     help = FFT library
     doc = Choose from "numpy", "scipy" or "fftw"
     userlevel = 1

--- a/test/core_tests/geometry_test.py
+++ b/test/core_tests/geometry_test.py
@@ -51,7 +51,6 @@ class GeometryTest(unittest.TestCase):
         g.shape = 256
         g.propagation = "nearfield"
         G = geometry.Geo(owner=P, pars=g)
-#         print G.resolution
         return G
 
     def test_geometry_near_field_init(self):
@@ -72,9 +71,9 @@ class GeometryTest(unittest.TestCase):
         C = prop.ifft(B)
 
         # asserts
-        assert (A.strides == B.strides), "FFT(x) has changed the strides of x, using fftw"
-        assert (B.strides == C.strides), "IFFT(x) has changed the strides of x, using fftw"
-        np.testing.assert_allclose(A,C, err_msg="IFFT(FFT(x) did not return the same as x, using fftw")
+        assert (A.strides == B.strides), "FFT(x) has changed the strides of x, using {:s}".format(prop.FFTch.ffttype)
+        assert (B.strides == C.strides), "IFFT(x) has changed the strides of x, using {:s}".format(prop.FFTch.ffttype)
+        np.testing.assert_allclose(A,C, err_msg="IFFT(FFT(x) did not return the same as x, using {:s}".format(prop.FFTch.ffttype))
 
     def test_basic_nearfield_propagator_fftw(self):
         G = self.set_up_nearfield()

--- a/test/core_tests/geometry_test.py
+++ b/test/core_tests/geometry_test.py
@@ -7,6 +7,9 @@ import ptypy.utils as u
 import numpy as np
 from ptypy.core import geometry
 from ptypy.core import Base as theBase
+from ptypy.core.geometry import BasicNearfieldPropagator
+from ptypy.core.geometry import BasicFarfieldPropagator
+
 
 # subclass for dictionary access
 Base = type('Base',(theBase,),{})
@@ -57,6 +60,52 @@ class GeometryTest(unittest.TestCase):
     def test_geometry_nearfield_resolution(self):
         G = self.set_up_nearfield()
         assert (np.round(G.resolution*1e7) == [1.00, 1.00]).all(), "geometry resolution incorrect for the nearfield"
+
+    def _basic_propagator_test(self, prop):
+
+        # Create random 2D array
+        S = (128,128)
+        A = np.random.random(S) + 1j * np.random.random(S)
+
+        # FFT and IFFT
+        B = prop.fft(A)
+        C = prop.ifft(B)
+
+        # asserts
+        assert (A.strides == B.strides), "FFT(x) has changed the strides of x, using fftw"
+        assert (B.strides == C.strides), "IFFT(x) has changed the strides of x, using fftw"
+        np.testing.assert_allclose(A,C, err_msg="IFFT(FFT(x) did not return the same as x, using fftw")
+
+    def test_basic_nearfield_propagator_fftw(self):
+        G = self.set_up_nearfield()
+        P = BasicNearfieldPropagator(G.p,ffttype="fftw")
+        self. _basic_propagator_test(P)
+
+    def test_basic_nearfield_propagator_numpy(self):
+        G = self.set_up_nearfield()
+        P = BasicNearfieldPropagator(G.p,ffttype="numpy")
+        self. _basic_propagator_test(P)
+
+    def test_basic_nearfield_propagator_scipy(self):
+        G = self.set_up_nearfield()
+        P = BasicNearfieldPropagator(G.p,ffttype="scipy")
+        self. _basic_propagator_test(P)
+
+    def test_basic_farfield_propagator_fftw(self):
+        G = self.set_up_farfield()
+        P = BasicFarfieldPropagator(G.p,ffttype="fftw")
+        self. _basic_propagator_test(P)
+
+    def test_basic_farfield_propagator_numpy(self):
+        G = self.set_up_farfield()
+        P = BasicFarfieldPropagator(G.p,ffttype="numpy")
+        self. _basic_propagator_test(P)
+
+    def test_basic_farfield_propagator_scipy(self):
+        G = self.set_up_farfield()
+        P = BasicFarfieldPropagator(G.p,ffttype="scipy")
+        self. _basic_propagator_test(P)
+    
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This resolves the issue reported in #474 that was caused by this recent [commit](https://github.com/ptycho/ptypy/commit/8b4a60d61a5ba60d850971bf62329c7f741a029f).

The underlying problem was that the Numpy FFT changes the `strides` of the ndarray and makes the target array F-contiguous which causes both in our MPI and CUDA implementations that require C-contiguous arrays. I have added `np.ascontiguousarray` to both the `fft` and `ifft` of the numpy FFT propagator. 

As a result, the numpy FFT might not be the fastest option, therefore we should allow the user to choose between the 3 available FFT types (numpy, scipy and fftw) - I added a new parameter `p.ffttype` in the scan model. This is a little inconsistent with the CUDA engines which define the FFT library in the engines. 

Also, its not quite clear what would be the best default choice for `ffttype`, currently it is set to "numpy".