### PR TITLE
Fixed a bug in stxm method for probe init

### DIFF
--- a/ptypy/core/illumination.py
+++ b/ptypy/core/illumination.py
@@ -409,7 +409,7 @@ def init_storage(storage, pars, energy=None, **kwargs):
             # Ok this is nearfield
             curve = 1.0
 
-        model = pod.bw(curve * np.sqrt(alldiff))
+        model = pod.bw(curve * np.sqrt(alldiff).astype(np.complex128))
     else:
         raise ValueError(
             prefix + 'Value to `model` key not understood in probe creation')


### PR DESCRIPTION
The idea of the "stxm" method for initialising the probe is to calculate the auto-correlation of the average diffraction pattern. However, this was not done correctly (or maybe the underlying FFT routine has changed?) as the inverse FFT of a real-valued array seems to be interpreted as the real-part of a complex array. But here, we would want the sqrt of the average diffraction to be the amplitude of the complex array. 

Explicitly casting to complex array solves the problem and gives the expected results (tested on real data).