### PR TITLE
Adding Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+/.*
+build
+doc
+tutorial
+extra
+archive
+*.md
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# Select MPI environment: openmpi or mpich
+ARG MPI=openmpi
+
+# Select Platform: core, full, pycuda or cupy
+ARG PLATFORM=cupy
+
+# Pull from mambaforge and install XML and ssh
+FROM condaforge/mambaforge as base
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y libxml2 ssh
+
+# Pull from base image and install OpenMPI/MPICH
+FROM base as mpi
+ARG MPI
+RUN mamba install -n base -c conda-forge ${MPI}
+
+# Pull from MPI build install core dependencies
+FROM base as core
+COPY ./dependencies_core.yml ./dependencies.yml
+RUN mamba env update -n base -f dependencies.yml
+
+# Pull from MPI build and install full dependencies
+FROM mpi as full
+COPY ./dependencies_full.yml ./dependencies.yml
+RUN mamba env update -n base -f dependencies.yml
+
+# Pull from MPI build and install accelerate/pycuda dependencies
+FROM mpi as pycuda
+COPY ./ptypy/accelerate/cuda_pycuda/dependencies.yml ./dependencies.yml
+COPY ./cufft/dependencies.yml ./dependencies_cufft.yml
+RUN mamba env update -n base -f dependencies.yml && mamba env update -n base -f dependencies_cufft.yml
+
+# Pull from MPI build and install accelerate/cupy dependencies
+FROM mpi as cupy
+COPY ./ptypy/accelerate/cuda_cupy/dependencies.yml ./dependencies.yml
+COPY ./cufft/dependencies.yml ./dependencies_cufft.yml
+RUN mamba env update -n base -f dependencies.yml && mamba env update -n base -f dependencies_cufft.yml
+
+# Pull from existing image with ptypy dependencies and set up testing
+FROM ${PLATFORM} as runtime
+COPY pyproject.toml setup.py ./
+COPY ./scripts ./scripts
+COPY ./templates ./templates
+COPY ./benchmark ./benchmark
+COPY ./cufft ./cufft
+COPY ./ptypy ./ptypy
+RUN pip install .
+RUN if [ "$PLATFORM" = "pycuda" ] || [ "$PLATFORM" = "cupy" ] ; then pip install ./cufft ; fi
+
+# Run PtyPy run script as entrypoint
+ENTRYPOINT ["ptypy.run"]


### PR DESCRIPTION
Dockerfile that can build containers for different MPI environments and ptypy dependencies, i.e.

- `podman/docker build . --target=runtime  --build-arg PLATFORM=core`
- `podman/docker build . --target=runtime --build-arg MPI=openmpi --build-arg PLATFORM=full`
- `podman/docker build . --target=runtime --build-arg MPI=mpich --build-arg PLATFORM=full`
- `podman/docker build . --target=runtime --build-arg MPI=openmpi --build-arg PLATFORM=cupy`
- `podman/docker build . --target=runtime --build-arg MPI=mpich --build-arg PLATFORM=cupy`