### PR TITLE
Using mpich as default MPI backend in actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,12 +57,13 @@ jobs:
         if [ ${{ matrix.conda-env }} == 'full' ] && [ ${{ matrix.python-version }} == '3.12' ]; then
           sed -i '/- pyfftw/d' dependencies_${{ matrix.conda-env }}.yml
         fi
-        if [ ${{ matrix.conda-env }} == 'full' ] && [ ${{ matrix.python-version }} == '3.8' ]; then
-          sed -i '/- mpi4py/d' dependencies_${{ matrix.conda-env }}.yml
-        fi
-        if [ ${{ matrix.conda-env }} == 'full' ] && [ ${{ matrix.python-version }} == '3.9' ]; then
-          sed -i '/- mpi4py/d' dependencies_${{ matrix.conda-env }}.yml
-        fi
+        # if [ ${{ matrix.conda-env }} == 'full' ] && [ ${{ matrix.python-version }} == '3.8' ]; then
+        #   sed -i '/- mpi4py/d' dependencies_${{ matrix.conda-env }}.yml
+        # fi
+        # if [ ${{ matrix.conda-env }} == 'full' ] && [ ${{ matrix.python-version }} == '3.9' ]; then
+        #   sed -i '/- mpi4py/d' dependencies_${{ matrix.conda-env }}.yml
+        # fi
+        conda install --solver=classic mpich
         conda env update --file dependencies_${{ matrix.conda-env }}.yml --name base
         conda install --solver=classic flake8 pytest pytest-cov
         conda list	


### PR DESCRIPTION
It looks like some CI jobs have picked up `impi`as the MPI backend which caused segfaults in the tests.