### PR TITLE
hdf5_loader.py - psize is expected to be scalar but it might be a tuple

### DIFF
--- a/ptypy/experiment/hdf5_loader.py
+++ b/ptypy/experiment/hdf5_loader.py
@@ -588,7 +588,7 @@ class Hdf5Loader(PtyScan):
 
         if None not in [self.p.recorded_psize.file, self.p.recorded_psize.key]:
             with h5.File(self.p.recorded_psize.file, 'r', swmr=self._is_swmr) as f:
-                self.p.psize = float(f[self.p.recorded_psize.key][()].item()[0] * self.p.recorded_psize.multiplier)
+                self.p.psize = float(f[self.p.recorded_psize.key][0].item() * self.p.recorded_psize.multiplier)
             self.info.psize = self.p.psize
             log(3, "loading psize={} from file".format(self.p.psize))
 

--- a/ptypy/experiment/hdf5_loader.py
+++ b/ptypy/experiment/hdf5_loader.py
@@ -588,7 +588,7 @@ class Hdf5Loader(PtyScan):
 
         if None not in [self.p.recorded_psize.file, self.p.recorded_psize.key]:
             with h5.File(self.p.recorded_psize.file, 'r', swmr=self._is_swmr) as f:
-                self.p.psize = float(f[self.p.recorded_psize.key][()].item() * self.p.recorded_psize.multiplier)
+                self.p.psize = float(f[self.p.recorded_psize.key][()].item()[0] * self.p.recorded_psize.multiplier)
             self.info.psize = self.p.psize
             log(3, "loading psize={} from file".format(self.p.psize))
 


### PR DESCRIPTION
From parameter tree docs:

scandata.PtyScan.psize(float, tuple)
    Detector pixel size
    Dimensions of the detector pixels (in meters)
    default = 0.000172 (>0.0)

psize can be a tuple... perhaps for non-square pixels, I have never used it that way but some older datasets have x,y pixel size, e.g., 

psize=[0.000172, 0.000172]

which are accepted by Ptydscan. The proposed change just (silently) uses the first element of psize.