### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+numpy
+matplotlib==3.7.3
+h5py
+pyzmq
+mpi4py
+pillow
+pyfftw
+pyyaml
+scipy
+cupy


### PR DESCRIPTION
Building by means of conda is not very friendly for new users. It is suggested to add familiar to python developers requirements.txt.

Specific version of matplotlib was chosen specially, because when installing the latest version, I get the error `AttributeError: module 'matplotlib.cm' has no attribute 'register_cmap'`. With version 3.7.3 there are no such problems. 

issue: #148 