### PR TITLE
Maximise the usage of dynamic shared memory for GaussianSmoothingKernel

### DIFF
--- a/ptypy/accelerate/cuda_cupy/array_utils.py
+++ b/ptypy/accelerate/cuda_cupy/array_utils.py
@@ -334,27 +334,36 @@ class GaussianSmoothingKernel:
         self.blockdim_x = 4
         self.blockdim_y = 16
 
-        # At least 2 blocks per SM
-        self.max_shared_per_block = 48 * 1024 // 2
-        self.max_shared_per_block_complex = self.max_shared_per_block / \
-            2 * np.dtype(np.float32).itemsize
-        self.max_kernel_radius = int(
-            self.max_shared_per_block_complex / self.blockdim_y)
-
+        # explicit opt-in to use the max dynamic shared memory available on the
+        # device for these two kernels
         self.convolution_row = load_kernel(
-            "convolution_row", file="convolution.cu", subs={
+            "convolution_row", file="convolution.cu", use_max_shm_optin=True,
+            subs={
                 'BDIM_X': self.blockdim_x,
                 'BDIM_Y': self.blockdim_y,
                 'DTYPE': self.stype,
                 'MATH_TYPE': self.kernel_type
             })
+
         self.convolution_col = load_kernel(
-            "convolution_col", file="convolution.cu", subs={
+            "convolution_col", file="convolution.cu", use_max_shm_optin=True,
+            subs={
                 'BDIM_X': self.blockdim_y,   # NOTE: we swap x and y in this columns
                 'BDIM_Y': self.blockdim_x,
                 'DTYPE': self.stype,
                 'MATH_TYPE': self.kernel_type
             })
+
+        # At least 2 blocks per SM
+        max_shm = min(self.convolution_row.attributes['max_dynamic_shared_size_bytes'],
+                      self.convolution_col.attributes['max_dynamic_shared_size_bytes'])
+        # 1 kB is reserved by the device
+        self.max_shared_per_block = (max_shm - 1024) // 2
+        self.max_shared_per_block_complex = self.max_shared_per_block / \
+            2 * np.dtype(np.float32).itemsize
+        self.max_kernel_radius = int(
+            self.max_shared_per_block_complex / self.blockdim_y)
+
         # pre-allocate kernel memory on gpu, with max-radius to accomodate
         dtype = np.float32 if self.kernel_type == 'float' else np.float64
         self.kernel_gpu = cp.empty((self.max_kernel_radius,), dtype=dtype)


### PR DESCRIPTION
This PR maximises the usage of available dynamic shared memory for a particular GPU device by explicitly opt-in for the `GaussianSmoothingKernel`. Both pycuda and CuPy version are modified, and a flag is added to the respective `load_kernel` function to support this behaviour. The modification of `load_kernel` allows future kernels to utilise the full shared memory capacity, should the need arises.

The benefit of this is that `GaussianSmoothingKernel` is able to support a larger `smooth_gradient`, as the smoothing radius is limited by the 'halo' in the CUDA kernel which uses dynamic shared memory. 

However, **this does not completely solve #497 as it still limits `smooth_gradient`, but it does allow a larger value if your GPU has a shared memory capacity greater than 48 kB**. Smoothing in the reciprocal space #504 will remove this limit. 
