### PR TITLE
Changes in numpy 1.25

### DIFF
--- a/archive/cuda_extension/python/gpu_extension.pyx
+++ b/archive/cuda_extension/python/gpu_extension.pyx
@@ -153,7 +153,7 @@ def abs2(input):
     cdef np.float32_t [:,:,::1] cout_3c
     cdef np.float64_t [:,::1] cout_d2c
     cdef np.float64_t [:,:,::1] cout_d3c
-    cdef int n = np.product(cin.shape)
+    cdef int n = np.prod(cin.shape)
 
     cdef np.float32_t [:, ::1] cin_f2c
     cdef np.complex64_t [:, ::1] cin_c2c

--- a/benchmark/mpi_allreduce_speed.py
+++ b/benchmark/mpi_allreduce_speed.py
@@ -11,7 +11,7 @@ sizes ={
 }
 
 def run_benchmark(shape):
-    megabytes = np.product(shape) * 8 / 1024 / 1024 * 2
+    megabytes = np.prod(shape) * 8 / 1024 / 1024 * 2
 
     data = np.zeros(shape, dtype=np.complex64)
     

--- a/ptypy/accelerate/cuda_cupy/array_utils.py
+++ b/ptypy/accelerate/cuda_cupy/array_utils.py
@@ -279,15 +279,15 @@ class DerivativesKernel:
             self.queue.use()
 
         if axis == input.ndim - 1:
-            flat_dim = np.int32(np.product(input.shape[0:-1]))
+            flat_dim = np.int32(np.prod(input.shape[0:-1]))
             self.delxf_last((
                 int((flat_dim +
                      self.last_axis_block[1] - 1) // self.last_axis_block[1]),
                 1, 1),
                 self.last_axis_block, (input, out, flat_dim, np.int32(input.shape[axis])))
         else:
-            lower_dim = np.int32(np.product(input.shape[(axis+1):]))
-            higher_dim = np.int32(np.product(input.shape[:axis]))
+            lower_dim = np.int32(np.prod(input.shape[(axis+1):]))
+            higher_dim = np.int32(np.prod(input.shape[:axis]))
             gx = int(
                 (lower_dim + self.mid_axis_block[0] - 1) // self.mid_axis_block[0])
             gy = 1
@@ -306,14 +306,14 @@ class DerivativesKernel:
         if self.queue is not None:
             self.queue.use()
         if axis == input.ndim - 1:
-            flat_dim = np.int32(np.product(input.shape[0:-1]))
+            flat_dim = np.int32(np.prod(input.shape[0:-1]))
             self.delxb_last((
                 int((flat_dim +
                      self.last_axis_block[1] - 1) // self.last_axis_block[1]),
                 1, 1), self.last_axis_block, (input, out, flat_dim, np.int32(input.shape[axis])))
         else:
-            lower_dim = np.int32(np.product(input.shape[(axis+1):]))
-            higher_dim = np.int32(np.product(input.shape[:axis]))
+            lower_dim = np.int32(np.prod(input.shape[(axis+1):]))
+            higher_dim = np.int32(np.prod(input.shape[:axis]))
             gx = int(
                 (lower_dim + self.mid_axis_block[0] - 1) // self.mid_axis_block[0])
             gy = 1

--- a/ptypy/accelerate/cuda_cupy/cufft.py
+++ b/ptypy/accelerate/cuda_cupy/cufft.py
@@ -23,7 +23,7 @@ class FFT_cuda(object):
         if rows != columns or rows not in [16, 32, 64, 128, 256, 512, 1024, 2048]:
             raise ValueError(
                 "CUDA FFT only supports powers of 2 for rows/columns, from 16 to 2048")
-        self.batches = int(np.product(
+        self.batches = int(np.prod(
             array.shape[0:dims-2]) if dims > 2 else 1)
         self.forward = forward
 

--- a/ptypy/accelerate/cuda_pycuda/array_utils.py
+++ b/ptypy/accelerate/cuda_pycuda/array_utils.py
@@ -270,7 +270,7 @@ class DerivativesKernel:
         axis = np.int32(axis)
 
         if axis == input.ndim - 1:
-            flat_dim = np.int32(np.product(input.shape[0:-1]))
+            flat_dim = np.int32(np.prod(input.shape[0:-1]))
             self.delxf_last(input, out, flat_dim, np.int32(input.shape[axis]),
                             block=self.last_axis_block,
                             grid=(
@@ -280,8 +280,8 @@ class DerivativesKernel:
                 stream=self.queue
             )
         else:
-            lower_dim = np.int32(np.product(input.shape[(axis+1):]))
-            higher_dim = np.int32(np.product(input.shape[:axis]))
+            lower_dim = np.int32(np.prod(input.shape[(axis+1):]))
+            higher_dim = np.int32(np.prod(input.shape[:axis]))
             gx = int(
                 (lower_dim + self.mid_axis_block[0] - 1) // self.mid_axis_block[0])
             gy = 1
@@ -301,7 +301,7 @@ class DerivativesKernel:
         axis = np.int32(axis)
 
         if axis == input.ndim - 1:
-            flat_dim = np.int32(np.product(input.shape[0:-1]))
+            flat_dim = np.int32(np.prod(input.shape[0:-1]))
             self.delxb_last(input, out, flat_dim, np.int32(input.shape[axis]),
                             block=self.last_axis_block,
                             grid=(
@@ -311,8 +311,8 @@ class DerivativesKernel:
                 stream=self.queue
             )
         else:
-            lower_dim = np.int32(np.product(input.shape[(axis+1):]))
-            higher_dim = np.int32(np.product(input.shape[:axis]))
+            lower_dim = np.int32(np.prod(input.shape[(axis+1):]))
+            higher_dim = np.int32(np.prod(input.shape[:axis]))
             gx = int(
                 (lower_dim + self.mid_axis_block[0] - 1) // self.mid_axis_block[0])
             gy = 1

--- a/ptypy/accelerate/cuda_pycuda/cufft.py
+++ b/ptypy/accelerate/cuda_pycuda/cufft.py
@@ -21,7 +21,7 @@ class FFT_cuda(object):
         columns = self.arr_shape[1]
         if rows != columns or rows not in [16, 32, 64, 128, 256, 512, 1024, 2048]:
             raise ValueError("CUDA FFT only supports powers of 2 for rows/columns, from 16 to 2048")
-        self.batches = int(np.product(array.shape[0:dims-2]) if dims > 2 else 1)
+        self.batches = int(np.prod(array.shape[0:dims-2]) if dims > 2 else 1)
         self.forward = forward
 
         self._load(array, pre_fft, post_fft, symmetric, forward)
@@ -121,11 +121,11 @@ class FFT_skcuda(FFT_cuda):
         )
         # with cuFFT, we need to scale ifft
         if not symmetric and not forward:
-            self.scale = 1 / np.product(self.arr_shape)
+            self.scale = 1 / np.prod(self.arr_shape)
         elif forward and not symmetric:
             self.scale = 1.0
         else:
-            self.scale = 1 / np.sqrt(np.product(self.arr_shape))
+            self.scale = 1 / np.sqrt(np.prod(self.arr_shape))
 
         if pre_fft is not None:
             self.pre_fft = gpuarray.to_gpu(pre_fft)

--- a/ptypy/experiment/diamond_nexus.py
+++ b/ptypy/experiment/diamond_nexus.py
@@ -214,18 +214,18 @@ class DiamondNexus(PtyScan):
 
 
         if None not in [INPUT_FILE, ENERGY_KEY]:
-            self.p.energy = float(h5.File(INPUT_FILE, 'r')[ENERGY_KEY][()] * self.ENERGY_MULTIPLIER)
+            self.p.energy = float(h5.File(INPUT_FILE, 'r')[ENERGY_KEY][()].item() * self.ENERGY_MULTIPLIER)
             self.meta.energy  = self.p.energy
             log(3, "loading energy={} from file".format(self.p.energy))
 
 
         if None not in [INPUT_FILE, DISTANCE_KEY]:
-            self.p.distance = h5.File(INPUT_FILE, 'r')[DISTANCE_KEY][()]
+            self.p.distance = h5.File(INPUT_FILE, 'r')[DISTANCE_KEY][()].item()
             self.meta.distance = self.p.distance
             log(3, "loading distance={} from file".format(self.p.distance))
         
         if None not in [INPUT_FILE, PIXEL_SIZE_KEY]:
-            self.p.psize = h5.File(INPUT_FILE, 'r')[PIXEL_SIZE_KEY][()]
+            self.p.psize = h5.File(INPUT_FILE, 'r')[PIXEL_SIZE_KEY][()].item()
             self.meta.psize = self.p.psize
             log(3, "loading psize={} from file".format(self.p.psize))
 

--- a/ptypy/experiment/hdf5_loader.py
+++ b/ptypy/experiment/hdf5_loader.py
@@ -539,20 +539,20 @@ class Hdf5Loader(PtyScan):
                 if self._is_spectro_scan and self.p.outer_index is not None:
                     self.p.energy = float(f[self.p.recorded_energy.key][self.p.outer_index])
                 else:
-                    self.p.energy = float(f[self.p.recorded_energy.key][()])
+                    self.p.energy = float(f[self.p.recorded_energy.key][()].item())
             self.p.energy = self.p.energy * self.p.recorded_energy.multiplier + self.p.recorded_energy.offset
             self.meta.energy  = self.p.energy
             log(3, "loading energy={} from file".format(self.p.energy))
 
         if None not in [self.p.recorded_distance.file, self.p.recorded_distance.key]:
             with h5.File(self.p.recorded_distance.file, 'r', swmr=self._is_swmr) as f:
-                self.p.distance = float(f[self.p.recorded_distance.key][()] * self.p.recorded_distance.multiplier)
+                self.p.distance = float(f[self.p.recorded_distance.key][()].item() * self.p.recorded_distance.multiplier)
             self.meta.distance = self.p.distance
             log(3, "loading distance={} from file".format(self.p.distance))
         
         if None not in [self.p.recorded_psize.file, self.p.recorded_psize.key]:
             with h5.File(self.p.recorded_psize.file, 'r', swmr=self._is_swmr) as f:
-                self.p.psize = float(f[self.p.recorded_psize.key][()] * self.p.recorded_psize.multiplier)
+                self.p.psize = float(f[self.p.recorded_psize.key][()].item() * self.p.recorded_psize.multiplier)
             self.info.psize = self.p.psize
             log(3, "loading psize={} from file".format(self.p.psize))
 

--- a/ptypy/utils/descriptor.py
+++ b/ptypy/utils/descriptor.py
@@ -853,7 +853,8 @@ class EvalDescriptor(ArgParseDescriptor):
                 (type(pars).__name__ == 'tuple' and 'list' in self.type) or \
                 (type(pars).__name__ == 'list' and 'tuple' in self.type) or \
                 (type(pars).__name__ == 'int' and 'float' in self.type) or \
-                (type(pars).__name__[:5] == 'float' and 'float' in self.type):
+                (type(pars).__name__[:5] == 'float' and 'float' in self.type) or \
+                (type(pars).__name__ == 'longdouble' and 'float' in self.type):
             yield {'d': self, 'path': path, 'status': 'ok', 'info': ''}
         else:
             yield {'d': self, 'path': path, 'status': 'wrongtype', 'info': type(pars).__name__}


### PR DESCRIPTION
**Bugfix**: From numpy 1.25 `type(np.float128)` results in `<class 'numpy.longdouble'>` instead of `<class 'numpy.float128'>` which breaks the type check in the validator. As a quick fix, have added additional check for  `type(pars).__name__ == longdouble`.

**Other changes**
- converted size-1 numpy arrays to scalars to avoid deprecation warnings.
- replaced `np.product` (which is deprecated from numpy 2.0) with `np.prod`