### PR TITLE
Update docs for 0.8.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Features
     $ mpiexec -n [nodes] python <your_ptypy_script>.py
 
 * **GPU acceleration** based on custom kernels, CuPy or PyCUDA/reikna.
-  See examples in ``templates/accelerate``. 
+  See examples in ``templates/accelerate``, ``templates/engines/pycuda`` and ``templates/engines/cupy``.
 
 * A **client-server** approach for visualization and control based on 
   `ZeroMQ <http://www.zeromq.org>`_ .
@@ -104,7 +104,7 @@ Ptypy depends on standard python packages:
 GPU support
 -----------
 
-We support an accelerated version of |ptypy|_ for CUDA-capable GPUs based on our own kernels and the
+We support an accelerated version of |ptypy| for CUDA-capable GPUs based on our own kernels and the
 `CuPy <https://cupy.dev/>`_ package. We recommend to install the dependencies for this version like so.
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Features
     $ mpiexec -n [nodes] python <your_ptypy_script>.py
 
 * **GPU acceleration** based on custom kernels, CuPy or PyCUDA/reikna.
-  See examples in ``templates/accelerate``, ``templates/engines/pycuda`` and ``templates/engines/cupy``.
+  See examples in ``templates/accelerate``, ``templates/engines/cupy`` and ``templates/engines/pycuda``.
 
 * A **client-server** approach for visualization and control based on 
   `ZeroMQ <http://www.zeromq.org>`_ .

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,8 @@ Features
   
     $ mpiexec -n [nodes] python <your_ptypy_script>.py
 
-* **GPU acceleration** based on custom kernels, pycuda, and reikna.
+* **GPU acceleration** based on custom kernels, CuPy or PyCUDA/reikna.
+  See examples in ``templates/accelerate``. 
 
 * A **client-server** approach for visualization and control based on 
   `ZeroMQ <http://www.zeromq.org>`_ .
@@ -100,6 +101,17 @@ Ptypy depends on standard python packages:
  * mpi4py (optional - required for parallel computing)
  * pyzmq (optional - required for the plotting client)
  
+GPU support
+-----------
+
+We support an accelerated version of |ptypy|_ for CUDA-capable GPUs based on our own kernels and the
+`CuPy <https://cupy.dev/>`_ package. We recommend to install the dependencies for this version like so.
+::
+
+    $ conda env create -f accelerate/cuda_cupy/dependencies.yml
+    $ conda activate ptypy_cupy
+    (ptypy_cupy)$ pip install .
+
  
 Quicklinks
 ----------

--- a/doc/html_templates/ptypysphinx/download.html
+++ b/doc/html_templates/ptypysphinx/download.html
@@ -20,7 +20,8 @@ unpack and follow the step-by-step
 <p>
 If you are having trouble getting ptypy up und running please let us know (
 <a href="https://github.com/pierrethibault">Pierre</a> or
-<a href="https://github.com/bjoernenders">Bjoern</a>).
+<a href="https://github.com/bjoernenders">Bjoern</a> or 
+<a href="https://github.com/daurer">Benedikt</a>).
 </p><p> You are also encouraged to file any issue, bug or request at the 
 <a href="www.github.com/ptycho/ptypy/issues">issue tracker</a>.
 </p>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -35,7 +35,8 @@ Highlights
   
     $ mpiexec/mpirun -n [nodes] python <your_ptypy_script>.py
 
-* **GPU acceleration** based on custom kernels, pycuda, and reikna.
+* **GPU acceleration** based on custom kernels, CuPy or PyCUDA/reikna.
+  See examples in ``templates/accelerate``. 
 
 * A **client-server** approach for visualization and control based on 
   `ZeroMQ <http://www.zeromq.org>`_ .

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,7 +36,7 @@ Highlights
     $ mpiexec/mpirun -n [nodes] python <your_ptypy_script>.py
 
 * **GPU acceleration** based on custom kernels, CuPy or PyCUDA/reikna.
-  See examples in ``templates/accelerate``. 
+  See examples in ``templates/accelerate``, ``templates/engines/pycuda`` and ``templates/engines/cupy``.
 
 * A **client-server** approach for visualization and control based on 
   `ZeroMQ <http://www.zeromq.org>`_ .

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,7 +36,7 @@ Highlights
     $ mpiexec/mpirun -n [nodes] python <your_ptypy_script>.py
 
 * **GPU acceleration** based on custom kernels, CuPy or PyCUDA/reikna.
-  See examples in ``templates/accelerate``, ``templates/engines/pycuda`` and ``templates/engines/cupy``.
+  See examples in ``templates/accelerate``, ``templates/engines/cupy`` and ``templates/engines/pycuda``.
 
 * A **client-server** approach for visualization and control based on 
   `ZeroMQ <http://www.zeromq.org>`_ .

--- a/doc/rst_templates/getting_started.tmp
+++ b/doc/rst_templates/getting_started.tmp
@@ -122,7 +122,7 @@ provide a filtered FFT, i.e. a FFT that is fused with a pointwise matrix multipl
 Optional installation of filtered cufft
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For optimal performance with both PyCUDA and CuPY engines, you can optionally install a version 
+For optimal performance with both CuPy and PyCUDA engines, you can optionally install a version 
 of the filtered FFT based on cufft and callbacks. Due to the nature of this extension it
 needs to be built for fixed array sizes externally and currently supports array 
 sizes of 16, 32, 64, 128, 256, 512, 1024 and 2048.

--- a/doc/rst_templates/getting_started.tmp
+++ b/doc/rst_templates/getting_started.tmp
@@ -86,10 +86,39 @@ Install the recommended version like so
     (ptypy_full)$ pip install .
 
 
-Recommended install for GPU support
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Recommended install for GPU support with CuPy
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We support an accelerated version of |ptypy|_ for CUDA-capable
+GPUs based on our own kernels and the
+`CuPy <https://cupy.dev/>`_ package.
+
+Install the dependencies for this version like so.
+::
+
+    $ conda env create -f ptypy/accelerate/cuda_cupy/dependencies.yml
+    $ conda activate ptypy_cupy
+    (ptypy_cupy)$ pip install .
+
+
+While we use the `CuPy FFT <https://docs.cupy.dev/en/stable/reference/fft.html>`_ to
+provide a filtered FFT, i.e. a FFT that is fused with a pointwise
+matrix multiplication, you can optionally also install a version
+based on cufft and callbacks. Due to the nature of this extension it
+needs to be built for fixed array sizes externally. The currently supported 
+array sizes are 16, 32, 64, 128, 256, 512, 1024 and 2048.
+::
+
+    $ conda activate ptypy_cupy
+    (ptypy_cupy)$ cd cufft
+    (ptypy_cupy)$ conda env update --file dependencies.yml --name ptypy_cupy
+    (ptypy_cupy)$ pip install .
+
+
+Install for GPU support with PyCUDA
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Alternatively, we also support an accelerated version of |ptypy|_ for CUDA-capable
 GPUs based on our own kernels and the
 `PyCUDA <https://pypi.org/project/pycuda/>`_ package.
 
@@ -105,7 +134,8 @@ While we use `Reikna <https://pypi.org/project/reikna/>`_ to
 provide a filtered FFT, i.e. a FFT that is fused with a pointwise
 matrix multiplication, you can optionally also install a version
 based on cufft and callbacks. Due to the nature of this extension it
-needs to be built for fixed array sizes externally.
+needs to be built for fixed array sizes externally. The currently supported 
+array sizes are 16, 32, 64, 128, 256, 512, 1024 and 2048.
 ::
 
     $ conda activate ptypy_pycuda

--- a/doc/rst_templates/getting_started.tmp
+++ b/doc/rst_templates/getting_started.tmp
@@ -128,10 +128,10 @@ needs to be built for fixed array sizes externally and currently supports array
 sizes of 16, 32, 64, 128, 256, 512, 1024 and 2048.
 ::
 
-    $ conda activate ptypy_pycuda
-    (ptypy_pycuda)$ cd cufft
-    (ptypy_pycuda)$ conda env update --file dependencies.yml --name ptypy_pycuda
-    (ptypy_pycuda)$ pip install .
+    $ conda activate ptypy_cupy
+    (ptypy_cupy)$ cd cufft
+    (ptypy_cupy)$ conda env update --file dependencies.yml --name ptypy_cupy
+    (ptypy_cupy)$ pip install .
 
 
 Optional packages

--- a/doc/rst_templates/getting_started.tmp
+++ b/doc/rst_templates/getting_started.tmp
@@ -101,20 +101,6 @@ Install the dependencies for this version like so.
     (ptypy_cupy)$ pip install .
 
 
-While we use the `CuPy FFT <https://docs.cupy.dev/en/stable/reference/fft.html>`_ to
-provide a filtered FFT, i.e. a FFT that is fused with a pointwise
-matrix multiplication, you can optionally also install a version
-based on cufft and callbacks. Due to the nature of this extension it
-needs to be built for fixed array sizes externally. The currently supported 
-array sizes are 16, 32, 64, 128, 256, 512, 1024 and 2048.
-::
-
-    $ conda activate ptypy_cupy
-    (ptypy_cupy)$ cd cufft
-    (ptypy_cupy)$ conda env update --file dependencies.yml --name ptypy_cupy
-    (ptypy_cupy)$ pip install .
-
-
 Install for GPU support with PyCUDA
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -130,12 +116,16 @@ Install the dependencies for this version like so.
     (ptypy_pycuda)$ pip install .
 
 
-While we use `Reikna <https://pypi.org/project/reikna/>`_ to
-provide a filtered FFT, i.e. a FFT that is fused with a pointwise
-matrix multiplication, you can optionally also install a version
-based on cufft and callbacks. Due to the nature of this extension it
-needs to be built for fixed array sizes externally. The currently supported 
-array sizes are 16, 32, 64, 128, 256, 512, 1024 and 2048.
+We use `Reikna <https://pypi.org/project/reikna/>`_ to
+provide a filtered FFT, i.e. a FFT that is fused with a pointwise matrix multiplication. 
+
+Optional installation of filtered cufft
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For optimal performance with both PyCUDA and CuPY engines, you can optionally install a version 
+of the filtered FFT based on cufft and callbacks. Due to the nature of this extension it
+needs to be built for fixed array sizes externally and currently supports array 
+sizes of 16, 32, 64, 128, 256, 512, 1024 and 2048.
 ::
 
     $ conda activate ptypy_pycuda

--- a/ptypy/version.py
+++ b/ptypy/version.py
@@ -1,6 +1,6 @@
 
-short_version = '0.8.0'
-version = '0.8.0'
+short_version = '0.8.1'
+version = '0.8.1'
 release = False
 
 if not release:


### PR DESCRIPTION
- Added installation instructions for CuPy version
- Included more info about GPU installation in README (#498)
- Mention supported array sizes for pre-compiled filtered FFT
- bumped version to 0.8.1