### PR TITLE
Reset parallel.loadmanager in EngineTestRunner after every data loading

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -16,6 +16,7 @@ import tempfile
 import numpy as np
 from ptypy import utils as u
 from ptypy.core import Ptycho
+from ptypy.utils import parallel
 
 
 def get_test_data_path(name):
@@ -76,6 +77,11 @@ def EngineTestRunner(engine_params,propagator='farfield',output_path='./', outpu
     if init_correct_probe:
         P.probe.S['SMFG00'].data[0] = P.model.scans['MF'].ptyscan.pr
     P.run()
+
+    # important for subdividing data, ensure a fresh start if a test will be
+    # run afterwards
+    parallel.loadmanager.reset()
+
     return P
 
 
@@ -164,4 +170,9 @@ def EngineTestRunner2(engine_params,propagator='farfield',output_path='./', outp
     p.engines.engine00 = engine_params
     P = Ptycho(p, level=4)
     P.run()
+
+    # important for subdividing data, ensure a fresh start if a test will be
+    # run afterwards
+    parallel.loadmanager.reset()
+
     return P


### PR DESCRIPTION
This PR resets `parallel.loadmanager` after a test running through `EngineTestRunner` is completed, ensuring the sub-division of data is consistent among tests. 

This is necessary because when the [data is divided into blocks](https://github.com/ptycho/ptypy/blob/2ab0bb42db962a32aa839aead5fedd7cfa75bf1a/ptypy/core/data.py#L639), it uses the same instance of `parallel.loadmanager` and the [calculation of `partition`](https://github.com/ptycho/ptypy/blob/2ab0bb42db962a32aa839aead5fedd7cfa75bf1a/ptypy/utils/parallel.py#L124) depends on `self.load`, which has been [modified in-place](https://github.com/ptycho/ptypy/blob/2ab0bb42db962a32aa839aead5fedd7cfa75bf1a/ptypy/utils/parallel.py#L138) by the previous loading. This is fine for normal reconstruction (not strictly for stochastic-type however), but not for comparing among tests when consistency is desired.

This small script using the `MoonFlowerScan` scan illustrates the difference:
```python
from ptypy import utils as u
from ptypy.core import Ptycho
from ptypy.utils import parallel


def construct(reset=False):
    p = u.Param()
    p.scans = u.Param()
    p.scans.MF = u.Param()
    p.scans.MF.name = 'BlockFull'
    p.scans.MF.propagation = 'farfield'
    p.scans.MF.data = u.Param()
    p.scans.MF.data.name = 'MoonFlowerScan'
    p.scans.MF.data.num_frames = 200

    P = Ptycho(p, level=2)

    if reset:
        parallel.loadmanager.reset()

    return P

if __name__ == '__main__':
    for _ in range(5):
        P = construct(reset=False)
        active = [p.active for _, p in P.pods.items()]
        print(f'[{parallel.rank}] {sum(active)}')
        parallel.barrier()
        if parallel.master:
            print('----------')
        parallel.barrier()
```
When executing with 4 MPI ranks, you would get something similar to this:
```
[1] 40
[2] 40
[3] 41
[0] 40
----------
[3] 40
[1] 40
[2] 41
[0] 40
----------
[2] 40
[3] 40
[1] 41
[0] 40
----------
[2] 40
[3] 40
[0] 41
[1] 40
----------
[1] 40
[3] 41
[2] 40
[0] 40
----------
```
Note the number 41, the number of active pods, belongs to different rank when this is executed sequentially in a for-loop. This should not happen in testing. Changing to `reset=True` in the above script givies
```
[0] 40
[3] 41
[1] 40
[2] 40
----------
[3] 41
[1] 40
[2] 40
[0] 40
----------
[2] 40
[3] 41
[0] 40
[1] 40
----------
[2] 40
[1] 40
[0] 40
[3] 41
----------
[3] 41
[1] 40
[0] 40
[2] 40
----------
```
