### PR TITLE
Cast mask to float32 to avoid precision issue 

### DIFF
--- a/ptypy/engines/utils.py
+++ b/ptypy/engines/utils.py
@@ -341,7 +341,7 @@ def basic_fourier_update_LEGACY(diff_view, pbound=None, alpha=1., LL_error=True)
     I = diff_view.data
 
     # Get the mask
-    fmask = diff_view.pod.mask
+    fmask = diff_view.pod.mask.astype(I.dtype)
 
     # For log likelihood error
     if LL_error is True:

--- a/ptypy/engines/utils.py
+++ b/ptypy/engines/utils.py
@@ -20,7 +20,7 @@ def dynamic_load(path, baselist, fail_silently = True):
 
     :param path: Path to Python files.
     """
-    
+
     import os
     import glob
     import re
@@ -28,40 +28,40 @@ def dynamic_load(path, baselist, fail_silently = True):
 
     # Loop through paths
     engine_path = {}
-    
+
     try:
         # Complete directory path
         directory = os.path.abspath(os.path.expanduser(path))
-    
+
         if not os.path.exists(directory):
             # Continue silently
             raise IOError('Engine path %s does not exist.'
                            % str(directory))
-    
+
         # Get list of python files
         py_files = glob.glob(directory + '/*.py')
         if not py_files:
-            raise IOError('Directory %s does not contain Python files,' 
+            raise IOError('Directory %s does not contain Python files,'
                                             % str(directory))
-    
+
         # Loop through files to find engines
         for filename in py_files:
             modname = os.path.splitext(os.path.split(filename)[-1])[0]
-    
+
             # Find classes
             res = re.findall(
                 r'^class (.*)\((.*)\)', open(filename, 'r').read(), re.M)
-    
+
             for classname, basename in res:
                 if (basename in baselist) and classname not in baselist:
                     # Match!
                     engine_path[classname] = (modname, filename)
                     u.logger.info("Found Engine '%s' in file '%s'"
                                   % (classname, filename))
-    
+
         # Load engines that have been found
         for classname, mf in engine_path.items():
-    
+
             # Import module
             modname, filename = mf
             print(modname, filename)
@@ -115,7 +115,7 @@ def projection_update_generalized(diff_view, a, b, c, pbound=None):
     .. math::
         x = 1 - a - b
 
-    and 
+    and
 
     .. math::
        y = 1 - c
@@ -158,8 +158,9 @@ def projection_update_generalized(diff_view, a, b, c, pbound=None):
     # Get measured data
     I = diff_view.data
 
-    # Get the mask
-    fmask = diff_view.pod.mask
+    # Get the mask (cast to the same type as diff, for precision when operating
+    # with other numerical arrays)
+    fmask = diff_view.pod.mask.astype(I.dtype)
 
     # Propagate the exit waves
     for name, pod in diff_view.pods.items():

--- a/test/engine_tests/engine_utils_test.py
+++ b/test/engine_tests/engine_utils_test.py
@@ -7,7 +7,6 @@ This file is part of the PTYPY package.
 """
 
 import unittest
-from test import utils as tu
 import numpy as np
 from ptypy import utils as u
 from ptypy.core import Ptycho


### PR DESCRIPTION
This PR changes the data type of `diff_view.pod.mask` to the same with the measured data before any further operation, instead of using `bool`, which will implicitly be cast to `np.float64`. Mixing data type results in precision issues afterwards, such as the calculation [here](https://github.com/ptycho/ptypy/blob/2ab0bb42db962a32aa839aead5fedd7cfa75bf1a/ptypy/engines/utils.py#L234).

This also matches the data type used in [serial](https://github.com/ptycho/ptypy/blob/2ab0bb42db962a32aa839aead5fedd7cfa75bf1a/ptypy/accelerate/base/engines/stochastic.py#L149) and [pycuda](https://github.com/ptycho/ptypy/blob/2ab0bb42db962a32aa839aead5fedd7cfa75bf1a/ptypy/accelerate/cuda_pycuda/engines/stochastic.py#L206) version.

This following small script illustrates the casting:

```python
import numpy as np


def fm_nopbound(fmask, fmag, af, eps=1e-10):
    return (1 - fmask) + fmask * fmag / (af + eps)

if __name__ == '__main__':
    # define testing data shape
    data_sh = (64, 64)

    # get some random data
    rng = np.random.default_rng(721)
    fmag = rng.random(data_sh, dtype=np.float32) * 1000
    af = rng.random(data_sh, dtype=np.float32) * 200

    # define fmask with different data type
    fmask_bool = np.ones(data_sh, dtype=bool)
    fmask_f32 = np.ones(data_sh, dtype=np.float32)

    # calculate fm with different data type of fmask
    fm_bool = fm_nopbound(fmask_bool, fmag, af) # this casts to float64
    fm_f32 = fm_nopbound(fmask_f32, fmag, af) # this remains as float32

    print(f'fm_bool dtype: {fm_bool.dtype}')
    print(f'fm_f32 dtype: {fm_f32.dtype}')

    # further operation results in precision issue due to different data type
    ...

```