### PR TITLE
Hotfix: DM_cupy is getting stuck if nccl get_unique_id throws error

### DIFF
--- a/ptypy/accelerate/cuda_cupy/multi_gpu.py
+++ b/ptypy/accelerate/cuda_cupy/multi_gpu.py
@@ -98,7 +98,10 @@ class MultiGpuCommunicatorNccl(MultiGpuCommunicatorBase):
         # get a unique identifier for the NCCL communicator and
         # broadcast it to all MPI processes (assuming one device per process)
         if self.rank == 0:
-            self.id = nccl.get_unique_id()
+            try:
+                self.id = nccl.get_unique_id()
+            except:
+                self.id = None
         else:
             self.id = None
 


### PR DESCRIPTION
We need to wrap nccl.get_unique_id() in a try/except to make sure we don't get stuck at the `parallel.bcast`. If NCCL is not configured we are still escaping the NCCL communicator class at `self.com = nccl.NcclCommunicator()`.