### PR TITLE
Python 3.11 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,16 +24,11 @@ jobs:
       max-parallel: 10
       fail-fast: false
       matrix:
-        python-version: ['3.7','3.8','3.9','3.10']
-        mpi: ['mpich', 'openmpi']
-    name: Testing with ${{ matrix.mpi }} and Python ${{ matrix.python-version }} 
+        python-version: ['3.7','3.8','3.9','3.10', '3.11']
+    name: Testing with Python ${{ matrix.python-version }} 
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Set up MPI
-      uses: mpi4py/setup-mpi@v1
-      with:
-        mpi: ${{ matrix.mpi }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       max-parallel: 10
       fail-fast: false
       matrix:
-        python-version: ['3.7','3.8','3.9','3.10', '3.11']
+        python-version: ['3.8','3.9','3.10', '3.11']
     name: Testing with Python ${{ matrix.python-version }} 
     steps:
     - name: Checkout
@@ -42,7 +42,7 @@ jobs:
     - name: Install dependencies
       run: |
         # replace python version in core dependencies
-        sed -i 's/python=3.9/python=${{ matrix.python-version }}/' dependencies_core.yml
+        sed -i 's/python/python=${{ matrix.python-version }}/' dependencies_core.yml
         conda env update --file dependencies_core.yml --name base
         conda list	
     - name: Prepare ptypy

--- a/cufft/dependencies.yml
+++ b/cufft/dependencies.yml
@@ -2,7 +2,7 @@ name: ptypy_cufft
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python
   - cmake>=3.8.0
   - pybind11
   - compilers

--- a/dependencies_core.yml
+++ b/dependencies_core.yml
@@ -1,6 +1,6 @@
 name: ptypy_core
 dependencies:
-  - python=3.9
+  - python
   - numpy
   - scipy
   - h5py

--- a/dependencies_dev.yml
+++ b/dependencies_dev.yml
@@ -2,7 +2,7 @@ name: ptypy_full
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python
   - numpy
   - scipy
   - matplotlib

--- a/dependencies_full.yml
+++ b/dependencies_full.yml
@@ -2,7 +2,7 @@ name: ptypy_full
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python
   - numpy
   - scipy
   - matplotlib

--- a/ptypy/accelerate/base/kernels.py
+++ b/ptypy/accelerate/base/kernels.py
@@ -109,7 +109,7 @@ class FourierUpdateKernel(BaseKernel):
         ## Actual math ##
 
         # Reduces the Fourier error along the last 2 dimensions.fd
-        #err_sum[:] = ferr.astype(np.double).sum(-1).sum(-1).astype(np.float)
+        #err_sum[:] = ferr.astype(np.double).sum(-1).sum(-1).astype(float)
         err_sum[:] = ferr.sum(-1).sum(-1)
         return
 

--- a/ptypy/accelerate/cuda_cupy/dependencies.yml
+++ b/ptypy/accelerate/cuda_cupy/dependencies.yml
@@ -2,7 +2,7 @@ name: ptypy_cupy
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python
   - numpy
   - scipy
   - matplotlib

--- a/ptypy/accelerate/cuda_pycuda/dependencies.yml
+++ b/ptypy/accelerate/cuda_pycuda/dependencies.yml
@@ -2,7 +2,7 @@ name: ptypy_pycuda
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python
   - numpy
   - scipy
   - matplotlib

--- a/ptypy/accelerate/ocl_pyopencl/npy_kernels.py
+++ b/ptypy/accelerate/ocl_pyopencl/npy_kernels.py
@@ -102,7 +102,7 @@ class Fourier_update_kernel(BaseKernel):
         ## Actual math ##
 
         # Reduceses the Fourier error along the last 2 dimensions.fd
-        error_sum[:] = ferr.astype(np.double).sum(-1).sum(-1).astype(np.float)
+        error_sum[:] = ferr.astype(np.double).sum(-1).sum(-1).astype(float)
 
     def fmag_all_update(self, pbound, g_mag, g_mask, g_err_sum, offset=0):
 

--- a/ptypy/accelerate/ocl_pyopencl/npy_kernels_for_block.py
+++ b/ptypy/accelerate/ocl_pyopencl/npy_kernels_for_block.py
@@ -87,7 +87,7 @@ class FourierUpdateKernel(BaseKernel):
         ## Actual math ##
 
         # Reduceses the Fourier error along the last 2 dimensions.fd
-        #err_sum[:] = ferr.astype(np.double).sum(-1).sum(-1).astype(np.float)
+        #err_sum[:] = ferr.astype(np.double).sum(-1).sum(-1).astype(float)
         err_sum[:] = ferr.sum(-1).sum(-1)
         return
 

--- a/ptypy/accelerate/ocl_pyopencl/ocl_fft.py
+++ b/ptypy/accelerate/ocl_pyopencl/ocl_fft.py
@@ -174,7 +174,7 @@ class FFT_2D_ocl_reikna(object):
 
         # attach scaling
         from reikna.transformations import mul_param
-        sc = mul_param(array, np.float)
+        sc = mul_param(array, float)
         ftreikna.parameter.output.connect(sc, sc.input, out=sc.output, scale=sc.param)
         iscale = np.sqrt(np.prod(array.shape[-2:])) if symmetric else 1.0
         scale = 1.0 / iscale

--- a/ptypy/accelerate/ocl_pyopencl/ocl_kernels_self_contained_for_future_reference.py
+++ b/ptypy/accelerate/ocl_pyopencl/ocl_kernels_self_contained_for_future_reference.py
@@ -253,7 +253,7 @@ class Fourier_update_kernel(BaseKernel):
         self.queue.finish()
 
     def npy_error_reduce(self, ferr, err_fmag):
-        err_fmag[:] = ferr.astype(np.double).sum(-1).sum(-1).astype(np.float)
+        err_fmag[:] = ferr.astype(np.double).sum(-1).sum(-1).astype(float)
 
     def ocl_error_reduce(self, ferr, err_fmag):
         shape = (self.fshape[0], 64),

--- a/ptypy/core/sample.py
+++ b/ptypy/core/sample.py
@@ -361,7 +361,7 @@ def simulate(A, pars, energy, fill=1.0, prefix="", **kwargs):
         logger.info(prefix +
                     "Simulation resource is a thickness profile")
         # Enforce floats
-        ob = obj.astype(np.float)
+        ob = obj.astype(float)
         ob -= ob.min()
         if d is not None:
             logger.info(prefix + "Rescaling to maximum thickness")

--- a/ptypy/core/xy.py
+++ b/ptypy/core/xy.py
@@ -152,7 +152,7 @@ def _complete(extent, steps, spacing):
     elif steps is None:
         e = u.expect2(extent)
         s = u.expect2(spacing)
-        l = (e / s).astype(np.int)
+        l = (e / s).astype(int)
     elif spacing is None:
         e = u.expect2(extent)
         l = u.expect2(steps)

--- a/ptypy/custom/ePIE_parallel.py
+++ b/ptypy/custom/ePIE_parallel.py
@@ -179,7 +179,7 @@ class EPIEParallel(BaseEngine):
             if pod.active:
                 self.ob_nodecover[pod.ob_view] = 1
         self.nodemask = np.array(list(self.ob_nodecover.S.values())[0].data[0],
-                                 dtype=np.bool)
+                                 dtype=bool)
 
         # communicate this over MPI
         parallel.allreduceC(self.ob_nodecover)

--- a/ptypy/engines/Bragg3d_engines.py
+++ b/ptypy/engines/Bragg3d_engines.py
@@ -167,7 +167,7 @@ class DM_3dBragg(DM):
                 r = np.sqrt((x_ - xcenter)**2 + (y_ - ycenter)**2)
                 scaling = np.min(geo.resolution)
                 r /= scaling
-                r = r.astype(np.int)
+                r = r.astype(int)
                 tbin = np.bincount(r.ravel(), arr.ravel())
                 nr = np.bincount(r.ravel())
                 s = np.arange(len(tbin)) * scaling

--- a/ptypy/experiment/cSAXS.py
+++ b/ptypy/experiment/cSAXS.py
@@ -100,7 +100,7 @@ class cSAXSScan(PtyScan):
     def load(self, indices):
         raw = {}
         for i in indices:
-            raw[i] = self.data_object.getframe(i).data.astype(np.float)
+            raw[i] = self.data_object.getframe(i).data.astype(float)
         return raw, {}, {}
 
 

--- a/ptypy/experiment/optiklabor.py
+++ b/ptypy/experiment/optiklabor.py
@@ -134,7 +134,7 @@ class FliSpecScanMultexp(PtyScan):
         exposures =[]
         for j in range(self.nexp):
             darks,meta = u.image_read(self.info.dark_dir + '/ccd*_%02d.raw' % j)
-            dark_imgs.append(np.array(darks,dtype=np.float).mean(0))
+            dark_imgs.append(np.array(darks,dtype=float).mean(0))
             exposures.append(meta[0][self.exp_string])
 
         # save in common dict/Param

--- a/ptypy/simulations/detector.py
+++ b/ptypy/simulations/detector.py
@@ -109,20 +109,20 @@ class Detector(object):
 
     def _make_mask(self):
         gaps = expect2(self.gaps)
-        module = np.ones(self.shape).astype(np.bool)
+        module = np.ones(self.shape).astype(bool)
         start = module.copy()
         for i in range(self.modules[0]-1):
-            gap = np.zeros((gaps[0],module.shape[1])).astype(np.bool)
+            gap = np.zeros((gaps[0],module.shape[1])).astype(bool)
             start = np.concatenate([start,np.concatenate([gap,module],axis=0)],axis=0)
         module = start.copy()
         for i in range(self.modules[1]-1):
-            gap = np.zeros((module.shape[0],gaps[1])).astype(np.bool)
+            gap = np.zeros((module.shape[0],gaps[1])).astype(bool)
             start = np.concatenate([start,np.concatenate([gap,module],axis=1)],axis=1)
         self._mask = start
 
     def _get_mask(self,sh):
         msh =  expect2(sh[-2:])
-        mask = np.zeros(msh).astype(np.bool)
+        mask = np.zeros(msh).astype(bool)
         offset = msh//2 - expect2(self.center)
         mask = fill2D(mask,self._mask,-offset)
         return np.resize(mask,sh)

--- a/ptypy/utils/misc.py
+++ b/ptypy/utils/misc.py
@@ -341,7 +341,7 @@ def clean_path(filename):
 
 
 def electron_wavelength(electron_energy):
-    """
+    r"""
     Calculate electron wavelength based on energy in keV:
 
     .. math::

--- a/ptypy/utils/scripts.py
+++ b/ptypy/utils/scripts.py
@@ -147,7 +147,7 @@ def hdr_image(img_list, exp_list, thresholds=[3000,50000], dark_list=[],
     img_list = [img.astype(float) for img in img_list]
     dark_list = [dark.astype(float) for dark in dark_list]
     exp_list = [float(exp) for exp in exp_list]
-    mask_list = [mask.astype(np.int) for mask in mask_list]
+    mask_list = [mask.astype(int) for mask in mask_list]
 
     for img, dark, exp,mask in zip(img_list, dark_list,exp_list,mask_list):
         img[:] = abs(img - dark)
@@ -177,7 +177,7 @@ def hdr_image(img_list, exp_list, thresholds=[3000,50000], dark_list=[],
                                                  ix[j]][themask.astype(bool)]
                                              * max_exp/exp_list[ix[j]])
     else:
-        mask_sum = np.zeros_like(mask_list[0]).astype(np.int)
+        mask_sum = np.zeros_like(mask_list[0]).astype(int)
         img_hdr = np.zeros_like(img_list[0])
         for img, exp, mask in zip(img_list,exp_list,mask_list):
             img = img * max_exp/exp

--- a/test/template_tests/prep_and_run_moonflower_test.py
+++ b/test/template_tests/prep_and_run_moonflower_test.py
@@ -33,7 +33,6 @@ class PrepAndRunMoonFlowerTest(unittest.TestCase):
         p.engines.engine00.name = 'DM'
         p.engines.engine00.numiter = 5
         P = Ptycho(p,level=5)
-        return P
 
     def test_dm_multiple_probes(self):
         p = u.Param()
@@ -67,7 +66,6 @@ class PrepAndRunMoonFlowerTest(unittest.TestCase):
         p.engines.engine00.numiter = 5
         p.engines.engine00.fourier_relax_factor = 0.05
         P = Ptycho(p,level=5)
-        return P
 
     def test_dm_resample(self):
         p = u.Param()
@@ -97,7 +95,6 @@ class PrepAndRunMoonFlowerTest(unittest.TestCase):
         p.engines.engine00.name = 'DM'
         p.engines.engine00.numiter = 5
         P = Ptycho(p,level=5)
-        return P
 
     def test_ml_single_probe(self):
         p = u.Param()
@@ -134,7 +131,6 @@ class PrepAndRunMoonFlowerTest(unittest.TestCase):
         p.engines.engine00.floating_intensities = False
         p.engines.engine00.numiter = 5
         P = Ptycho(p,level=5)
-        return P
 
     def test_ml_resample(self):
         p = u.Param()
@@ -172,7 +168,6 @@ class PrepAndRunMoonFlowerTest(unittest.TestCase):
         p.engines.engine00.floating_intensities = False
         p.engines.engine00.numiter = 5
         P = Ptycho(p,level=5)
-        return P
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Python 3.7 reaches end of its life-cycle, no need to support any longer.
- Replaced deprecated data types, i.e. np.float -> float, np.int -> int, np.bool -> bool
- Removed specific Python version from dependencies files.
- Fixed a few more deprecation issues
- Removed MPI version from Github actions test pipeline (not required).