### PR TITLE
GitHub actions: pin conda version to 23.11.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         # There is a bug in the most recent version (24.1.2)
         conda install conda=24.1.1
-	conda --version
+        conda --version
     - name: Install dependencies
       run: |
         # replace python version in core dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,11 @@ jobs:
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH
         conda --version
+    - name: Change conda version
+      run: |
+        # There is a bug in the most recent version (24.1.2)
+        conda install conda=24.1.1
+	conda --version
     - name: Install dependencies
       run: |
         # replace python version in core dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Change conda version
       run: |
         # There is a bug in the most recent version (24.1.2)
-        conda install conda=23.11.0
+        conda install conda=23.11.0 python=3.11
         conda --version
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Change conda version
       run: |
         # There is a bug in the most recent version (24.1.2)
-        conda install conda=24.1.1
+        conda install conda=23.11.0
         conda --version
     - name: Install dependencies
       run: |


### PR DESCRIPTION
It looks like there is a bug in conda >= 24.1.0: https://github.com/conda/conda/issues/13560
Temporary fix: pin down conda to 23.11.0 