### PR TITLE
Add new kind to save all used params into .ptyr

### DIFF
--- a/ptypy/core/ptycho.py
+++ b/ptypy/core/ptycho.py
@@ -155,7 +155,8 @@ class Ptycho(Base):
     doc = Choose a reconstruction file format for after engine completion.
        - ``'minimal'``: Bare minimum of information
        - ``'dls'``:    Custom format for Diamond Light Source
-    choices = 'minimal','dls'
+       - ``'used_params'``: Same as minimal but including all used parameters 
+    choices = 'minimal','dls','used_params'
 
     [io.interaction]
     default = None
@@ -987,7 +988,7 @@ class Ptycho(Base):
 
                 content = dump
 
-            elif kind == 'minimal' or kind == 'dls':
+            elif kind in ('minimal', 'dls', 'used_params'):
                 # if self.interactor is not None:
                 #    self.interactor.stop()
                 logger.info('Generating shallow copies of probe, object and '
@@ -1002,7 +1003,7 @@ class Ptycho(Base):
                     defaults_tree['ptycho'].validate(self.p) # check the parameters are actually able to be read back in
                 except RuntimeError:
                     logger.warning("The parameters we are saving won't pass a validator check!")
-                minimal.pars = self.p.copy()  # _to_dict(Recursive=True)
+                minimal.pars = self.p.copy(depth=99)  # _to_dict(Recursive=True)
                 minimal.runtime = self.runtime.copy()
 
                 content = minimal
@@ -1015,6 +1016,13 @@ class Ptycho(Base):
 
                 for ID, S in self.obj.storages.items():
                     content.obj[ID]['grids'] = S.grids()
+
+            if kind == 'used_params':
+                for name, engine in self.engines.items():
+                    content.pars.engines[name] = engine.p
+                for name, scan in self.model.scans.items():
+                    content.pars.scans[name] = scan.p
+                    content.pars.scans[name].data = scan.ptyscan.p
 
             if kind in ['minimal', 'dls'] and self.record_positions:
                 content.positions = {}


### PR DESCRIPTION
This solves #488 by making a new saving format "used_params" which gets the actually used parameter from the engines/scanmodel classes and saves them into the .ptyr file. Use `p.io.rformat = "used_params"` for this functionality.