### PR TITLE
Update dependencies for cupy/pycuda

### DIFF
--- a/ptypy/accelerate/cuda_cupy/dependencies.yml
+++ b/ptypy/accelerate/cuda_cupy/dependencies.yml
@@ -11,7 +11,7 @@ dependencies:
   - mpi4py
   - pillow
   - pyfftw
-  - cupy
-  - cudatoolkit-dev
   - pip
   - compilers
+  - cupy
+  

--- a/ptypy/accelerate/cuda_pycuda/dependencies.yml
+++ b/ptypy/accelerate/cuda_pycuda/dependencies.yml
@@ -1,6 +1,7 @@
 name: ptypy_pycuda
 channels:
   - conda-forge
+  - nvidia
 dependencies:
   - python
   - numpy
@@ -14,8 +15,7 @@ dependencies:
   - pyyaml
   - reikna
   - pycuda
-  - cudatoolkit-dev
+  - cuda-nvcc
+  - cuda-cudart-dev
   - pip
   - compilers
-  - pip:
-    - scikit-cuda


### PR DESCRIPTION
Remove `cudatoolkit-dev` dependency which seems to be stuck at version 11.7
Instead, use packages from the [nvidia conda channel](https://anaconda.org/nvidia/repo).