### PR TITLE
Control the start of probe update in WASP

### DIFF
--- a/ptypy/custom/WASP.py
+++ b/ptypy/custom/WASP.py
@@ -124,11 +124,11 @@ class WASP(base.PositionCorrectionEngine):
         self.article = dict(
                 title='WASP: Weighted Average of Sequential Projections for ptychographic phase retrieval',
                 author='A. M. Maiden, W. Mei and P. Li',
-                journal='Optica',
-                volume=42,
+                journal='Optics Express',
+                volume=32,
                 year=2024,
-                page=42,
-                doi='doi',
+                page=21327,
+                doi='10.1364/OE.516946',
                 comment='Weighted Average of Sequential Projections',
                 )
         self.ptycho.citations.add_article(**self.article)

--- a/ptypy/custom/WASP_cupy.py
+++ b/ptypy/custom/WASP_cupy.py
@@ -338,8 +338,9 @@ class WASP_cupy(WASP_serial):
                     ob_old = ob.copy()
                     POK.ob_update_wasp(addr, ob, pr, ex, aux, ob_sum_nmr,
                                        ob_sum_dnm, alpha=self.p.alpha)
-                    POK.pr_update_wasp(addr, pr, ob_old, ex, aux, pr_sum_nmr,
-                                       pr_sum_dnm, beta=self.p.beta)
+                    if self.p.probe_update_start <= self.curiter:
+                        POK.pr_update_wasp(addr, pr, ob_old, ex, aux, pr_sum_nmr,
+                                           pr_sum_dnm, beta=self.p.beta)
 
                     ## compute log-likelihood
                     if self.p.compute_log_likelihood:
@@ -355,7 +356,8 @@ class WASP_cupy(WASP_serial):
                 self.multigpu.allReduceSum(pr_sum_dnm)
 
                 POK.avg_wasp(ob, ob_sum_nmr, ob_sum_dnm)
-                POK.avg_wasp(pr, pr_sum_nmr, pr_sum_dnm)
+                if self.p.probe_update_start <= self.curiter:
+                    POK.avg_wasp(pr, pr_sum_nmr, pr_sum_dnm)
 
                 # Clip object
                 if self.p.clip_object is not None:

--- a/ptypy/custom/WASP_pycuda.py
+++ b/ptypy/custom/WASP_pycuda.py
@@ -338,9 +338,9 @@ class WASP_pycuda(WASP_serial):
                     ob_old = ob.copy()
                     POK.ob_update_wasp(addr, ob, pr, ex, aux, ob_sum_nmr,
                                        ob_sum_dnm, alpha=self.p.alpha)
-                    POK.pr_update_wasp(addr, pr, ob_old, ex, aux, pr_sum_nmr,
-                                       pr_sum_dnm, beta=self.p.beta)
-
+                    if self.p.probe_update_start <= self.curiter:
+                        POK.pr_update_wasp(addr, pr, ob_old, ex, aux, pr_sum_nmr,
+                                           pr_sum_dnm, beta=self.p.beta)
 
                     ## compute log-likelihood
                     if self.p.compute_log_likelihood:
@@ -356,7 +356,8 @@ class WASP_pycuda(WASP_serial):
                 self.multigpu.allReduceSum(pr_sum_dnm)
 
                 POK.avg_wasp(ob, ob_sum_nmr, ob_sum_dnm)
-                POK.avg_wasp(pr, pr_sum_nmr, pr_sum_dnm)
+                if self.p.probe_update_start <= self.curiter:
+                    POK.avg_wasp(pr, pr_sum_nmr, pr_sum_dnm)
 
                 # Clip object
                 if self.p.clip_object is not None:

--- a/ptypy/custom/WASP_serial.py
+++ b/ptypy/custom/WASP_serial.py
@@ -292,8 +292,9 @@ class WASP_serial(WASP):
                     ob_old = ob.copy()
                     POK.ob_update_wasp(addr, ob, pr, ex, aux, ob_sum_nmr,
                                        ob_sum_dnm, alpha=self.p.alpha)
-                    POK.pr_update_wasp(addr, pr, ob_old, ex, aux, pr_sum_nmr,
-                                       pr_sum_dnm, beta=self.p.beta)
+                    if self.p.probe_update_start <= self.curiter:
+                        POK.pr_update_wasp(addr, pr, ob_old, ex, aux, pr_sum_nmr,
+                                           pr_sum_dnm, beta=self.p.beta)
 
                     self.benchmark.wasp_ob_pr_update += time.time() - t1
                     self.benchmark.calls_wasp_ob_pr_update += 1
@@ -321,7 +322,8 @@ class WASP_serial(WASP):
                 parallel.allreduce(pr_sum_dnm)
 
                 POK.avg_wasp(ob, ob_sum_nmr, ob_sum_dnm)
-                POK.avg_wasp(pr, pr_sum_nmr, pr_sum_dnm)
+                if self.p.probe_update_start <= self.curiter:
+                    POK.avg_wasp(pr, pr_sum_nmr, pr_sum_dnm)
 
                 self.benchmark.wasp_averaging += time.time() - t1
                 self.benchmark.calls_wasp_averaging += 1

--- a/ptypy/utils/plot_utils.py
+++ b/ptypy/utils/plot_utils.py
@@ -415,8 +415,12 @@ franzmap_cm = {'red':   ((0.000,   0,    0),
                                                       (0.340,   1,    1),
                                                       (0.650,   0,    0),
                                                       (1.000,   0,    0))}
-                                                      
-mpl.colormaps.register(cmap=LinearSegmentedColormap(name='franzmap', segmentdata=franzmap_cm, N=256))
+
+_lscm = LinearSegmentedColormap(name='franzmap', segmentdata=franzmap_cm, N=256)
+try:
+    mpl.colormaps.register(cmap=_lscm)
+except AttributeError:
+    matplotlib.cm.register_cmap(cmap=_lscm)
 
 def franzmap():
     """\

--- a/ptypy/utils/plot_utils.py
+++ b/ptypy/utils/plot_utils.py
@@ -128,7 +128,7 @@ except ImportError:
                     print(message)
                 time.sleep(timeout)
 
-# BD: With version 9.1.0 of PIL, _MODE_CONV has been removed, 
+# BD: With version 9.1.0 of PIL, _MODE_CONV has been removed,
 #     see here: https://github.com/python-pillow/Pillow/pull/6057
 #     can't see a reason why this is still needed, therefore commenting it out
 # FIXME: Is this still needed?
@@ -179,7 +179,7 @@ def complex2hsv(cin, vmin=0., vmax=None):
     else:
         assert vmin < vmax
         v = (v.clip(vmin, vmax)-vmin)/(vmax-vmin)
-    
+
     return np.asarray((h, s, v))
 
 
@@ -345,7 +345,7 @@ def imsave(a, filename=None, vmin=None, vmax=None, cmap=None):
     uses a matplotlib colormap with name 'gray'
     """
     if str(cmap) == cmap:
-        cmap = mpl.colormaps.get_cmap(cmap)
+        cmap = mpl.colormaps[cmap]
 
     if a.dtype.kind == 'c':
         i = complex2rgb(a, vmin=vmin, vmax=vmax)
@@ -426,7 +426,7 @@ def franzmap():
     im = mpl.pyplot.gci()
 
     if im is not None:
-        im.set_cmap(matplotlib.cm.get_cmap('franzmap'))
+        im.set_cmap(mpl.colormaps['franzmap'])
     mpl.pyplot.draw_if_interactive()
 
 
@@ -595,46 +595,46 @@ class PtyAxis(object):
     """
     Plot environment for matplotlib to allow for a Image plot with color axis,
     potentially of a potentially complex array.
-    
+
     Please note that this class may undergo changes or become obsolete altogether.
     """
     def __init__(self, ax=None, data=None, channel='r', cmap=None, fontsize=8, **kwargs):
         """
-        
+
         Parameters
         ----------
-        
+
         ax : pyplot.axis
             An axis in matplotlib figure. If ``None`` a figure with a single
             axis will be created.
-            
+
         data : numpy.ndarray
-            The (complex) twodimensional data to be displayed. 
-            
+            The (complex) twodimensional data to be displayed.
+
         channel : str
             Choose
-            
+
             - ``'a'`` to plot absolute/modulus value of the data,
             - ``'p'`` to plot phase value of the data,
             - ``'a'`` to plot real value of the data,
             - ``'a'`` to plot imaginary value of the data,
-            - ``'a'`` to plot a composite image where phase channel maps to hue and 
+            - ``'a'`` to plot a composite image where phase channel maps to hue and
               modulus channel maps to brightness of the color.
-              
-        cmap : str 
+
+        cmap : str
             String representation of one of matplotlibs colormaps.
-            
+
         fontsize : int
             Base font size of labels, etc.
-            
+
         Keyword Arguments
         -----------------
         vmin, vmax : float
             Minimum and maximum value for colormap scaling
-            
+
         rmramp : bool
             Remove phase ramp if ``True``, default is ``False``
-            
+
         """
         if ax is None:
             fig = plt.figure()
@@ -679,10 +679,10 @@ class PtyAxis(object):
 
     def set_cmap(self, cmap, update=True):
         try:
-            self.cmap = mpl.colormaps.get_cmap(cmap)
+            self.cmap = mpl.colormaps[cmap]
         except:
             logger.debug("Colormap `%s` not found. Using `gray`" % str(cmap))
-            self.cmap = mpl.colormaps.get_cmap('gray')
+            self.cmap = mpl.colormaps['gray']
         if update:
             self._update()
             self._update_colorscale()

--- a/test/accelerate_tests/base_tests/WASP_tests.py
+++ b/test/accelerate_tests/base_tests/WASP_tests.py
@@ -99,6 +99,7 @@ class WASPSerialTest(unittest.TestCase):
             engine_params = u.Param()
             engine_params.name = eng
             engine_params.numiter = 10
+            engine_params.clip_object = (0, 2)
             engine_params.random_seed = 721
             out.append(tu.EngineTestRunner(engine_params, output_path=self.outpath, init_correct_probe=True,
                                            scanmodel="BlockFull", autosave=False, verbose_level="critical"))
@@ -120,12 +121,28 @@ class WASPSerialTest(unittest.TestCase):
         if parallel.master:
             self.check_engine_output(out, plotting=False, debug=False)
 
+    def test_WASP_serial_probe_start(self):
+        out = []
+        for eng in ["WASP", "WASP_serial"]:
+            engine_params = u.Param()
+            engine_params.name = eng
+            engine_params.numiter = 10
+            engine_params.clip_object = (0, 2)
+            engine_params.probe_update_start = 4
+            engine_params.random_seed = 721
+            out.append(tu.EngineTestRunner(engine_params, output_path=self.outpath, init_correct_probe=True,
+                                           scanmodel="BlockFull", autosave=False, verbose_level="critical"))
+
+        if parallel.master:
+            self.check_engine_output(out, plotting=False, debug=False)
+
     def test_WASP_serial_alpha_beta(self):
         out = []
         for eng in ["WASP", "WASP_serial"]:
             engine_params = u.Param()
             engine_params.name = eng
             engine_params.numiter = 10
+            engine_params.clip_object = (0, 2)
             engine_params.alpha = 0.64
             engine_params.beta = 0.94
             engine_params.random_seed = 721

--- a/test/accelerate_tests/base_tests/array_utils_test.py
+++ b/test/accelerate_tests/base_tests/array_utils_test.py
@@ -2,11 +2,12 @@
 Tests for the array_utils module
 '''
 
-import unittest
+import unittest, pytest
 import numpy as np
 from ptypy.accelerate.base import FLOAT_TYPE, COMPLEX_TYPE
 from ptypy.accelerate.base import array_utils as au
 
+_numpy_version = tuple(map(int, np.__version__.split(".")))
 
 class ArrayUtilsTest(unittest.TestCase):
 
@@ -291,6 +292,7 @@ class ArrayUtilsTest(unittest.TestCase):
                          dtype=np.complex64)
         np.testing.assert_array_almost_equal(A, exp_A)
 
+    @pytest.mark.skipif(_numpy_version < (2,0), reason="requires Numpy 2.0 or higher to match expected output")
     def test_fft_filter(self):
         data = np.zeros((256, 512), dtype=COMPLEX_TYPE)
         data[64:-64,128:-128] = 1 + 1.j
@@ -342,6 +344,7 @@ class ArrayUtilsTest(unittest.TestCase):
         
         np.testing.assert_array_almost_equal(output.flat[::2000], known_test_output, decimal=5)
 
+    @pytest.mark.skipif(_numpy_version < (2,0), reason="requires Numpy 2.0 or higher to match expected output")
     def test_fft_filter_batched(self):
         data = np.zeros((2,256, 512), dtype=COMPLEX_TYPE)
         data[:,64:-64,128:-128] = 1 + 1.j

--- a/test/accelerate_tests/cuda_cupy_tests/WASP_tests.py
+++ b/test/accelerate_tests/cuda_cupy_tests/WASP_tests.py
@@ -98,6 +98,7 @@ class WASPCupyTest(unittest.TestCase):
             engine_params = u.Param()
             engine_params.name = eng
             engine_params.numiter = 10
+            engine_params.clip_object = (0, 2)
             engine_params.random_seed = 721
             out.append(tu.EngineTestRunner(engine_params, output_path=self.outpath, init_correct_probe=True,
                                            scanmodel="BlockFull", autosave=False, verbose_level="critical"))
@@ -119,12 +120,28 @@ class WASPCupyTest(unittest.TestCase):
         if parallel.master:
             self.check_engine_output(out, plotting=False, debug=False)
 
+    def test_WASP_cupy_probe_start(self):
+        out = []
+        for eng in ["WASP_serial", "WASP_cupy"]:
+            engine_params = u.Param()
+            engine_params.name = eng
+            engine_params.numiter = 10
+            engine_params.clip_object = (0, 2)
+            engine_params.probe_update_start = 4
+            engine_params.random_seed = 721
+            out.append(tu.EngineTestRunner(engine_params, output_path=self.outpath, init_correct_probe=True,
+                                           scanmodel="BlockFull", autosave=False, verbose_level="critical"))
+
+        if parallel.master:
+            self.check_engine_output(out, plotting=False, debug=False)
+
     def test_WASP_cupy_alpha_beta(self):
         out = []
         for eng in ["WASP_serial", "WASP_cupy"]:
             engine_params = u.Param()
             engine_params.name = eng
             engine_params.numiter = 10
+            engine_params.clip_object = (0, 2)
             engine_params.alpha = 0.64
             engine_params.beta = 0.94
             engine_params.random_seed = 721

--- a/test/accelerate_tests/cuda_pycuda_tests/WASP_tests.py
+++ b/test/accelerate_tests/cuda_pycuda_tests/WASP_tests.py
@@ -98,6 +98,7 @@ class WASPPycudaTest(unittest.TestCase):
             engine_params = u.Param()
             engine_params.name = eng
             engine_params.numiter = 10
+            engine_params.clip_object = (0, 2)
             engine_params.random_seed = 721
             out.append(tu.EngineTestRunner(engine_params, output_path=self.outpath, init_correct_probe=True,
                                            scanmodel="BlockFull", autosave=False, verbose_level="critical"))
@@ -119,12 +120,28 @@ class WASPPycudaTest(unittest.TestCase):
         if parallel.master:
             self.check_engine_output(out, plotting=False, debug=False)
 
+    def test_WASP_pycuda_probe_start(self):
+        out = []
+        for eng in ["WASP_serial", "WASP_pycuda"]:
+            engine_params = u.Param()
+            engine_params.name = eng
+            engine_params.numiter = 10
+            engine_params.clip_object = (0, 2)
+            engine_params.probe_update_start = 4
+            engine_params.random_seed = 721
+            out.append(tu.EngineTestRunner(engine_params, output_path=self.outpath, init_correct_probe=True,
+                                           scanmodel="BlockFull", autosave=False, verbose_level="critical"))
+
+        if parallel.master:
+            self.check_engine_output(out, plotting=False, debug=False)
+
     def test_WASP_pycuda_alpha_beta(self):
         out = []
         for eng in ["WASP_serial", "WASP_pycuda"]:
             engine_params = u.Param()
             engine_params.name = eng
             engine_params.numiter = 10
+            engine_params.clip_object = (0, 2)
             engine_params.alpha = 0.64
             engine_params.beta = 0.94
             engine_params.random_seed = 721


### PR DESCRIPTION
Fix #600 

This PR let users to control the start of probe update by using the parameter `probe_update_start`, as the case for other reconstruction engines. This has not been implemented in WASP previously although it is a valid parameter, and this should be available.

The publication about WASP is also updated (a placeholder was used as the manuscript was still being reviewed when this had been implemented here).

Tests using `probe_update_start` in different WASP engines are added.