### PR TITLE
Retain context and device memory pool among pycuda engines

### DIFF
--- a/ptypy/accelerate/cuda_pycuda/__init__.py
+++ b/ptypy/accelerate/cuda_pycuda/__init__.py
@@ -4,6 +4,7 @@ import os
 import numpy as np
 import pycuda.driver as cuda
 from pycuda.compiler import SourceModule
+from pycuda.tools import DeviceMemoryPool
 
 from ptypy.utils import parallel
 
@@ -20,6 +21,7 @@ else:
 os.environ['CUDA_DEVICE'] = str(parallel.rank_local)
 
 queue = None
+dev_pool = None
 
 
 def ctx_hook(type, value, tb):
@@ -63,6 +65,16 @@ def get_context(new_queue=False):
         queue = cuda.Stream()
 
     return context, queue
+
+
+def get_dev_pool():
+    global dev_pool
+
+    # retain a single global instance of device memory pool
+    if dev_pool is None:
+        dev_pool = DeviceMemoryPool()
+
+    return dev_pool
 
 
 def load_kernel(name, subs={}, file=None):

--- a/ptypy/accelerate/cuda_pycuda/__init__.py
+++ b/ptypy/accelerate/cuda_pycuda/__init__.py
@@ -40,7 +40,7 @@ def ctx_hook(type, value, tb):
 
 sys.excepthook = ctx_hook
 
-def get_context(new_context=False, new_queue=False):
+def get_context(new_queue=False):
 
     global queue
 
@@ -53,10 +53,9 @@ def get_context(new_context=False, new_queue=False):
             parallel.rank, parallel.rank_local, cuda.Device.count()
         ))
 
-    # create a new primary context through pycuda interface either
-    #     - there is no current context, or
-    #     - when explicitly asked
-    if (context := cuda.Context.get_current()) is None or new_context:
+    # the existing context will always be the primary context, unless
+    # explicitly created elsewhere
+    if (context := cuda.Context.get_current()) is None:
         from pycuda import autoprimaryctx
         context = autoprimaryctx.context
 

--- a/ptypy/accelerate/cuda_pycuda/__init__.py
+++ b/ptypy/accelerate/cuda_pycuda/__init__.py
@@ -1,7 +1,11 @@
+import os
+
+import numpy as np
 import pycuda.driver as cuda
 from pycuda.compiler import SourceModule
-import numpy as np
-import os
+
+from ptypy.utils import parallel
+
 kernel_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'cuda_common'))
 debug_options = ['-O3', '-DNDEBUG', '-lineinfo', '-I' + kernel_dir] # release mode flags
 
@@ -11,33 +15,35 @@ if cuda.get_version()[0] >= 9:
 else:
     debug_options += ['-std=c++11']
 
-context = None
+# ensure pycuda's make_default_context picks up the correct GPU for that rank
+os.environ['CUDA_DEVICE'] = str(parallel.rank_local)
+
 queue = None
+
 
 def get_context(new_context=False, new_queue=False):
 
-    from ptypy.utils import parallel
-
-    global context
     global queue
 
-    if context is None or new_context:
-        cuda.init()
-        if parallel.rank_local >= cuda.Device.count():
-            raise Exception('Local rank must be smaller than total device count, \
-                rank={}, rank_local={}, device_count={}'.format(
-                parallel.rank, parallel.rank_local, cuda.Device.count()
-            ))
-        context = cuda.Device(parallel.rank_local).make_context()
-        context.push()
-        # print("made context %s on rank %s" % (str(context), str(parallel.rank)))
-        # print("The cuda device count on %s is:%s" % (str(parallel.rank),
-        #                                              str(cuda.Device.count())))
-        # print("parallel.rank:%s, parallel.rank_local:%s" % (str(parallel.rank),
-        #                                                     str(parallel.rank_local)))
+    # idempotent anyway
+    cuda.init()
+
+    if parallel.rank_local >= cuda.Device.count():
+        raise Exception('Local rank must be smaller than total device count, \
+            rank={}, rank_local={}, device_count={}'.format(
+            parallel.rank, parallel.rank_local, cuda.Device.count()
+        ))
+
+    # create a new primary context through pycuda interface either
+    #     - there is no current context, or
+    #     - when explicitly asked
+    if (context := cuda.Context.get_current()) is None or new_context:
+        from pycuda import autoprimaryctx
+        context = autoprimaryctx.context
+
     if queue is None or new_queue:
         queue = cuda.Stream()
-    
+
     return context, queue
 
 
@@ -59,9 +65,8 @@ def load_kernel(name, subs={}, file=None):
     escaped = fn.replace("\\", "\\\\")
     kernel = '#line 1 "{}"\n'.format(escaped) + kernel
     mod = SourceModule(kernel, include_dirs=[np.get_include()], no_extern_c=True, options=debug_options)
-    
+
     if isinstance(name, str):
         return mod.get_function(name)
     else:  # tuple
         return tuple(mod.get_function(n) for n in name)
-

--- a/ptypy/accelerate/cuda_pycuda/engines/ML_pycuda.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/ML_pycuda.py
@@ -163,8 +163,6 @@ class ML_pycuda(ML_serial):
         fit = int(mem - 200 * 1024 * 1024) // blk  # leave 200MB room for safety
         if not fit:
             log(1,"Cannot fit memory into device, if possible reduce frames per block. Exiting...")
-            self.context.pop()
-            self.context.detach()
             raise SystemExit("ptypy has been exited.")
 
         # TODO grow blocks dynamically
@@ -301,7 +299,7 @@ class ML_pycuda(ML_serial):
         return err
 
     def position_update(self):
-        """ 
+        """
         Position refinement
         """
         if not self.do_position_refinement or (not self.curiter):
@@ -342,7 +340,7 @@ class ML_pycuda(ML_serial):
                 max_oby = ob.shape[-2] - aux.shape[-2] - 1
                 max_obx = ob.shape[-1] - aux.shape[-1] - 1
 
-                # We need to re-calculate the current error 
+                # We need to re-calculate the current error
                 PCK.build_aux(aux, addr, ob, pr)
                 PROP.fw(aux, aux)
                 PCK.queue.wait_for_event(ev)
@@ -351,9 +349,9 @@ class ML_pycuda(ML_serial):
                 cuda.memcpy_dtod(dest=error_state.ptr,
                                     src=err_phot.ptr,
                                     size=err_phot.nbytes)
-                
+
                 PCK.mangler.setup_shifts(self.curiter, nframes=addr.shape[0])
-                                
+
                 log(4, 'Position refinement trial: iteration %s' % (self.curiter))
                 for i in range(PCK.mangler.nshifts):
                     PCK.mangler.get_address(i, addr, mangled_addr, max_oby, max_obx)
@@ -422,8 +420,6 @@ class ML_pycuda(ML_serial):
 
 
         #self.queue.synchronize()
-        self.context.pop()
-        self.context.detach()
         super().engine_finalize()
 
 class GaussianModel(BaseModelSerial):

--- a/ptypy/accelerate/cuda_pycuda/engines/ML_pycuda.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/ML_pycuda.py
@@ -79,7 +79,7 @@ class ML_pycuda(ML_serial):
         """
         Prepare for ML reconstruction.
         """
-        self.context, self.queue = get_context(new_context=True, new_queue=True)
+        self.context, self.queue = get_context(new_context=False, new_queue=True)
 
         if self.p.use_cuda_device_memory_pool:
             self._dmp = DeviceMemoryPool()

--- a/ptypy/accelerate/cuda_pycuda/engines/ML_pycuda.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/ML_pycuda.py
@@ -79,7 +79,7 @@ class ML_pycuda(ML_serial):
         """
         Prepare for ML reconstruction.
         """
-        self.context, self.queue = get_context(new_context=False, new_queue=True)
+        self.context, self.queue = get_context(new_queue=True)
 
         if self.p.use_cuda_device_memory_pool:
             self._dmp = DeviceMemoryPool()

--- a/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda.py
@@ -69,9 +69,9 @@ class _ProjectionEngine_pycuda(projectional_serial._ProjectionEngine_serial):
         Prepare for reconstruction.
         """
         # Context, Multi GPU communicator and Stream (needs to be in this order)
-        self.context, self.queue = get_context(new_context=False, new_queue=False)
+        self.context, self.queue = get_context(new_queue=False)
         self.multigpu = get_multi_gpu_communicator()
-        self.context, self.queue = get_context(new_context=False, new_queue=True)
+        self.context, self.queue = get_context(new_queue=True)
 
         # Gaussian Smoothing Kernel
         self.GSK = GaussianSmoothingKernel(queue=self.queue)

--- a/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda.py
@@ -69,7 +69,7 @@ class _ProjectionEngine_pycuda(projectional_serial._ProjectionEngine_serial):
         Prepare for reconstruction.
         """
         # Context, Multi GPU communicator and Stream (needs to be in this order)
-        self.context, self.queue = get_context(new_context=True, new_queue=False)
+        self.context, self.queue = get_context(new_context=False, new_queue=False)
         self.multigpu = get_multi_gpu_communicator()
         self.context, self.queue = get_context(new_context=False, new_queue=True)
 

--- a/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda.py
@@ -555,9 +555,6 @@ class _ProjectionEngine_pycuda(projectional_serial._ProjectionEngine_serial):
         for name, s in self.pr.S.items():
             s.data = np.copy(s.data)
 
-        self.context.pop()
-        self.context.detach()
-
         # we don't need the  "benchmarking" in DM_serial
         super().engine_finalize(benchmark=False)
 

--- a/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda_stream.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda_stream.py
@@ -64,8 +64,6 @@ class _ProjectionEngine_pycuda_stream(projectional_pycuda._ProjectionEngine_pycu
         fit = int(mem - 200 * 1024 * 1024) // blk  # leave 200MB room for safety
         if not fit:
             log(1,"Cannot fit memory into device, if possible reduce frames per block. Exiting...")
-            self.context.pop()
-            self.context.detach()
             raise SystemExit("ptypy has been exited.")
 
         # TODO grow blocks dynamically
@@ -138,7 +136,7 @@ class _ProjectionEngine_pycuda_stream(projectional_pycuda._ProjectionEngine_pycu
             self.ex_data.add_data_block()
             self.ma_data.add_data_block()
             self.mag_data.add_data_block()
-        
+
     def engine_iterate(self, num=1):
         """
         Compute one iteration.
@@ -148,7 +146,7 @@ class _ProjectionEngine_pycuda_stream(projectional_pycuda._ProjectionEngine_pycu
         atomics_probe = self.p.probe_update_cuda_atomics
         atomics_object = self.p.object_update_cuda_atomics
         use_tiles = (not atomics_object) or (not atomics_probe)
-        
+
         for it in range(num):
 
             error = {}
@@ -311,7 +309,7 @@ class _ProjectionEngine_pycuda_stream(projectional_pycuda._ProjectionEngine_pycu
                 # Update positions
                 if do_update_pos:
                     """
-                    Iterates through all positions and refines them by a given algorithm. 
+                    Iterates through all positions and refines them by a given algorithm.
                     """
                     log(4, "----------- START POS REF -------------")
                     for dID in self.di.S.keys():
@@ -347,7 +345,7 @@ class _ProjectionEngine_pycuda_stream(projectional_pycuda._ProjectionEngine_pycu
                         # wait for data to arrive
                         self.queue.wait_for_event(ev_mag)
 
-                        # We need to re-calculate the current error 
+                        # We need to re-calculate the current error
                         if self.p.position_refinement.metric == "fourier":
                             PCK.fourier_error(aux, addr, mag, ma, ma_sum)
                             PCK.error_reduce(addr, err_fourier)

--- a/ptypy/accelerate/cuda_pycuda/engines/stochastic.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/stochastic.py
@@ -68,7 +68,7 @@ class _StochasticEnginePycuda(_StochasticEngineSerial):
         """
         Prepare for reconstruction.
         """
-        self.context, self.queue = get_context(new_context=True, new_queue=True)
+        self.context, self.queue = get_context(new_context=False, new_queue=True)
 
         # initialise kernels for centring probe if required
         if self.p.probe_center_tol is not None:

--- a/ptypy/accelerate/cuda_pycuda/engines/stochastic.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/stochastic.py
@@ -160,8 +160,6 @@ class _StochasticEnginePycuda(_StochasticEngineSerial):
         fit = int(mem - 200 * 1024 * 1024) // blk  # leave 200MB room for safety
         if not fit:
             log(1,"Cannot fit memory into device, if possible reduce frames per block. Exiting...")
-            self.context.pop()
-            self.context.detach()
             raise SystemExit("ptypy has been exited.")
 
         # TODO grow blocks dynamically
@@ -484,7 +482,6 @@ class _StochasticEnginePycuda(_StochasticEngineSerial):
         for name, s in self.ob.S.items():
             s.data = np.copy(s.data)
 
-        self.context.detach()
         super().engine_finalize()
 
 

--- a/ptypy/accelerate/cuda_pycuda/engines/stochastic.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/stochastic.py
@@ -68,7 +68,7 @@ class _StochasticEnginePycuda(_StochasticEngineSerial):
         """
         Prepare for reconstruction.
         """
-        self.context, self.queue = get_context(new_context=False, new_queue=True)
+        self.context, self.queue = get_context(new_queue=True)
 
         # initialise kernels for centring probe if required
         if self.p.probe_center_tol is not None:


### PR DESCRIPTION
This PR proposes a solution to #472.

To avoid unforeseeable problems, it is desirable to retain a single pycuda context throughout the reconstruction. This PR set up a single pycuda context in the function `get_context` using `pycuda.autoprimaryctx` (see #468). `get_context` always returns that primary context.

Before the change here, with a CUDA-aware MPI installation, if `DM_pycuda` is executed consecutively with more than 1 rank, you would see something similar to this:
```
================================================================================                                                                                          
[hostname:1782233:0:1782233] Caught signal 11 (Segmentation fault: invalid permissions for mapped object at address 0x7f1680a00000)                              
[hostname:1782232:0:1782232] Caught signal 11 (Segmentation fault: Sent by the kernel at address (nil))                                                          
[hostname:1782235:0:1782235] Caught signal 11 (Segmentation fault: invalid permissions for mapped object at address 0x55cab2a14)                                 
--------------------------------------------------------------------------                                                                                                
The call to cuMemcpyAsync failed. This is a unrecoverable error and will                                                                                                cause the program to abort.                                                                                                                                               
  cuMemcpyAsync(0x5648afc48f90, 0x7f906de00000, 484128) returned value 400                                                                                                
Check the cuda.h file for what the return value means.                                                                                                                    
--------------------------------------------------------------------------                                                                                                
[[hostname]):1782234] CUDA: Error in cuMemcpy: res=-1, dest=0x5648afc48f90, src=0x7f906de00000, size=484128

(further horrible messages skipped)
```  

The following minimal example should illustrate the idea:
```python
import tempfile

import numpy as np

from ptypy import utils as u
from ptypy.core import Ptycho
import ptypy
ptypy.load_gpu_engines("cuda")


def param_ML():
    engine_param = u.Param()
    engine_param.name = 'ML_pycuda'
    engine_param.numiter = 5
    engine_param.floating_intensities = False
    engine_param.reg_del2 = True
    engine_param.reg_del2_amplitude = 1.
    engine_param.scale_precond = False

    return engine_param

def param_DM():
    engine_param = u.Param()
    engine_param.name = 'DM_pycuda'
    engine_param.numiter = 5
    engine_param.alpha =1
    engine_param.probe_update_start = 2
    engine_param.overlap_converge_factor = 0.05
    engine_param.overlap_max_iterations = 10
    engine_param.probe_inertia = 1e-3
    engine_param.object_inertia = 0.1
    engine_param.fourier_relax_factor = 0.01
    engine_param.obj_smooth_std = 20

    return engine_param

if __name__ == '__main__':
    p = u.Param()

    # for verbose output
    p.verbose_level = 3

    # set home path
    p.io = u.Param()
    p.io.home = tempfile.mkdtemp(suffix="pycuda_multi")
    p.io.autosave = u.Param(active=False)
    p.io.autoplot = u.Param(active=False)
    p.io.interaction = u.Param(active=False)

    p.scans = u.Param()
    p.scans.MF = u.Param()
    p.scans.MF.name = 'BlockFull'
    p.scans.MF.propagation = 'farfield'
    p.scans.MF.data = u.Param()
    p.scans.MF.data.name = 'MoonFlowerScan'
    p.scans.MF.data.num_frames = 200
    p.scans.MF.data.shape = 64
    p.scans.MF.data.save = None
    p.scans.MF.data.photons = 1e8
    p.scans.MF.data.psf = 0.0
    p.scans.MF.data.density = 0.2
    p.scans.MF.data.add_poisson_noise = False

    p.engines = u.Param()

    # first engine
    p.engines.engine00 = param_DM()

    # second engine
    p.engines.engine01 = param_DM()

    P = Ptycho(p, level=4)
    P.run()
```
After the change, it runs without the above error. More `DM_pycuda` can be added by for example `p.engines.engine02 = param_DM()`, or mixed with `ML_pycuda` by `p.engines.engine01 = param_ML()`. 

If an exception is raised when using the pycuda engines, previously it would give you a message similar to
```
-------------------------------------------------------------------
PyCUDA ERROR: The context stack was not empty upon module cleanup.
-------------------------------------------------------------------
A context was still active when the context stack was being
cleaned up. At this point in our execution, CUDA may already
have been deinitialized, so there is no way we can finish
cleanly. The program will be aborted now.
Use Context.pop() to avoid this problem.
-------------------------------------------------------------------
```
Setting up the primary context through `pycuda.autoprimaryctx` avoids explicit calls to pop/detach in `engine_finalize`, as the clean-up operations is [registered with `atexit`](https://github.com/inducer/pycuda/blob/5cb2e1a32f330c2984e2c1bf0579022494381ef1/pycuda/autoprimaryctx.py#L21-L28).

While working on the PR, it was found that instances of `DeviceMemoryPool` should be properly cleaned up if an exception is raised once allocation through it happened. A function `get_dev_pool` is added to retain the `DeviceMemoryPool` instance for further memory allocation, and an exception hook is added to handle [the clean-up](https://documen.tician.de/pycuda/util.html#pycuda.tools.DeviceMemoryPool.stop_holding) of that `DeviceMemoryPool` instance. This clean-up is not needed if it exits without an exception.

Note: mixing pycuda and CuPy has not been tested.