### PR TITLE
Fix filtered_cufft custom compiler

### DIFF
--- a/cufft/extensions.py
+++ b/cufft/extensions.py
@@ -4,8 +4,8 @@ Compilation tools for Nvidia builds of extension modules.
 import os, re
 import subprocess
 import sysconfig
-from distutils.unixccompiler import UnixCCompiler
-from distutils.command.build_ext import build_ext
+from setuptools._distutils.unixccompiler import UnixCCompiler
+from setuptools.command.build_ext import build_ext
 
 
 def find_in_path(name, path):
@@ -116,6 +116,7 @@ class NvccCompiler(UnixCCompiler):
         compiler_command = [self.CUDA["nvcc"]] + self.NVCC_FLAGS + self.OPTFLAGS + ["-Xcompiler"] + self.CXXFLAGS + CPPFLAGS
         compiler_exec = " ".join(compiler_command)
         self.set_executable('compiler_so', compiler_exec)
+        self.set_executable('compiler_so_cxx', compiler_exec)
         postargs = [] # we don't actually have any postargs
         super(NvccCompiler, self)._compile(obj, src, ext, cc_args, postargs, pp_opts) # the _compile method
         # reset the default compiler_so, which we might have changed for cuda

--- a/cufft/setup.py
+++ b/cufft/setup.py
@@ -2,7 +2,7 @@
 
 # we should aim to remove the distutils dependency
 import setuptools
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import os
 
 ext_modules = []


### PR DESCRIPTION
It turned out there was a [change](https://github.com/pypa/distutils/commit/2c937116cc0dcd9b26b6070e89a3dc5dcbedc2ae#diff-6ed3ec12221684cf8ef45abffe2d8fd7042ac8f936f68f434d885c68cc096ba5R189) in distutils/setuptools that has broken our compilation of the filtered_cufft module --> fixed

Also decided to import all the compiler related modules from setuptools instead of distutils per recommendation [here](https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html) and in[ PEP632](https://peps.python.org/pep-0632/#migration-advice).