### PR TITLE
if refined positions are saved, they are also saved to dump files

### DIFF
--- a/ptypy/core/ptycho.py
+++ b/ptypy/core/ptycho.py
@@ -989,6 +989,11 @@ class Ptycho(Base):
                 if len(self.runtime.iter_info) > 0:
                     dump.runtime.iter_info = [self.runtime.iter_info[-1]]
 
+                if self.record_positions:
+                    dump.positions = {}
+                    for ID, S in self.obj.storages.items():
+                        dump.positions[ID] = np.array([v.coord for v in S.views if v.pod.pr_view.layer==0])
+
                 content = dump
 
             elif kind == 'minimal' or kind == 'dls':


### PR DESCRIPTION
When position correction is used within an engine, up to now, the refined positions were only saved in the last/reconstruction file written by that engine. As it can be interesting to track the refinement process of the scan positions over the iterations, it would be nice to also have the possibility to save the refined positions to the dump files.

The changes to ptypy/core/ptycho.py accomplish just this. Once the record_positions parameter is set, dump files also get filled with the positions. By default this parameter is still set to False. So it is a conscious decision by the user to have the positions saved.