### PR TITLE
Suggest a value for frames_per_block if the memory is insufficient 

### DIFF
--- a/ptypy/accelerate/base/mem_utils.py
+++ b/ptypy/accelerate/base/mem_utils.py
@@ -1,0 +1,48 @@
+from math import floor
+
+
+def max_fpb_from_scans(scans):
+    """Find maximum 'frames_per_block' from different scan models.
+
+    Parameters
+    ----------
+    scans : dict
+        a dictionary contains different scan models, i.e. instances of
+        ptypy.core.manager.ScanModel.
+
+    Returns
+    -------
+    max_fpb : int
+        the maximum number of 'frames_per_block' in these scan models,
+        None if any one of them is GradFull as it is irrelevant.
+
+    """
+    max_fpb = 0
+    for scan in scans.values():
+        if scan.__class__.__name__ == "GradFull":
+            # the 'frames_per_block' is irrelevant for the GradFull
+            # model
+            return None
+        max_fpb = max(scan.max_frames_per_block, max_fpb)
+
+    return max_fpb
+
+def calculate_safe_fpb(mem_avail, mem_per_frame, nblk=3):
+    """Return a safe value of 'frames_per_block' from memory information.
+
+    Parameters
+    ----------
+    mem_avail : int
+        the available GPU memory
+    mem_per_frame : int
+        the GPU memory required for a single frame
+    nblk : int, optional
+        the total number of blocks the data will be divided into.
+        Default to 3.
+
+    """
+    if mem_per_frame < 0 or mem_avail < 0:
+        msg = "Memory should be a positive number."
+        raise ValueError(msg)
+
+    return floor((mem_avail / nblk) / mem_per_frame)

--- a/ptypy/accelerate/cuda_cupy/engines/ML_cupy.py
+++ b/ptypy/accelerate/cuda_cupy/engines/ML_cupy.py
@@ -161,7 +161,8 @@ class ML_cupy(ML_serial):
         mem = cp.cuda.runtime.memGetInfo()[0] + mempool.total_bytes() - mempool.used_bytes()
 
         # leave 200MB room for safety
-        fit = int(mem - 200 * 1024 * 1024) // blk
+        avail_mem = max(int(mem - 200 * 1024 * 1024), 0)
+        fit =  avail_mem // blk
         if not fit:
             log(1, "Cannot fit memory into device, if possible reduce frames per block. Exiting...")
             raise SystemExit("ptypy has been exited.")

--- a/ptypy/accelerate/cuda_cupy/engines/stochastic.py
+++ b/ptypy/accelerate/cuda_cupy/engines/stochastic.py
@@ -162,7 +162,8 @@ class _StochasticEngineCupy(_StochasticEngineSerial):
         mem = cp.cuda.runtime.memGetInfo()[0]
         blk = ex_mem * EX_MA_BLOCKS_RATIO + ma_mem + mag_mem
         # leave 200MB room for safety
-        fit = int(mem - 200 * 1024 * 1024) // blk
+        avail_mem = max(int(mem - 200 * 1024 * 1024), 0)
+        fit =  avail_mem // blk
         if not fit:
             log(1, "Cannot fit memory into device, if possible reduce frames per block. Exiting...")
             raise SystemExit("ptypy has been exited.")

--- a/ptypy/accelerate/cuda_cupy/engines/stochastic.py
+++ b/ptypy/accelerate/cuda_cupy/engines/stochastic.py
@@ -19,6 +19,8 @@ from ptypy.utils import parallel
 from ptypy.engines import register
 from ptypy.engines.stochastic import EPIEMixin, SDRMixin
 from ptypy.accelerate.base.engines.stochastic import _StochasticEngineSerial
+from ptypy.accelerate.base.mem_utils import (max_fpb_from_scans,
+calculate_safe_fpb)
 from ptypy.accelerate.base import address_manglers
 from .. import get_context
 from ..kernels import FourierUpdateKernel, AuxiliaryWaveKernel, PoUpdateKernel,\
@@ -167,20 +169,14 @@ class _StochasticEngineCupy(_StochasticEngineSerial):
         avail_mem = max(int(mem - 200 * 1024 * 1024), 0)
         fit =  avail_mem // blk
         if not fit:
-            # find max number of frames_per_block
-            max_fpc = 0
-            isGradFull = False
-            for scan in self.ptycho.model.scans.values():
-                if scan.__class__.__name__ == "GradFull":
-                    isGradFull = True
-                    break
-                max_fpc = max(scan.max_frames_per_block, max_fpc)
-
             log(1, "Cannot fit memory into device, if possible reduce frames per block. Exiting...")
-            if not isGradFull:
-                per_frame = blk / max_fpc
-                safe_fpb = int(np.floor((avail_mem / NUM_BLK_SAFE_FPB) / per_frame))
-                log(1,f"Your current 'frames_per_block' is {max_fpc}.")
+            # max_fpb is None if there is a GradFull in the scan models
+            # as 'frames_per_block' is irrelevant
+            max_fpb = max_fpb_from_scans(self.ptycho.model.scans)
+            if max_fpb is not None:
+                per_frame = blk / max_fpb
+                safe_fpb = calculate_safe_fpb(avail_mem, per_frame, NUM_BLK_SAFE_FPB)
+                log(1,f"Your current 'frames_per_block' is {max_fpb}.")
                 log(1,f"With current reconstruction parameters and computing resources, you can try setting 'frames_per_block' to {safe_fpb}.")
                 log(1,f"This would divide your reonstruction into {NUM_BLK_SAFE_FPB} blocks.")
             raise SystemExit("ptypy has been exited.")

--- a/ptypy/accelerate/cuda_cupy/engines/stochastic.py
+++ b/ptypy/accelerate/cuda_cupy/engines/stochastic.py
@@ -165,8 +165,6 @@ class _StochasticEngineCupy(_StochasticEngineSerial):
         fit = int(mem - 200 * 1024 * 1024) // blk
         if not fit:
             log(1, "Cannot fit memory into device, if possible reduce frames per block. Exiting...")
-            self.context.pop()
-            self.context.detach()
             raise SystemExit("ptypy has been exited.")
 
         # TODO grow blocks dynamically

--- a/ptypy/accelerate/cuda_pycuda/engines/stochastic.py
+++ b/ptypy/accelerate/cuda_pycuda/engines/stochastic.py
@@ -19,6 +19,8 @@ from ptypy.utils import parallel
 from ptypy.engines import register
 from ptypy.engines.stochastic import EPIEMixin, SDRMixin
 from ptypy.accelerate.base.engines.stochastic import _StochasticEngineSerial
+from ptypy.accelerate.base.mem_utils import (max_fpb_from_scans,
+calculate_safe_fpb)
 from ptypy.accelerate.base import address_manglers
 from .. import get_context
 from ..kernels import FourierUpdateKernel, AuxiliaryWaveKernel, PoUpdateKernel,\
@@ -34,6 +36,8 @@ MPI = False
 EX_MA_BLOCKS_RATIO = 2
 MAX_BLOCKS = 99999  # can be used to limit the number of blocks, simulating that they don't fit
 #MAX_BLOCKS = 10  # can be used to limit the number of blocks, simulating that they don't fit
+# the number of blocks to have with a safe value of frames_per_block
+NUM_BLK_SAFE_FPB = 3
 
 class _StochasticEnginePycuda(_StochasticEngineSerial):
 
@@ -157,9 +161,20 @@ class _StochasticEnginePycuda(_StochasticEngineSerial):
         ma_mem = mag_mem
         mem = cuda.mem_get_info()[0]
         blk = ex_mem * EX_MA_BLOCKS_RATIO + ma_mem + mag_mem
-        fit = int(mem - 200 * 1024 * 1024) // blk  # leave 200MB room for safety
+        # leave 200MB room for safety
+        avail_mem = max(int(mem - 200 * 1024 * 1024), 0)
+        fit =  avail_mem // blk
         if not fit:
             log(1,"Cannot fit memory into device, if possible reduce frames per block. Exiting...")
+            # max_fpb is None if there is a GradFull in the scan models
+            # as 'frames_per_block' is irrelevant
+            max_fpb = max_fpb_from_scans(self.ptycho.model.scans)
+            if max_fpb is not None:
+                per_frame = blk / max_fpb
+                safe_fpb = calculate_safe_fpb(avail_mem, per_frame, NUM_BLK_SAFE_FPB)
+                log(1,f"Your current 'frames_per_block' is {max_fpb}.")
+                log(1,f"With current reconstruction parameters and computing resources, you can try setting 'frames_per_block' to {safe_fpb}.")
+                log(1,f"This would divide your reonstruction into {NUM_BLK_SAFE_FPB} blocks.")
             raise SystemExit("ptypy has been exited.")
 
         # TODO grow blocks dynamically


### PR DESCRIPTION
This PR aims to provide a conservative value for the parameter `frames_per_block` if the block cannot be fitted into the current GPU memory.

It is more helpful for PtyPy to provide a value for `frames_per_block` as most of the users do not have any idea what a sensible value should be. The ideal way is to provide an option such as `frames_per_block='auto'` so the user can forget about it but the memory estimation happens after the data is loaded alongside with other stuff and it also depends on the algorithm. As a result it is not possible to achieve this as [it is wished here](https://github.com/ptycho/ptypy/blob/master/ptypy/core/ptycho.py#L442-L443).

When the block is too big, it prints out a message similar to this:
```text
Cannot fit memory into device, if possible reduce frames per block. Exiting...
Your current 'frames_per_block' is 2000.
With current reconstruction parameters and computing resources, you can try setting 'frames_per_block' to 721.
This would divide your reonstruction into 3 blocks.
ptypy has been exited.
```

This is only relevant for any `_Block` model.

This also fixes a small bug by removing `self.context` in the CuPy's EPIE engine.