### PR TITLE
SimScan: reset diff storage to zeros (bugfix)

### DIFF
--- a/ptypy/simulations/simscan.py
+++ b/ptypy/simulations/simscan.py
@@ -164,6 +164,10 @@ class SimScan(PtyScan):
         P = self.manipulate_ptycho(P)
         #############################################################
 
+        # Make sure all diff storages are empty
+        for name, storage in P.diff.S.items():
+            storage.data.fill(0.)
+
         # Simulate diffraction signal
         logger.info('Propagating exit waves.')
         for name,pod in P.pods.items():


### PR DESCRIPTION
By default the `PtyScan` class is generating dummy diffraction data as shown [here](https://github.com/ptycho/ptypy/blob/4cce5ae6a57ef8ca923ace0a902e504f6430fb5e/ptypy/core/data.py#L1087-L1090). This means that the diffraction simulated with `SimScan` is polluted with this dummy data. A simple fix is to reset the diffraction to zeros in Simscan.