### PR TITLE
Some precision improvements for serial kernels 

### DIFF
--- a/ptypy/accelerate/base/kernels.py
+++ b/ptypy/accelerate/base/kernels.py
@@ -443,11 +443,12 @@ class AuxiliaryWaveKernel(BaseKernel):
         aux = b_aux[:maxz * nmodes]
         flat_addr = addr.reshape(maxz * nmodes, sh[2], sh[3])
         rows, cols = ex.shape[-2:]
+
         for ind, (prc, obc, exc, mac, dic) in enumerate(flat_addr):
-            tmp = ob[obc[0], obc[1]:obc[1] + rows, obc[2]:obc[2] + cols] * \
-                  pr[prc[0], :, :] * c_po + \
-                  ex[exc[0], exc[1]:exc[1] + rows, exc[2]:exc[2] + cols] * c_e
+            tmp = (1-c_po) * ex[exc[0], exc[1]:exc[1] + rows, exc[2]:exc[2] + cols] +\
+                  c_po * pr[prc[0], :, :] * ob[obc[0], obc[1]:obc[1] + rows, obc[2]:obc[2] + cols]
             aux[ind, :, :] = tmp
+
         return
 
     def build_exit(self, b_aux, addr, ob, pr, ex, alpha=1):

--- a/ptypy/accelerate/base/kernels.py
+++ b/ptypy/accelerate/base/kernels.py
@@ -65,7 +65,7 @@ class FourierUpdateKernel(BaseKernel):
         # build model from complex fourier magnitudes, summing up 
         # all modes incoherently
         tf = aux.reshape(maxz, self.nmodes, sh[1], sh[2])
-        af = np.sqrt((np.abs(tf) ** 2).sum(1))
+        af = np.sqrt(abs2(tf).sum(1))
 
         # calculate difference to real data (g_mag)
         fdev[:] = af - mag
@@ -89,7 +89,7 @@ class FourierUpdateKernel(BaseKernel):
         # build model from complex fourier magnitudes, summing up 
         # all modes incoherently
         tf = aux.reshape(maxz, self.nmodes, sh[1], sh[2])
-        af = np.sqrt((np.abs(tf) ** 2).sum(1))
+        af = np.sqrt(abs2(tf).sum(1))
 
         # calculate difference to real data (g_mag)
         fdev[:] = af - mag

--- a/ptypy/accelerate/base/kernels.py
+++ b/ptypy/accelerate/base/kernels.py
@@ -33,7 +33,6 @@ class FourierUpdateKernel(BaseKernel):
         # temporary buffer arrays
         self.npy.fdev = None
         self.npy.ferr = None
-        self.npy.af = None
 
         self.kernels = [
             'fourier_error',
@@ -49,7 +48,6 @@ class FourierUpdateKernel(BaseKernel):
         # temporary buffer arrays
         self.npy.fdev = np.zeros(self.fshape, dtype=np.float32)
         self.npy.ferr = np.zeros(self.fshape, dtype=np.float32)
-        self.npy.af = np.zeros(self.fshape, dtype=np.float32)
 
     def fourier_error(self, b_aux, addr, mag, mask, mask_sum):
         # reference shape (write-to shape)
@@ -68,9 +66,6 @@ class FourierUpdateKernel(BaseKernel):
         # all modes incoherently
         tf = aux.reshape(maxz, self.nmodes, sh[1], sh[2])
         af = np.sqrt(abs2(tf).sum(1))
-
-        # store it to avoid re-calculate later
-        self.npy.af[:maxz] = af
 
         # calculate difference to real data (g_mag)
         fdev[:] = af - mag
@@ -95,9 +90,6 @@ class FourierUpdateKernel(BaseKernel):
         # all modes incoherently
         tf = aux.reshape(maxz, self.nmodes, sh[1], sh[2])
         af = np.sqrt(abs2(tf).sum(1))
-
-        # store it to avoid re-calculate later
-        self.npy.af[:maxz] = af
 
         # calculate difference to real data (g_mag)
         fdev[:] = af - mag
@@ -156,7 +148,7 @@ class FourierUpdateKernel(BaseKernel):
         renorm[ind] = np.sqrt(pbound / err_sum[ind])
         renorm = renorm.reshape((renorm.shape[0], 1, 1))
 
-        af = self.npy.af[:maxz]
+        af = fdev + mag
         fm[:] = (1 - mask) + mask * (mag + fdev * renorm) / (af + self.denom)
 
         #fm[:] = mag / (af + 1e-6)
@@ -184,8 +176,7 @@ class FourierUpdateKernel(BaseKernel):
         # local values
         fm = np.ones((maxz, sh[1], sh[2]), np.float32)
 
-        af = self.npy.af[:maxz]
-
+        af = fdev + mag
         fm[:] = (1 - mask) + mask * mag / (af + self.denom)
 
         # upcasting

--- a/ptypy/accelerate/base/kernels.py
+++ b/ptypy/accelerate/base/kernels.py
@@ -25,7 +25,7 @@ class FourierUpdateKernel(BaseKernel):
     def __init__(self, aux, nmodes=1):
 
         super(FourierUpdateKernel, self).__init__()
-        self.denom = 1e-7
+        self.denom = 1e-10
         self.nmodes = np.int32(nmodes)
         ash = aux.shape
         self.fshape = (ash[0] // nmodes, ash[1], ash[2])
@@ -220,7 +220,7 @@ class GradientDescentKernel(BaseKernel):
     def __init__(self, aux, nmodes=1):
 
         super(GradientDescentKernel, self).__init__()
-        self.denom = 1e-7
+        self.denom = 1e-10
         self.nmodes = np.int32(nmodes)
         ash = aux.shape
         self.bshape = ash


### PR DESCRIPTION
This PR contains several fixes that improve the precision in some serial kernels to match those in the normal implementation. 

- the same epsilon is used to avoid division by zero, as in [here](https://github.com/ptycho/ptypy/blob/2ab0bb42db962a32aa839aead5fedd7cfa75bf1a/ptypy/engines/utils.py#L221-L227)
- use PtyPy's `abs2` to calculate `af`
- ~~do not re-calculate `af` by `fdev + mag`, but storing it~~
- use the exact same formula to propagate as in [here](https://github.com/ptycho/ptypy/blob/2ab0bb42db962a32aa839aead5fedd7cfa75bf1a/ptypy/engines/utils.py#L168)

The operations above are mathematically the same before and after the changes, but associative property does not generally hold for floating-point arithmetic, so the above changes ensure the implementation in serial kernels can get the same precision with the normal implementation.  

EDIT: Memory is probably more important than precision here, so we don't use additional storage for `af`.