### PR TITLE
interactive plotting: move Ipython dependency into jupyter client

### DIFF
--- a/ptypy/core/ptycho.py
+++ b/ptypy/core/ptycho.py
@@ -722,11 +722,10 @@ class Ptycho(Base):
                     if (self.p.io.autoplot.active) and (not self.p.io.autoplot.threaded):
                         if not (info["iteration"] % self.p.io.autoplot.interval):
                             if self._jupyter_client is None:
-                                from IPython import display
                                 from ptypy.utils.plot_client import _JupyterClient
                                 self._jupyter_client = _JupyterClient(self, autoplot_pars=self.p.io.autoplot, layout_pars=self.p.io.autoplot.layout)
                             self._jupyter_client.runtime.update(self.runtime)
-                            display.display(self._jupyter_client.plot(title=imsg), clear=True)
+                            self._jupyter_client.display(imsg)
                     else:
                         ilog_streamer(imsg)
                     

--- a/ptypy/utils/plot_client.py
+++ b/ptypy/utils/plot_client.py
@@ -715,6 +715,10 @@ class _JupyterClient(MPLplotter):
                                       runtime=ptycho.runtime,
                                       in_thread=False)
         self.initialized = False
+
+        # not ideal but currently best solution
+        # avoiding a module-level import of Ipython
+        # since its not part of the core dependencies
         import IPython
         self.ipython = IPython
 

--- a/ptypy/utils/plot_client.py
+++ b/ptypy/utils/plot_client.py
@@ -715,6 +715,8 @@ class _JupyterClient(MPLplotter):
                                       runtime=ptycho.runtime,
                                       in_thread=False)
         self.initialized = False
+        import IPython
+        self.ipython = IPython
 
     def plot(self, title=""):
         if not self.initialized:
@@ -724,6 +726,10 @@ class _JupyterClient(MPLplotter):
         self.plot_all()
         plt.close(self.plot_fig)
         return self.plot_fig
+
+    def display(self,title):
+        self.ipython.display.display(self.plot(title=title), clear=True)
+        
 
 def figure_from_ptycho(P, pars=None):
     """


### PR DESCRIPTION
this fixes an issue where the interactive jupyter plotting would throw an error when more than one engines is being used. This had to do with the local import of IPython. Moving the import into the jupyter client itself fixed the problem. 