### PR TITLE
gather_dict on local error is big bottleneck for large datasets

### DIFF
--- a/ptypy/accelerate/cuda_cupy/engines/stochastic.py
+++ b/ptypy/accelerate/cuda_cupy/engines/stochastic.py
@@ -227,8 +227,12 @@ class _StochasticEngineCupy(_StochasticEngineSerial):
         Compute one iteration.
         """
         self.dID_list = list(self.di.S.keys())
-        error = {}
+
         for it in range(num):
+
+            reduced_error = np.zeros((3,))
+            reduced_error_count = 0
+            local_error = {}
 
             for iblock, dID in enumerate(self.dID_list):
 
@@ -378,14 +382,24 @@ class _StochasticEngineCupy(_StochasticEngineSerial):
             err_fourier = prep.err_fourier_gpu.get()
             err_phot = prep.err_phot_gpu.get()
             err_exit = prep.err_exit_gpu.get()
-            errs = np.ascontiguousarray(
-                np.vstack([err_fourier, err_phot, err_exit]).T)
-            error.update(zip(prep.view_IDs, errs))
+            errs = np.ascontiguousarray(np.vstack([err_fourier, err_phot, err_exit]).T)
+            if self.p.record_local_error:
+                local_error.update(zip(prep.view_IDs, errs))
+            else:
+                reduced_error += errs.sum(axis=0)
+                reduced_error_count += errs.shape[0]
+
+        if self.p.record_local_error:
+            error = local_error
+        else:
+            # Gather errors across all MPI ranks
+            error = parallel.allreduce(reduced_error)
+            count = parallel.allreduce(reduced_error_count)
+            error /= count
 
         # wait for the async transfers
         self.qu_dtoh.synchronize()
 
-        self.error = error
         return error
 
     def position_update_local(self, prep, i):

--- a/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda.py
@@ -208,7 +208,11 @@ class _ProjectionEngine_pycuda(projectional_serial._ProjectionEngine_serial):
         queue = self.queue
 
         for it in range(num):
-            error = {}
+
+            reduced_error = np.zeros((3,))
+            reduced_error_count = 0
+            local_error = {}
+
             for dID in self.di.S.keys():
 
                 # find probe, object and exit ID in dependence of dID
@@ -290,9 +294,19 @@ class _ProjectionEngine_pycuda(projectional_serial._ProjectionEngine_serial):
             err_phot = prep.err_phot_gpu.get()
             err_exit = prep.err_exit_gpu.get()
             errs = np.ascontiguousarray(np.vstack([err_fourier, err_phot, err_exit]).T)
-            error.update(zip(prep.view_IDs, errs))
+            if self.p.record_local_error:
+                local_error.update(zip(prep.view_IDs, errs))
+            else:
+                reduced_error += errs.sum(axis=0)
+                reduced_error_count += errs.shape[0]
 
-        self.error = error
+        if self.p.record_local_error:
+            error = local_error
+        else:
+            # Gather errors across all MPI ranks
+            error = parallel.allreduce(reduced_error)
+            count = parallel.allreduce(reduced_error_count)
+            error /= count
         return error
 
     def position_update(self):

--- a/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda_stream.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/projectional_pycuda_stream.py
@@ -387,9 +387,7 @@ class _ProjectionEngine_pycuda_stream(projectional_pycuda._ProjectionEngine_pycu
         for name, s in self.pr.S.items():
             s.data[:] = s.gpu.get()
 
-        # costly but needed to sync back with
-        # for name, s in self.ex.S.items():
-        #     s.data[:] = s.gpu.get()
+        # Gather errors
         for dID, prep in self.diff_info.items():
             err_fourier = prep.err_fourier_gpu.get()
             err_phot = prep.err_phot_gpu.get()


### PR DESCRIPTION
By default errors for each view are saved at the end of each block of iterations into a dictionary. Those dictionaries are then gathered across all MPI ranks into a global dictionary and might be saved into the .ptyr file if `record_local_error` is true in the engine params. 

For the high-perfomance engines, the dictionary MPI gathering of the errors can be a major bottleneck. In this PR I have made the collection of per-view error metrics optional (using the existing `record_local_error` parameter) and if not needed, the errors are first reduced on each rank with a subsequent MPI allreduce across all the ranks. This completely removes the bottleneck but still allows collecting the per-view errors if required. By default `record_local_error` is false. 