### PR TITLE
Reduce overhead in reformat

### DIFF
--- a/ptypy/core/manager.py
+++ b/ptypy/core/manager.py
@@ -1673,12 +1673,13 @@ class ModelManager(object):
 
         # Attempt to get new data
         new_data = []
+        prb_ids, obj_ids, pod_ids = dict(), dict(), set()
         for label, scan in self.scans.items():
             if not scan.data_available:
                 continue
             else:
                 ilog_streamer('%s: loading data for scan %s' %(type(scan).__name__,label))
-                prb_ids, obj_ids, pod_ids = dict(), dict(), set()
+                
                 nd = scan.new_data(_nframes)
                 while nd:
                     new_data.append((label, nd[0]))
@@ -1690,16 +1691,16 @@ class ModelManager(object):
                     nd = scan.new_data(_nframes)
                 ilog_newline()
 
-                # Reformatting
-                ilog_message('%s: loading data for scan %s (reformatting probe/obj/exit)'  %(type(scan).__name__,label))
-                self.ptycho.probe.reformat(True)
-                self.ptycho.obj.reformat(True)
-                self.ptycho.exit.reformat(True)
+        # Reformatting
+        ilog_message('Reformatting probe/obj/exit)')
+        self.ptycho.probe.reformat(True, update=False)
+        self.ptycho.obj.reformat(True, update=False)
+        self.ptycho.exit.reformat(True, update=False)
 
-                # Initialize probe/object/exit
-                ilog_message('%s: loading data for scan %s (initializing probe/obj/exit)'  %(type(scan).__name__,label))
-                scan._initialize_probe(prb_ids)
-                scan._initialize_object(obj_ids)
-                scan._initialize_exit(list(pod_ids))
+        # Initialize probe/object/exit
+        ilog_message('%Initializing probe/obj/exit)')
+        scan._initialize_probe(prb_ids)
+        scan._initialize_object(obj_ids)
+        scan._initialize_exit(list(pod_ids))
 
         return new_data

--- a/ptypy/core/manager.py
+++ b/ptypy/core/manager.py
@@ -1693,9 +1693,9 @@ class ModelManager(object):
 
         # Reformatting
         ilog_message('Reformatting probe/obj/exit)')
-        self.ptycho.probe.reformat(True, update=False)
-        self.ptycho.obj.reformat(True, update=False)
-        self.ptycho.exit.reformat(True, update=False)
+        self.ptycho.probe.reformat(True, update=True)
+        self.ptycho.obj.reformat(True, update=True)
+        self.ptycho.exit.reformat(True, update=True)
 
         # Initialize probe/object/exit
         ilog_message('%Initializing probe/obj/exit)')


### PR DESCRIPTION
The way we are currently updating views, there can be a huge overhead which is especially problematic in two scenarios

- A single dataset (scan) with a very large number of views (e.g. electron ptychography)
- A combination of datasets loaded as a large list of scans
<hr>

Two avoid such overheads, I am proposing the following changes

1. Move container reformating to the outermost layer in `new_data`, 
i.e. reformat once after all scans and views have been loaded
2. Keep track of changes that are made to particular views and only update if absolutely needed
<hr>

Example benchmarks of data loading times before/after the above changes have been applied

### Case 1
Electron Ptychography data with N frames of shape XxY
Data loading before: XX seconds
Data loading after: YY seconds
Speed increase Nx

### Case 2
Ptychography data set with N scans, each with K frames of shape XxY, combined into a single reconstruction.
Data loading before: XX seconds
Data loading after: YY seconds
Speed increase Nx
