### PR TITLE
Filtered cufft: update dependencies and better error handling

### DIFF
--- a/cufft/dependencies.yml
+++ b/cufft/dependencies.yml
@@ -1,10 +1,14 @@
 name: ptypy_cufft
 channels:
   - conda-forge
+  - nvidia
 dependencies:
   - python
   - cmake>=3.8.0
   - pybind11
   - compilers
-  - cudatoolkit-dev
+  - cuda-nvcc
+  - cuda-cudart-dev
+  - libcufft-dev
+  - libcufft-static
   - pip

--- a/cufft/extensions.py
+++ b/cufft/extensions.py
@@ -40,6 +40,11 @@ def locate_cuda():
     cudaconfig = {'home': home, 'nvcc': nvcc,
                   'include': os.path.join(home, 'include'),
                   'lib64': os.path.join(home, 'lib64')}
+
+    # If lib64 does not exist, try lib instead (as common in conda env)
+    if not os.path.exists(cudaconfig['lib64']):
+        cudaconfig['lib64'] = os.path.join(home, 'lib')
+    
     for k, v in cudaconfig.items():
         if not os.path.exists(v):
             raise EnvironmentError('The CUDA %s path could not be located in %s' % (k, v))

--- a/cufft/setup.py
+++ b/cufft/setup.py
@@ -24,12 +24,19 @@ try:
     )
     cmdclass = {"build_ext": CustomBuildExt}
     EXTBUILD_MESSAGE = "The filtered cufft extension has been successfully installed.\n"
-except:
+except EnvironmentError as e:
     EXTBUILD_MESSAGE = '*' * 75 + "\n"
     EXTBUILD_MESSAGE += "Could not install the filtered cufft extension.\n"
-    EXTBUILD_MESSAGE += "Make sure to have CUDA >= 10 and pybind11 installed.\n"
+    EXTBUILD_MESSAGE += "Make sure to have CUDA >= 10 installed.\n"
     EXTBUILD_MESSAGE += '*' * 75 + "\n"
-
+    EXTBUILD_MESSAGE += 'Error message: ' + str(e)
+except ImportError as e:
+    EXTBUILD_MESSAGE = '*' * 75 + "\n"
+    EXTBUILD_MESSAGE += "Could not install the filtered cufft extension.\n"
+    EXTBUILD_MESSAGE += "Make sure to have pybind11 installed.\n"
+    EXTBUILD_MESSAGE += '*' * 75 + "\n"
+    EXTBUILD_MESSAGE += 'Error message: ' + str(e)
+    
 exclude_packages = []
 package_list = setuptools.find_packages(exclude=exclude_packages)
 setup(


### PR DESCRIPTION
Remove `cudatoolkit-dev` dependency and improve error handling.
Also, check for libraries in `lib` (that's where the files are for conda env) in addition to `lib64` (that's where files are for CUDA toolkit installation)