### PR TITLE
Clipping magnitude and phase 

### DIFF
--- a/ptypy/accelerate/base/array_utils.py
+++ b/ptypy/accelerate/base/array_utils.py
@@ -145,13 +145,15 @@ def interpolated_shift(c, shift, do_linear=False):
             np.imag(c), shift, order=1, mode='constant', cval=0, prefilter=False)
 
 
-def clip_complex_magnitudes_to_range(complex_input, clip_min, clip_max):
+def clip_object_to_range(complex_input, clip_min_mag, clip_max_mag, clip_min_phase, clip_max_phase):
     '''
-    This takes a single precision 2D complex input, clips the absolute magnitudes to be within a range, but leaves the phase untouched.
+    This takes a single precision 2D complex input, and clips its magnitude and phase to the given ranges.
     '''
     ampl = np.abs(complex_input)
     phase = np.exp(1j * np.angle(complex_input))
-    ampl = np.clip(ampl, clip_min, clip_max)
+    ampl = np.clip(ampl, clip_min_mag, clip_max_mag)
+    phase = np.clip(np.angle(complex_input), clip_min_phase, clip_max_phase)
+    phase = np.exp(1j * phase)  
     complex_input[:] = ampl * phase
 
 

--- a/ptypy/accelerate/base/engines/ML_serial.py
+++ b/ptypy/accelerate/base/engines/ML_serial.py
@@ -302,6 +302,10 @@ class ML_serial(ML):
             self.ob_h *= self.tmin
             self.pr_h *= self.tmin
             self.ob += self.ob_h
+
+            for name, s in self.ob.storages.items(): 
+                self.clip_object(s)
+
             self.pr += self.pr_h
             # Newton-Raphson loop would end here
 

--- a/ptypy/accelerate/base/engines/projectional_serial.py
+++ b/ptypy/accelerate/base/engines/projectional_serial.py
@@ -468,15 +468,9 @@ class _ProjectionEngine_serial(_ProjectionEngine):
             else:
                 ob.data /= obn.data
 
-            # Clip object (This call takes like one ms. Not time critical)
-            if self.p.clip_object is not None:
-                clip_min, clip_max = self.p.clip_object
-                ampl_obj = np.abs(ob.data)
-                phase_obj = np.exp(1j * np.angle(ob.data))
-                too_high = (ampl_obj > clip_max)
-                too_low = (ampl_obj < clip_min)
-                ob.data[too_high] = clip_max * phase_obj[too_high]
-                ob.data[too_low] = clip_min * phase_obj[too_low]
+
+            self.clip_object(ob.data) # Clip object (This call takes like one ms. Not time critical)
+
 
         self.benchmark.object_update += time.time() - t1
         self.benchmark.calls_object += 1

--- a/ptypy/accelerate/base/engines/stochastic.py
+++ b/ptypy/accelerate/base/engines/stochastic.py
@@ -277,6 +277,8 @@ class _StochasticEngineSerial(_StochasticEngine):
                     self.benchmark.object_update += time.time() - t1
                     self.benchmark.calls_object += 1
 
+                    self.clip_object(ob) 
+                    
                     # probe update
                     t1 = time.time()
                     if self._object_norm_is_global and self._pr_a == 0:

--- a/ptypy/accelerate/cuda_common/clip_magnitudes.cu
+++ b/ptypy/accelerate/cuda_common/clip_magnitudes.cu
@@ -4,8 +4,10 @@
  #include "common.cuh"
  
  extern "C" __global__ void clip_magnitudes(IN_TYPE *arr,
-                                            float clip_min,
-                                            float clip_max,
+                                            float clip_min_mag,
+                                            float clip_max_mag,
+                                            float clip_min_phase,
+                                            float clip_max_phase,                                            
                                             int N)                                             
 {
   int id = threadIdx.x + blockIdx.x * blockDim.x;
@@ -17,10 +19,14 @@
   auto mag = abs(v);
   auto theta = arg(v);
 
-  if (mag > clip_max)
-    mag = clip_max;
-  if (mag < clip_min)
-    mag = clip_min;
+  if (mag > clip_max_mag)
+    mag = clip_max_mag;
+  if (mag < clip_min_mag)
+    mag = clip_min_mag;
+  if (theta > clip_max_phase)
+    theta = clip_max_phase;
+  if (theta < clip_min_phase)
+    theta = clip_min_phase;
 
   v = thrust::polar(mag, theta);
   arr[id] = v;

--- a/ptypy/accelerate/cuda_common/clip_object.cu
+++ b/ptypy/accelerate/cuda_common/clip_object.cu
@@ -1,9 +1,9 @@
-/** clip_magnitudes.
+/** clip_object.
  *
  */
  #include "common.cuh"
  
- extern "C" __global__ void clip_magnitudes(IN_TYPE *arr,
+ extern "C" __global__ void clip_object(IN_TYPE *arr,
                                             float clip_min_mag,
                                             float clip_max_mag,
                                             float clip_min_phase,
@@ -19,14 +19,16 @@
   auto mag = abs(v);
   auto theta = arg(v);
 
-  if (mag > clip_max_mag)
+  if (isfinite(clip_max_mag) == 1 && mag > clip_max_mag)
     mag = clip_max_mag;
-  if (mag < clip_min_mag)
+  if (isfinite(clip_min_mag) == 1 && mag < clip_min_mag)
     mag = clip_min_mag;
-  if (theta > clip_max_phase)
+  if (isfinite(clip_max_phase) == 1 && theta > clip_max_phase)
     theta = clip_max_phase;
-  if (theta < clip_min_phase)
+  if (isfinite(clip_min_phase) == 1 && theta < clip_min_phase)
     theta = clip_min_phase;
+
+
 
   v = thrust::polar(mag, theta);
   arr[id] = v;

--- a/ptypy/accelerate/cuda_cupy/array_utils.py
+++ b/ptypy/accelerate/cuda_cupy/array_utils.py
@@ -555,27 +555,37 @@ class GaussianSmoothingKernel:
             data[:] = tmp[:]  # only one of them has run, output is in tmp
 
 
-class ClipMagnitudesKernel:
+class ClipObjectKernel:
 
     def __init__(self, queue=None):
         self.queue = queue
-        self.clip_magnitudes_cuda = load_kernel("clip_magnitudes", {
+        self.clip_object_cuda = load_kernel("clip_object", {
             'IN_TYPE': 'complex<float>',
         })
 
-    def clip_magnitudes_to_range(self, array, clip_min_mag, clip_max_mag, clip_min_phase, clip_max_phase):
+    def clip_object_to_range(self, array, clip_limits):
+
+        if len(clip_limits) == 2: # using if statement to guarantee backwards compatibility with previous scenario that used only magnitude clipping
+            clip_min_mag, clip_max_mag = clip_limits
+            clip_min_phase, clip_max_phase = None, None
+        elif len(clip_limits) == 4:
+            clip_min_mag, clip_max_mag, clip_min_phase, clip_max_phase = clip_limits
+        else:
+            raise ValueError("clip_limits must be a tuple of 2 or 4 elements")
+
         if self.queue is not None:
             self.queue.use()
 
-        clip_min_mag = np.float32(clip_min_mag)
-        clip_max_mag = np.float32(clip_max_mag)
-        clip_min_phase = np.float32(clip_min_phase)
-        clip_max_phase = np.float32(clip_max_phase)        
+        # Change from None to +/- inf. This will be used to identify None cases inside CUDA kernel. Important to cast to float32 before calling kernel
+        clip_min_mag = np.float32(-np.inf) if clip_min_mag is None else np.float32(clip_min_mag)
+        clip_max_mag = np.float32(np.inf) if clip_max_mag is None else np.float32(clip_max_mag)
+        clip_min_phase = np.float32(-np.inf) if clip_min_phase is None else np.float32(clip_min_phase)
+        clip_max_phase = np.float32(np.inf) if clip_max_phase is None else np.float32(clip_max_phase)
 
         npixel = np.int32(np.prod(array.shape))
         bx = 256
         gx = int((npixel + bx - 1) // bx)
-        self.clip_magnitudes_cuda((gx, 1, 1), (bx, 1, 1), (array, clip_min_mag, clip_max_mag, clip_min_phase, clip_max_phase , npixel))
+        self.clip_object_cuda((gx, 1, 1), (bx, 1, 1), (array, clip_min_mag, clip_max_mag, clip_min_phase, clip_max_phase , npixel))
 
 class MassCenterKernel:
 

--- a/ptypy/accelerate/cuda_cupy/array_utils.py
+++ b/ptypy/accelerate/cuda_cupy/array_utils.py
@@ -563,18 +563,19 @@ class ClipMagnitudesKernel:
             'IN_TYPE': 'complex<float>',
         })
 
-    def clip_magnitudes_to_range(self, array, clip_min, clip_max):
+    def clip_magnitudes_to_range(self, array, clip_min_mag, clip_max_mag, clip_min_phase, clip_max_phase):
         if self.queue is not None:
             self.queue.use()
 
-        cmin = np.float32(clip_min)
-        cmax = np.float32(clip_max)
+        clip_min_mag = np.float32(clip_min_mag)
+        clip_max_mag = np.float32(clip_max_mag)
+        clip_min_phase = np.float32(clip_min_phase)
+        clip_max_phase = np.float32(clip_max_phase)        
 
         npixel = np.int32(np.prod(array.shape))
         bx = 256
         gx = int((npixel + bx - 1) // bx)
-        self.clip_magnitudes_cuda((gx, 1, 1), (bx, 1, 1), (array, cmin, cmax,
-                npixel))
+        self.clip_magnitudes_cuda((gx, 1, 1), (bx, 1, 1), (array, clip_min_mag, clip_max_mag, clip_min_phase, clip_max_phase , npixel))
 
 class MassCenterKernel:
 

--- a/ptypy/accelerate/cuda_cupy/engines/projectional_cupy.py
+++ b/ptypy/accelerate/cuda_cupy/engines/projectional_cupy.py
@@ -21,7 +21,7 @@ from ptypy.accelerate.base.engines import projectional_serial
 from ..kernels import FourierUpdateKernel, AuxiliaryWaveKernel, PoUpdateKernel, PositionCorrectionKernel
 from ..kernels import PropagationKernel, RealSupportKernel, FourierSupportKernel
 from ..array_utils import ArrayUtilsKernel, GaussianSmoothingKernel,\
-    TransposeKernel, ClipMagnitudesKernel, MassCenterKernel, Abs2SumKernel,\
+    TransposeKernel, ClipObjectKernel, MassCenterKernel, Abs2SumKernel,\
     InterpolatedShiftKernel
 from ..mem_utils import make_pagelocked_paired_arrays as mppa
 from ..multi_gpu import get_multi_gpu_communicator
@@ -79,7 +79,7 @@ class _ProjectionEngine_cupy(projectional_serial._ProjectionEngine_serial):
         self.FSK = {}
 
         # Clip Magnitudes Kernel
-        self.CMK = ClipMagnitudesKernel(queue=self.queue)
+        self.CMK = ClipObjectKernel(queue=self.queue)
 
         # initialise kernels for centring probe if required
         if self.p.probe_center_tol is not None:
@@ -555,8 +555,7 @@ class _ProjectionEngine_cupy(projectional_serial._ProjectionEngine_serial):
         Clips magnitudes of object into given range.
         """
         if self.p.clip_object is not None:
-            clip_min_mag, clip_max_mag, clip_min_phase, clip_max_phase = self.p.clip_object
-            self.CMK.clip_magnitudes_to_range(ob, clip_min_mag, clip_max_mag, clip_min_phase, clip_max_phase)
+            self.CMK.clip_object_to_range(ob, self.p.clip_object)
 
 
     def engine_finalize(self):

--- a/ptypy/accelerate/cuda_cupy/engines/projectional_cupy.py
+++ b/ptypy/accelerate/cuda_cupy/engines/projectional_cupy.py
@@ -555,8 +555,9 @@ class _ProjectionEngine_cupy(projectional_serial._ProjectionEngine_serial):
         Clips magnitudes of object into given range.
         """
         if self.p.clip_object is not None:
-            cmin, cmax = self.p.clip_object
-            self.CMK.clip_magnitudes_to_range(ob, cmin, cmax)
+            clip_min_mag, clip_max_mag, clip_min_phase, clip_max_phase = self.p.clip_object
+            self.CMK.clip_magnitudes_to_range(ob, clip_min_mag, clip_max_mag, clip_min_phase, clip_max_phase)
+
 
     def engine_finalize(self):
         """

--- a/ptypy/accelerate/cuda_cupy/engines/projectional_cupy.py
+++ b/ptypy/accelerate/cuda_cupy/engines/projectional_cupy.py
@@ -552,7 +552,7 @@ class _ProjectionEngine_cupy(projectional_serial._ProjectionEngine_serial):
 
     def clip_object(self, ob):
         """
-        Clips magnitudes of object into given range.
+        Clips object magnitude and phase into given range.
         """
         if self.p.clip_object is not None:
             self.CMK.clip_object_to_range(ob, self.p.clip_object)

--- a/ptypy/accelerate/cuda_cupy/engines/stochastic.py
+++ b/ptypy/accelerate/cuda_cupy/engines/stochastic.py
@@ -25,7 +25,7 @@ from ..kernels import FourierUpdateKernel, AuxiliaryWaveKernel, PoUpdateKernel,\
     PositionCorrectionKernel, PropagationKernel
 from ..array_utils import ArrayUtilsKernel, GaussianSmoothingKernel,\
     TransposeKernel, MaxAbs2Kernel, MassCenterKernel, Abs2SumKernel,\
-    InterpolatedShiftKernel, ClipMagnitudesKernel
+    InterpolatedShiftKernel, ClipObjectKernel
 from ..mem_utils import make_pagelocked_paired_arrays as mppa
 from ..mem_utils import GpuDataManager
 
@@ -145,8 +145,8 @@ class _StochasticEngineCupy(_StochasticEngineSerial):
             kern.resolution = geo.resolution[0]
 
             # Clip Magnitudes Kernel
-            log(4, "Setting up ClipMagnitudesKernel")
-            kern.CMK = ClipMagnitudesKernel(queue=self.queue)
+            log(4, "Setting up ClipObjectKernel")
+            kern.CMK = ClipObjectKernel(queue=self.queue)
 
             if self.do_position_refinement:
                 log(4, "Setting up position correction")
@@ -336,7 +336,7 @@ class _StochasticEngineCupy(_StochasticEngineSerial):
                         addr, ob, pr, ex, aux, prn, a=self._ob_a, b=self._ob_b)
                     
                     if self.p.clip_object is not None:
-                        CMK.clip_magnitudes_to_range(ob, *self.p.clip_object)
+                        CMK.clip_object_to_range(ob, self.p.clip_object)
                     
                     # probe update
                     if self._object_norm_is_global and self._pr_a == 0:

--- a/ptypy/accelerate/cuda_cupy/engines/stochastic.py
+++ b/ptypy/accelerate/cuda_cupy/engines/stochastic.py
@@ -25,7 +25,7 @@ from ..kernels import FourierUpdateKernel, AuxiliaryWaveKernel, PoUpdateKernel,\
     PositionCorrectionKernel, PropagationKernel
 from ..array_utils import ArrayUtilsKernel, GaussianSmoothingKernel,\
     TransposeKernel, MaxAbs2Kernel, MassCenterKernel, Abs2SumKernel,\
-    InterpolatedShiftKernel
+    InterpolatedShiftKernel, ClipMagnitudesKernel
 from ..mem_utils import make_pagelocked_paired_arrays as mppa
 from ..mem_utils import GpuDataManager
 
@@ -144,6 +144,10 @@ class _StochasticEngineCupy(_StochasticEngineSerial):
             kern.PROP.allocate()
             kern.resolution = geo.resolution[0]
 
+            # Clip Magnitudes Kernel
+            log(4, "Setting up ClipMagnitudesKernel")
+            kern.CMK = ClipMagnitudesKernel(queue=self.queue)
+
             if self.do_position_refinement:
                 log(4, "Setting up position correction")
                 kern.PCK = PositionCorrectionKernel(
@@ -247,6 +251,7 @@ class _StochasticEngineCupy(_StochasticEngineSerial):
                 POK = kern.POK
                 MAK = kern.MAK
                 PROP = kern.PROP
+                CMK = kern.CMK
 
                 # get aux buffer
                 aux = kern.aux
@@ -329,7 +334,10 @@ class _StochasticEngineCupy(_StochasticEngineSerial):
                     POK.pr_norm_local(addr, pr, prn)
                     POK.ob_update_local(
                         addr, ob, pr, ex, aux, prn, a=self._ob_a, b=self._ob_b)
-
+                    
+                    if self.p.clip_object is not None:
+                        CMK.clip_magnitudes_to_range(ob, *self.p.clip_object)
+                    
                     # probe update
                     if self._object_norm_is_global and self._pr_a == 0:
                         obn_max = cp.empty((1,), dtype=np.float32)

--- a/ptypy/custom/WASP.py
+++ b/ptypy/custom/WASP.py
@@ -336,20 +336,6 @@ class WASP(base.PositionCorrectionEngine):
                 is_zero = np.isclose(pr_sum_dnm, 0)
                 p.data = np.where(is_zero, pr_sum_nmr, pr_sum_nmr / pr_sum_dnm)
 
-    def clip_object(self, ob):
-        """Copied from _ProjectionEngine
-        """
-
-        # Clip object (This call takes like one ms. Not time critical)
-        if self.p.clip_object is not None:
-            clip_min, clip_max = self.p.clip_object
-            ampl_obj = np.abs(ob.data)
-            phase_obj = np.exp(1j * np.angle(ob.data))
-            too_high = (ampl_obj > clip_max)
-            too_low = (ampl_obj < clip_min)
-            ob.data[too_high] = clip_max * phase_obj[too_high]
-            ob.data[too_low] = clip_min * phase_obj[too_low]
-
     def center_probe(self):
         """Copied from _ProjectionEngine
         """

--- a/ptypy/custom/WASP_cupy.py
+++ b/ptypy/custom/WASP_cupy.py
@@ -42,8 +42,16 @@ class WASP_cupy(WASP_serial):
     help =
     doc =
 
-    
-    
+    [probe_update_cuda_atomics]
+    default = False
+    type = bool
+    help = For GPU, use the atomics version for probe update kernel
+
+    [object_update_cuda_atomics]
+    default = True
+    type = bool
+    help = For GPU, use the atomics version for object update kernel
+
     [fft_lib]
     default = reikna
     type = str

--- a/ptypy/custom/WASP_cupy.py
+++ b/ptypy/custom/WASP_cupy.py
@@ -15,7 +15,7 @@ from ..accelerate.cuda_cupy.kernels import (FourierUpdateKernel,
     AuxiliaryWaveKernel, PoUpdateKernel, PositionCorrectionKernel,
     PropagationKernel)
 from ..accelerate.cuda_cupy.array_utils import (ArrayUtilsKernel,
-    GaussianSmoothingKernel, TransposeKernel, ClipMagnitudesKernel,
+    GaussianSmoothingKernel, TransposeKernel, ClipObjectKernel,
     MaxAbs2Kernel, MassCenterKernel, Abs2SumKernel, InterpolatedShiftKernel)
 from ..accelerate.cuda_cupy.mem_utils import make_pagelocked_paired_arrays as mppa
 from ..accelerate.cuda_cupy.mem_utils import GpuDataManager
@@ -82,7 +82,7 @@ class WASP_cupy(WASP_serial):
             self.ISK = InterpolatedShiftKernel(queue=self.queue)
 
         # Clip Magnitudes Kernel
-        self.CMK = ClipMagnitudesKernel(queue=self.queue)
+        self.CMK = ClipObjectKernel(queue=self.queue)
 
         super().engine_initialize()
         self.qu_htod = cp.cuda.Stream()

--- a/ptypy/custom/WASP_cupy.py
+++ b/ptypy/custom/WASP_cupy.py
@@ -42,6 +42,8 @@ class WASP_cupy(WASP_serial):
     help =
     doc =
 
+    
+    
     [fft_lib]
     default = reikna
     type = str
@@ -403,10 +405,10 @@ class WASP_cupy(WASP_serial):
 
     def clip_object(self, ob):
         """
-        Clips magnitudes of object into given range.
+        Clips object magnitude and phase into given range.
         """
-        cmin, cmax = self.p.clip_object
-        self.CMK.clip_magnitudes_to_range(ob, cmin, cmax)
+        if self.p.clip_object is not None:
+            self.CMK.clip_object_to_range(ob, self.p.clip_object)
 
     def position_update(self):
         """

--- a/ptypy/custom/WASP_serial.py
+++ b/ptypy/custom/WASP_serial.py
@@ -328,15 +328,7 @@ class WASP_serial(WASP):
                 self.benchmark.wasp_averaging += time.time() - t1
                 self.benchmark.calls_wasp_averaging += 1
 
-                # Clip object (This call takes like one ms. Not time critical)
-                if self.p.clip_object is not None:
-                    clip_min, clip_max = self.p.clip_object
-                    ampl_obj = np.abs(ob)
-                    phase_obj = np.exp(1j * np.angle(ob))
-                    too_high = (ampl_obj > clip_max)
-                    too_low = (ampl_obj < clip_min)
-                    ob[too_high] = clip_max * phase_obj[too_high]
-                    ob[too_low] = clip_min * phase_obj[too_low]
+                self.clip_object(ob)
 
             # Re-center the probe
             self.center_probe()

--- a/ptypy/custom/WASP_serial.py
+++ b/ptypy/custom/WASP_serial.py
@@ -328,7 +328,7 @@ class WASP_serial(WASP):
                 self.benchmark.wasp_averaging += time.time() - t1
                 self.benchmark.calls_wasp_averaging += 1
 
-                self.clip_object(ob)
+                self.clip_object(self.ob.S[oID]) 
 
             # Re-center the probe
             self.center_probe()

--- a/ptypy/engines/ML.py
+++ b/ptypy/engines/ML.py
@@ -361,6 +361,10 @@ class ML(PositionCorrectionEngine):
             self.ob_h *= self.tmin
             self.pr_h *= self.tmin
             self.ob += self.ob_h
+
+            for name, s in self.ob.storages.items(): 
+                self.clip_object(s)
+
             self.pr += self.pr_h
             # Newton-Raphson loop would end here
 

--- a/ptypy/engines/base.py
+++ b/ptypy/engines/base.py
@@ -58,6 +58,11 @@ class BaseEngine(object):
     help = Valid probe area as fraction of the probe frame
     doc = Defines a circular area centered on the probe frame, in which the probe is allowed to be nonzero.
 
+    [clip_object]
+    default = None
+    type = tuple
+    help = Clip object amplitude and phase (min mag, max mag) or (min mag, max mag, min phase, max phase). Disclaimer: so far only implemented for projectional and stochastic engines for CPU and cupy. 
+
     [probe_fourier_support]
     default = None
     type = float, None
@@ -198,6 +203,37 @@ class BaseEngine(object):
         support = self._probe_support.get(storage.ID)
         if support is not None:
             storage.data *= support
+
+    def clip_object(self, ob):
+        # Clip object (This call takes like one ms. Not time critical)
+        if self.p.clip_object is not None:
+                if len(self.p.clip_object) == 2:
+                    clip_min_mag, clip_max_mag = self.p.clip_object
+                    clip_min_phase, clip_max_phase = None, None
+                elif len(self.p.clip_object) == 4:    
+                    clip_min_mag, clip_max_mag, clip_min_phase, clip_max_phase = self.p.clip_object
+                else: 
+                    raise ValueError('clip_object must be a tuple of 2 or 4 elements')
+                    
+                # clip magnitudes
+                ampl_obj = np.abs(ob.data)
+                phase_obj = np.exp(1j * np.angle(ob.data))
+                if clip_max_mag is not None: 
+                    too_high = (ampl_obj > clip_max_mag)
+                    ob.data[too_high] = clip_max_mag * phase_obj[too_high]
+                if clip_min_mag is not None:
+                    too_low = (ampl_obj < clip_min_mag)
+                    ob.data[too_low] = clip_min_mag * phase_obj[too_low]
+
+                # clip phase
+                ampl_obj = np.abs(ob.data)
+                phase_obj = np.angle(ob.data)
+                if clip_max_phase is not None: 
+                    too_high = (phase_obj > clip_max_phase)
+                    ob.data[too_high] = ampl_obj[too_high] * np.exp(1j*clip_max_phase)
+                if clip_min_phase is not None:
+                    too_low = (phase_obj < clip_min_phase)
+                    ob.data[too_low] = ampl_obj[too_low] * np.exp(1j*clip_min_phase)
 
     def iterate(self, num=None):
         """

--- a/ptypy/engines/projectional.py
+++ b/ptypy/engines/projectional.py
@@ -91,11 +91,6 @@ class _ProjectionEngine(PositionCorrectionEngine):
     help = Gaussian smoothing (pixel) of the current object prior to update
     doc = If None, smoothing is deactivated. This smoothing can be used to reduce the amplitude of spurious pixels in the outer, least constrained areas of the object.
 
-    [clip_object]
-    default = None
-    type = tuple
-    help = Clip object amplitude into this interval
-
     [probe_center_tol]
     default = None
     type = float
@@ -273,31 +268,6 @@ class _ProjectionEngine(PositionCorrectionEngine):
 
         return error_dct
 
-    def clip_object(self, ob):
-        # Clip object (This call takes like one ms. Not time critical)
-        if self.p.clip_object is not None:
-                clip_min_mag, clip_max_mag, clip_min_phase, clip_max_phase = self.p.clip_object
-                
-                # clip magnitudes
-                ampl_obj = np.abs(ob.data)
-                phase_obj = np.exp(1j * np.angle(ob.data))
-                if clip_max_mag is not None: 
-                    too_high = (ampl_obj > clip_max_mag)
-                    ob.data[too_high] = clip_max_mag * phase_obj[too_high]
-                if clip_min_mag is not None:
-                    too_low = (ampl_obj < clip_min_mag)
-                    ob.data[too_low] = clip_min_mag * phase_obj[too_low]
-
-                # clip phase
-                ampl_obj = np.abs(ob.data)
-                phase_obj = np.exp(1j * np.angle(ob.data))
-                if clip_max_phase is not None: 
-                    too_high = (phase_obj > clip_max_phase)
-                    ob.data[too_high] = ampl_obj[too_high] * np.exp(1j*clip_max_phase)
-                if clip_min_phase is not None:
-                    too_low = (phase_obj < clip_min_phase)
-                    ob.data[too_low] = ampl_obj[too_low] * np.exp(1j*clip_min_phase)
-                
 
     def overlap_update(self):
         """

--- a/ptypy/engines/projectional.py
+++ b/ptypy/engines/projectional.py
@@ -276,13 +276,28 @@ class _ProjectionEngine(PositionCorrectionEngine):
     def clip_object(self, ob):
         # Clip object (This call takes like one ms. Not time critical)
         if self.p.clip_object is not None:
-            clip_min, clip_max = self.p.clip_object
-            ampl_obj = np.abs(ob.data)
-            phase_obj = np.exp(1j * np.angle(ob.data))
-            too_high = (ampl_obj > clip_max)
-            too_low = (ampl_obj < clip_min)
-            ob.data[too_high] = clip_max * phase_obj[too_high]
-            ob.data[too_low] = clip_min * phase_obj[too_low]
+                clip_min_mag, clip_max_mag, clip_min_phase, clip_max_phase = self.p.clip_object
+                
+                # clip magnitudes
+                ampl_obj = np.abs(ob.data)
+                phase_obj = np.exp(1j * np.angle(ob.data))
+                if clip_max_mag is not None: 
+                    too_high = (ampl_obj > clip_max_mag)
+                    ob.data[too_high] = clip_max_mag * phase_obj[too_high]
+                if clip_min_mag is not None:
+                    too_low = (ampl_obj < clip_min_mag)
+                    ob.data[too_low] = clip_min_mag * phase_obj[too_low]
+
+                # clip phase
+                ampl_obj = np.abs(ob.data)
+                phase_obj = np.exp(1j * np.angle(ob.data))
+                if clip_max_phase is not None: 
+                    too_high = (phase_obj > clip_max_phase)
+                    ob.data[too_high] = ampl_obj[too_high] * np.exp(1j*clip_max_phase)
+                if clip_min_phase is not None:
+                    too_low = (phase_obj < clip_min_phase)
+                    ob.data[too_low] = ampl_obj[too_low] * np.exp(1j*clip_min_phase)
+                
 
     def overlap_update(self):
         """

--- a/ptypy/engines/stochastic.py
+++ b/ptypy/engines/stochastic.py
@@ -107,6 +107,10 @@ class _StochasticEngine(PositionCorrectionEngine):
                 # Object update
                 self.object_update(view, exit_wave)
 
+                # Clip object
+                if self.p.clip_object is not None: # if parameter is given
+                    self.clip_object(view.pod.ob_view.storage) # clipping after object_update to use the same logic as for projectional engines
+
                 # Probe update
                 self.probe_update(view, exit_wave)
 

--- a/ptypy/engines/stochastic.py
+++ b/ptypy/engines/stochastic.py
@@ -108,8 +108,7 @@ class _StochasticEngine(PositionCorrectionEngine):
                 self.object_update(view, exit_wave)
 
                 # Clip object
-                if self.p.clip_object is not None: # if parameter is given
-                    self.clip_object(view.pod.ob_view.storage) # clipping after object_update to use the same logic as for projectional engines
+                self.clip_object(view.pod.ob_view.storage) # clipping after object_update to use the same logic as for projectional engines
 
                 # Probe update
                 self.probe_update(view, exit_wave)

--- a/test/accelerate_tests/base_tests/array_utils_test.py
+++ b/test/accelerate_tests/base_tests/array_utils_test.py
@@ -242,7 +242,7 @@ class ArrayUtilsTest(unittest.TestCase):
         probe[0] = au.interpolated_shift(probe[0], offset)
         np.testing.assert_array_almost_equal(probe, not_shifted_probe, decimal=8)
 
-    def test_clip_magnitudes_to_range(self):
+    def test_clip_object_to_range(self):
         data = np.ones((5, 5), dtype=COMPLEX_TYPE)
         data[2, 4] = 20.0 * np.exp(1j * np.pi / 2)
         data[3, 1] = 0.2 * np.exp(1j * np.pi / 3)

--- a/test/accelerate_tests/base_tests/array_utils_test.py
+++ b/test/accelerate_tests/base_tests/array_utils_test.py
@@ -252,8 +252,8 @@ class ArrayUtilsTest(unittest.TestCase):
         clip_min_phase = -np.pi / 4
         clip_max_phase = np.pi / 4
         expected_out = np.ones_like(data)
-        expected_out[2, 4] = 2.0 * np.exp(1j * -np.pi / 2)
-        expected_out[3, 1] = 0.5 * np.exp(1j * np.pi / 3)
+        expected_out[2, 4] = 2.0 * np.exp(1j * -np.pi / 4)
+        expected_out[3, 1] = 0.5 * np.exp(1j * np.pi / 4)
         au.clip_object_to_range(data, clip_min_mag, clip_max_mag, clip_min_phase, clip_max_phase)
         np.testing.assert_array_almost_equal(data, expected_out, decimal=7)  # floating point precision I guess...
 

--- a/test/accelerate_tests/base_tests/array_utils_test.py
+++ b/test/accelerate_tests/base_tests/array_utils_test.py
@@ -244,15 +244,17 @@ class ArrayUtilsTest(unittest.TestCase):
 
     def test_clip_object_to_range(self):
         data = np.ones((5, 5), dtype=COMPLEX_TYPE)
-        data[2, 4] = 20.0 * np.exp(1j * np.pi / 2)
+        data[2, 4] = 20.0 * np.exp(1j * -np.pi / 2)
         data[3, 1] = 0.2 * np.exp(1j * np.pi / 3)
 
-        clip_min = 0.5
-        clip_max = 2.0
+        clip_min_mag = 0.5
+        clip_max_mag = 2.0
+        clip_min_phase = -np.pi / 4
+        clip_max_phase = np.pi / 4
         expected_out = np.ones_like(data)
-        expected_out[2, 4] = 2.0 * np.exp(1j * np.pi / 2)
+        expected_out[2, 4] = 2.0 * np.exp(1j * -np.pi / 2)
         expected_out[3, 1] = 0.5 * np.exp(1j * np.pi / 3)
-        au.clip_complex_magnitudes_to_range(data, clip_min, clip_max)
+        au.clip_object_to_range(data, clip_min_mag, clip_max_mag, clip_min_phase, clip_max_phase)
         np.testing.assert_array_almost_equal(data, expected_out, decimal=7)  # floating point precision I guess...
 
     def test_crop_pad_1(self):

--- a/test/accelerate_tests/cuda_cupy_tests/array_utils_test.py
+++ b/test/accelerate_tests/cuda_cupy_tests/array_utils_test.py
@@ -403,7 +403,7 @@ class ArrayUtilsTest(CupyCudaTest):
                                    err_msg="The object norm array has not been updated as expected")
 
 
-    def test_clip_magnitudes_to_range_UNITY(self):
+    def test_clip_object_to_range_UNITY(self):
         np.random.seed(1987)
         A = np.random.random((2,10,10))
         B = A[0] + 1j* A[1]
@@ -411,8 +411,8 @@ class ArrayUtilsTest(CupyCudaTest):
         B_gpu = cp.asarray(B)
 
         au.clip_complex_magnitudes_to_range(B, 0.2,0.8)
-        CMK = gau.ClipMagnitudesKernel()
-        CMK.clip_magnitudes_to_range(B_gpu, 0.2, 0.8)
+        CMK = gau.ClipObjectKernel()
+        CMK.clip_object_to_range(B_gpu, 0.2, 0.8)
 
         np.testing.assert_allclose(B_gpu.get(), B, rtol=1e-6, atol=1e-6,
             err_msg="The magnitudes of the array have not been clipped as expected")

--- a/test/accelerate_tests/cuda_cupy_tests/array_utils_test.py
+++ b/test/accelerate_tests/cuda_cupy_tests/array_utils_test.py
@@ -410,9 +410,9 @@ class ArrayUtilsTest(CupyCudaTest):
         B = B.astype(np.complex64)
         B_gpu = cp.asarray(B)
 
-        au.clip_complex_magnitudes_to_range(B, 0.2,0.8)
+        au.clip_object_to_range(B, 0.2,0.8, -np.pi/4, np.pi/4)
         CMK = gau.ClipObjectKernel()
-        CMK.clip_object_to_range(B_gpu, 0.2, 0.8)
+        CMK.clip_object_to_range(B_gpu, (0.2, 0.8, -np.pi/4, np.pi/4))
 
         np.testing.assert_allclose(B_gpu.get(), B, rtol=1e-6, atol=1e-6,
             err_msg="The magnitudes of the array have not been clipped as expected")


### PR DESCRIPTION
The clipping input is now assumed to be either a 2-tuple or 4-tuple. 

In case it is as 2-tuple, it is assumed to be (mininum_magnitude, maximum_magnitude)
In case it is as 4-tuple, it is assumed to be (mininum_magnitude, maximum_magnitude, minimum_phase,maximum_phase)

For ignoring a specific clipping, use None. For instance: (minimum_magnitude, None, None, maximum_phase)

I kept the approach that was already implemented for the magnitude clipping, so it is done right after object update and before probe update.

Done:
- [x] Change clipping functions to clip not only magnitude but also phase (CPU and cupy)
- [x] Renamed .cu file and functions that referred to "clip magnitude" to "clip object" 
- [x] Add clipping functionality to stochastic engine (CPU and cupy)
- [x] Add clipping functionality to ML engine (CPU and cupy)
- [x] Edit WASP engines to also use the new clipping strategy

Still possible ToDos:
- [ ]  add clipping strategy to pycuda engines
- [ ] Improve clipping strategy (see comment below)

One open point of discussion: what is the "correct" way of doing such a clipping? Currently, we clip the magnitudes (np.abs) followed by clipping of the phase (np.angle), which would result in a behavior in the complex plane as the following:

<img width="689" height="699" alt="Image" src="https://github.com/user-attachments/assets/c0f32268-32d1-4cce-9938-a50e1dcf14d1" />
