### PR TITLE
Raise megapixel limit to 500

### DIFF
--- a/ptypy/core/classes.py
+++ b/ptypy/core/classes.py
@@ -81,7 +81,7 @@ GEO_PREFIX = 'G'
 
 # Hard-coded limit in array size
 # TODO: make this dynamic from available memory.
-MEGAPIXEL_LIMIT = 500
+MEGAPIXEL_LIMIT = 100
 
 
 class Base(object):
@@ -709,8 +709,8 @@ class Storage(Base):
 
             megapixels = np.array(new_shape).astype(float).prod() / 1e6
             if megapixels > MEGAPIXEL_LIMIT:
-                raise RuntimeError('Arrays larger than %dM not supported. You '
-                                   'requested %.2fM pixels.' % (MEGAPIXEL_LIMIT, megapixels))
+                logger.warning('Arrays larger than %dM not supported. You '
+                               'requested %.2fM pixels.' % (MEGAPIXEL_LIMIT, megapixels))
 
             # Apply Nd misfit
             if self.data is not None:

--- a/ptypy/core/classes.py
+++ b/ptypy/core/classes.py
@@ -709,7 +709,7 @@ class Storage(Base):
 
             megapixels = np.array(new_shape).astype(float).prod() / 1e6
             if megapixels > MEGAPIXEL_LIMIT:
-                logger.warning('Arrays larger than %dM not supported. You '
+                logger.warning('Arrays larger than %dM not recommended. You '
                                'requested %.2fM pixels.' % (MEGAPIXEL_LIMIT, megapixels))
 
             # Apply Nd misfit

--- a/ptypy/core/classes.py
+++ b/ptypy/core/classes.py
@@ -81,7 +81,7 @@ GEO_PREFIX = 'G'
 
 # Hard-coded limit in array size
 # TODO: make this dynamic from available memory.
-MEGAPIXEL_LIMIT = 50
+MEGAPIXEL_LIMIT = 500
 
 
 class Base(object):

--- a/test/core_tests/classes_test.py
+++ b/test/core_tests/classes_test.py
@@ -98,7 +98,7 @@ class TestDefaultParameters(unittest.TestCase):
         self.assertEqual(c.GEO_PREFIX, 'G',
                          'Default prefix changed.')
 
-        self.assertEqual(c.MEGAPIXEL_LIMIT, 500,
+        self.assertEqual(c.MEGAPIXEL_LIMIT, 100,
                          'Default MEGAPIXEL_LIMIT changed.')
 
 

--- a/test/core_tests/classes_test.py
+++ b/test/core_tests/classes_test.py
@@ -98,7 +98,7 @@ class TestDefaultParameters(unittest.TestCase):
         self.assertEqual(c.GEO_PREFIX, 'G',
                          'Default prefix changed.')
 
-        self.assertEqual(c.MEGAPIXEL_LIMIT, 50,
+        self.assertEqual(c.MEGAPIXEL_LIMIT, 500,
                          'Default MEGAPIXEL_LIMIT changed.')
 
 


### PR DESCRIPTION
This is a quick change in response to #511 - we should probably make this into a parameter or define dynamically based on available memory.