### PR TITLE
Add CI for publishing container on tagging

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -11,6 +11,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        platform: [full, cupy]
+        mpi: [openmpi, mpich]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -30,7 +34,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}_cupy_openmpi
+          images: ghcr.io/${{ github.repository }}_${{ matrix.platform }}_${{ matrix.mpi }}
           tags: |
             type=raw,value=v0.9.0
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,50 @@
+name: Build and Push Container Image
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Version from Tag
+        id: tags
+        run: echo version=$(echo "${{ github.ref_name }}" | cut -c 2-) >> $GITHUB_OUTPUT
+
+      - name: Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ steps.tags.outputs.version }}
+            type=raw,value=latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and Push Image
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          target: runtime
+          build-args: |
+            PLATFORM=${{ matrix.platform}}
+            MPI=${{ matrix.mpi }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -30,10 +30,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository }}_cupy_openmpi
           tags: |
-            type=raw,value=${{ steps.tags.outputs.version }}
-            type=raw,value=latest
+            type=raw,value=v0.9.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,27 +8,27 @@ ARG PLATFORM=cupy
 ARG CUDAVERSION=12.4
 
 # Pull from mambaforge and install XML and ssh
-FROM condaforge/mambaforge as base
+FROM condaforge/mambaforge AS base
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y libxml2 ssh
 
 # Pull from base image and install OpenMPI/MPICH
-FROM base as mpi
+FROM base AS mpi
 ARG MPI
 RUN mamba install -n base -c conda-forge ${MPI}
 
 # Pull from MPI build install core dependencies
-FROM base as core
+FROM base AS core
 COPY ./dependencies_core.yml ./dependencies.yml
 RUN mamba env update -n base -f dependencies.yml
 
 # Pull from MPI build and install full dependencies
-FROM mpi as full
+FROM mpi AS full
 COPY ./dependencies_full.yml ./dependencies.yml
 RUN mamba env update -n base -f dependencies.yml
 
 # Pull from MPI build and install accelerate/pycuda dependencies
-FROM mpi as pycuda
+FROM mpi AS pycuda
 ARG CUDAVERSION
 COPY ./ptypy/accelerate/cuda_pycuda/dependencies.yml ./dependencies.yml
 COPY ./cufft/dependencies.yml ./dependencies_cufft.yml
@@ -37,7 +37,7 @@ RUN mamba install cuda-version=${CUDAVERSION} && \
     mamba env update -n base -f dependencies_cufft.yml
 
 # Pull from MPI build and install accelerate/cupy dependencies
-FROM mpi as cupy
+FROM mpi AS cupy
 ARG CUDAVERSION
 COPY ./ptypy/accelerate/cuda_cupy/dependencies.yml ./dependencies.yml
 COPY ./cufft/dependencies.yml ./dependencies_cufft.yml
@@ -46,7 +46,7 @@ RUN mamba install cuda-version=${CUDAVERSION} && \
     mamba env update -n base -f dependencies_cufft.yml
 
 # Pull from platform specific image and install ptypy 
-FROM ${PLATFORM} as build
+FROM ${PLATFORM} AS build
 COPY pyproject.toml ./
 COPY ./templates ./templates
 COPY ./benchmark ./benchmark
@@ -55,19 +55,19 @@ COPY ./ptypy ./ptypy
 RUN pip install .
 
 # For core/full build, no post processing needed
-FROM build as core-post
-FROM build as full-post
+FROM build AS core-post
+FROM build AS full-post
 
 # For pycuda build, install filtered cufft
-FROM build as pycuda-post
+FROM build AS pycuda-post
 RUN pip install ./cufft
 
 # For pycuda build, install filtered cufft
-FROM build as cupy-post
+FROM build AS cupy-post
 RUN pip install ./cufft
 
 # Platform specific runtime container
-FROM ${PLATFORM}-post as runtime
+FROM ${PLATFORM}-post AS runtime
 
 # Run PtyPy run script as entrypoint
 ENTRYPOINT ["ptypy.cli"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,18 +32,18 @@ FROM mpi AS pycuda
 ARG CUDAVERSION
 COPY ./ptypy/accelerate/cuda_pycuda/dependencies.yml ./dependencies.yml
 COPY ./cufft/dependencies.yml ./dependencies_cufft.yml
-RUN mamba install cuda-version=${CUDAVERSION} && \
-    mamba env update -n base -f dependencies.yml && \
-    mamba env update -n base -f dependencies_cufft.yml
+RUN mamba env update -n base -f dependencies.yml && \
+    mamba env update -n base -f dependencies_cufft.yml && \
+    mamba install cuda-version=${CUDAVERSION}
 
 # Pull from MPI build and install accelerate/cupy dependencies
 FROM mpi AS cupy
 ARG CUDAVERSION
 COPY ./ptypy/accelerate/cuda_cupy/dependencies.yml ./dependencies.yml
 COPY ./cufft/dependencies.yml ./dependencies_cufft.yml
-RUN mamba install cuda-version=${CUDAVERSION} && \
-    mamba env update -n base -f dependencies.yml && \
-    mamba env update -n base -f dependencies_cufft.yml
+RUN mamba env update -n base -f dependencies.yml && \
+    mamba env update -n base -f dependencies_cufft.yml && \
+    mamba install cuda-version=${CUDAVERSION}
 
 # Pull from platform specific image and install ptypy 
 FROM ${PLATFORM} AS build

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG MPI=openmpi
 ARG PLATFORM=cupy
 
 # Select CUDA version
-ARG CUDAVERSION=12.4
+ARG CUDAVERSION=12.8
 
 # Pull from mambaforge and install XML and ssh
 FROM condaforge/mambaforge AS base
@@ -17,57 +17,80 @@ FROM base AS mpi
 ARG MPI
 RUN mamba install -n base -c conda-forge ${MPI}
 
-# Pull from MPI build install core dependencies
+# Pull from MPI build and install core dependencies
 FROM base AS core
-COPY ./dependencies_core.yml ./dependencies.yml
-RUN mamba env update -n base -f dependencies.yml
+RUN mamba install -n base -y -c conda-forge \
+    python numpy scipy h5py pip
 
 # Pull from MPI build and install full dependencies
 FROM mpi AS full
-COPY ./dependencies_full.yml ./dependencies.yml
-RUN mamba env update -n base -f dependencies.yml
+ARG MPI
+RUN mamba install -n base -y -c conda-forge \
+    python numpy scipy matplotlib h5py \ 
+    pyzmq mpi4py[build=*${MPI}*] packaging \
+    pillow pyfftw pyyaml pip
 
 # Pull from MPI build and install accelerate/pycuda dependencies
 FROM mpi AS pycuda
-ARG CUDAVERSION
-COPY ./ptypy/accelerate/cuda_pycuda/dependencies.yml ./dependencies.yml
-COPY ./cufft/dependencies.yml ./dependencies_cufft.yml
-RUN mamba env update -n base -f dependencies.yml && \
-    mamba env update -n base -f dependencies_cufft.yml && \
-    mamba install cuda-version=${CUDAVERSION}
+ARG CUDAVERSION MPI
+RUN mamba install -n base -y -c conda-forge -c nvidia \
+    python numpy scipy matplotlib h5py pyzmq mpi4py[build=*${MPI}*] \
+    pillow pyfftw pyyaml compilers pip \
+    reikna pycuda cuda-nvcc cuda-cudart-dev cuda-version=${CUDAVERSION}
 
 # Pull from MPI build and install accelerate/cupy dependencies
 FROM mpi AS cupy
-ARG CUDAVERSION
-COPY ./ptypy/accelerate/cuda_cupy/dependencies.yml ./dependencies.yml
-COPY ./cufft/dependencies.yml ./dependencies_cufft.yml
-RUN mamba env update -n base -f dependencies.yml && \
-    mamba env update -n base -f dependencies_cufft.yml && \
-    mamba install cuda-version=${CUDAVERSION}
+ARG CUDAVERSION MPI
+RUN mamba install -n base -y -c conda-forge \
+    python numpy scipy matplotlib h5py pyzmq mpi4py[build=*${MPI}*] \
+    pillow pyfftw pyyaml compilers pip \
+    cupy cuda-version=${CUDAVERSION}
+RUN mamba clean -y -a
 
 # Pull from platform specific image and install ptypy 
 FROM ${PLATFORM} AS build
 COPY pyproject.toml ./
 COPY ./templates ./templates
 COPY ./benchmark ./benchmark
-COPY ./cufft ./cufft
 COPY ./ptypy ./ptypy
 RUN pip install .
 
-# For core/full build, no post processing needed
+# For core build, clean up conda env
 FROM build AS core-post
+RUN mamba clean -y -a
+
+# For full build, clean up conda env
 FROM build AS full-post
+RUN mamba clean -y -a
 
 # For pycuda build, install filtered cufft
 FROM build AS pycuda-post
+ARG CUDAVERSION
+RUN mamba install -n base -y -c conda-forge -c nvidia \
+    python cmake>=3.8.0 pybind11 compilers \
+    cuda-nvcc cuda-cudart-dev libcufft-dev libcufft-static cuda-version=${CUDAVERSION}
+COPY ./cufft ./cufft
 RUN pip install ./cufft
+RUN mamba remove -n base -y \
+    cmake pybind11 cuda-nvcc cuda-cudart-dev libcufft-dev libcufft-static
+RUN mamba clean -y -a
 
-# For pycuda build, install filtered cufft
+# For cupy build, install filtered cufft
 FROM build AS cupy-post
+ARG CUDAVERSION
+RUN mamba install -n base -y -c conda-forge -c nvidia \
+    python cmake>=3.8.0 pybind11 compilers \
+    cuda-nvcc cuda-cudart-dev libcufft-dev libcufft-static cuda-version=${CUDAVERSION}
+COPY ./cufft ./cufft
 RUN pip install ./cufft
+RUN mamba remove -n base -y \
+    cmake pybind11 libcufft-dev libcufft-static
+RUN mamba clean -y -a
 
 # Platform specific runtime container
 FROM ${PLATFORM}-post AS runtime
+RUN useradd --user-group ptypy-user
+USER ptypy-user
 
 # Run PtyPy run script as entrypoint
 ENTRYPOINT ["ptypy.cli"]


### PR DESCRIPTION
Building docker images on release with Github actions for the following combinations

- platform: full, cupy
- mpi: openmpi, mpich

using CUDA toolkit version 12.8