### PR TITLE
Improve ML cupy memory estimation

### DIFF
--- a/ptypy/accelerate/cuda_cupy/engines/ML_cupy.py
+++ b/ptypy/accelerate/cuda_cupy/engines/ML_cupy.py
@@ -167,7 +167,7 @@ class ML_cupy(ML_serial):
         mempool = cp.get_default_memory_pool()
         mem = cp.cuda.runtime.memGetInfo()[0] + mempool.total_bytes() - mempool.used_bytes()
         tot = cp.cuda.runtime.memGetInfo()[1]
-        safety_margin = device_memory_fractional_safety_margin * tot
+        safety_margin = max(device_memory_fractional_safety_margin * tot, 400 * 1024 * 1024)
 
         # leave room for safety
         fit = int(mem - safety_margin) // blk

--- a/ptypy/accelerate/cuda_cupy/engines/ML_cupy.py
+++ b/ptypy/accelerate/cuda_cupy/engines/ML_cupy.py
@@ -36,10 +36,10 @@ __all__ = ['ML_cupy']
 MAX_BLOCKS = 99999
 # MAX_BLOCKS = 3  # can be used to limit the number of blocks, simulating that they don't fit
 
-# Limit the amount of device memory that will be estimated as being available
-max_device_occupancy = 0.9
-if "PTYPY_DEVICE_OCCUPANCY" in os.environ:
-    max_device_occupancy = float(PTYPY_DEVICE_OCCUPANCY)
+# Estimate the device memory safety margin as fraction of total device memory
+device_memory_fractional_safety_margin = 0.025
+if "PTYPY_DEVICE_MEM_SAFETY" in os.environ:
+    device_memory_fractional_safety_margin = float(PTYPY_DEVICE_MEM_SAFETY)
 
 
 @register()
@@ -166,9 +166,11 @@ class ML_cupy(ML_serial):
         # as both will be used for allocations
         mempool = cp.get_default_memory_pool()
         mem = cp.cuda.runtime.memGetInfo()[0] + mempool.total_bytes() - mempool.used_bytes()
+        tot = cp.cuda.runtime.memGetInfo()[1]
+        safety_margin = device_memory_fractional_safety_margin * tot
 
-        # leave 200MB room for safety
-        fit = int(max_device_occupancy * mem - 200 * 1024 * 1024) // blk
+        # leave room for safety
+        fit = int(mem - safety_margin) // blk
         if not fit:
             log(1, "Cannot fit memory into device, if possible reduce frames per block. Exiting...")
             raise SystemExit("ptypy has been exited.")

--- a/ptypy/accelerate/cuda_cupy/engines/ML_cupy.py
+++ b/ptypy/accelerate/cuda_cupy/engines/ML_cupy.py
@@ -39,7 +39,7 @@ MAX_BLOCKS = 99999
 # Estimate the device memory safety margin as fraction of total device memory
 device_memory_fractional_safety_margin = 0.025
 if "PTYPY_DEVICE_MEM_SAFETY" in os.environ:
-    device_memory_fractional_safety_margin = float(PTYPY_DEVICE_MEM_SAFETY)
+    device_memory_fractional_safety_margin = float(os.environ["PTYPY_DEVICE_MEM_SAFETY"])
 
 
 @register()

--- a/ptypy/accelerate/cuda_cupy/engines/ML_cupy.py
+++ b/ptypy/accelerate/cuda_cupy/engines/ML_cupy.py
@@ -14,6 +14,7 @@ This file is part of the PTYPY package.
 import numpy as np
 import cupy as cp
 import cupyx
+import os
 
 from ptypy.engines import register
 from ptypy.accelerate.base.engines.ML_serial import ML_serial, BaseModelSerial
@@ -34,6 +35,11 @@ __all__ = ['ML_cupy']
 # can be used to limit the number of blocks, simulating that they don't fit
 MAX_BLOCKS = 99999
 # MAX_BLOCKS = 3  # can be used to limit the number of blocks, simulating that they don't fit
+
+# Limit the amount of device memory that will be estimated as being available
+max_device_occupancy = 0.9
+if "PTYPY_DEVICE_OCCUPANCY" in os.environ:
+    max_device_occupancy = float(PTYPY_DEVICE_OCCUPANCY)
 
 
 @register()
@@ -162,7 +168,7 @@ class ML_cupy(ML_serial):
         mem = cp.cuda.runtime.memGetInfo()[0] + mempool.total_bytes() - mempool.used_bytes()
 
         # leave 200MB room for safety
-        fit = int(mem - 200 * 1024 * 1024) // blk
+        fit = int(max_device_occupancy * mem - 200 * 1024 * 1024) // blk
         if not fit:
             log(1, "Cannot fit memory into device, if possible reduce frames per block. Exiting...")
             raise SystemExit("ptypy has been exited.")

--- a/ptypy/accelerate/cuda_cupy/engines/projectional_cupy_stream.py
+++ b/ptypy/accelerate/cuda_cupy/engines/projectional_cupy_stream.py
@@ -13,6 +13,7 @@ This file is part of the PTYPY package.
     :license: see LICENSE for details.
 """
 
+import os
 import numpy as np
 import cupy as cp
 import cupyx
@@ -31,6 +32,11 @@ EX_MA_BLOCKS_RATIO = 2
 # can be used to limit the number of blocks, simulating that they don't fit
 MAX_BLOCKS = 99999
 # MAX_BLOCKS = 3  # can be used to limit the number of blocks, simulating that they don't fit
+
+# Estimate the device memory safety margin as fraction of total device memory
+device_memory_fractional_safety_margin = 0.025
+if "PTYPY_DEVICE_MEM_SAFETY" in os.environ:
+    device_memory_fractional_safety_margin = float(os.environ["PTYPY_DEVICE_MEM_SAFETY"])
 
 __all__ = ['DM_cupy_stream', 'RAAR_cupy_stream']
 
@@ -65,9 +71,11 @@ class _ProjectionEngine_cupy_stream(projectional_cupy._ProjectionEngine_cupy):
         # as both will be used for allocations
         mempool = cp.get_default_memory_pool()
         mem = cp.cuda.runtime.memGetInfo()[0] + mempool.total_bytes() - mempool.used_bytes()
-        
-        # leave 200MB room for safety
-        fit = int(mem - 200 * 1024 * 1024) // blk
+        tot = cp.cuda.runtime.memGetInfo()[1]
+        safety_margin = max(device_memory_fractional_safety_margin * tot, 400 * 1024 * 1024)
+
+        # leave room for safety
+        fit = int(mem - safety_margin) // blk
         if not fit:
             log(1, "Cannot fit memory into device, if possible reduce frames per block. Exiting...")
             raise SystemExit("ptypy has been exited.")


### PR DESCRIPTION
In some cases, we have noticed that when the last block of data is allocated in the ML cupy engine, there is not enough memory available despite upfront calculations on how much device memory is free. 

The origin of this issue could be related to discrepancies between memory allocation of cupy and via the lower level CUDA runtime API - this needs further investigation.

As an intermediate solution, I am adding the capabilities to leave more extra device memory (now defined as a fraction of total memory) and allow users to change this "safety margin" by adding an environment variable PTYPY_DEVICE_MEM_SAFETY. 

The new default for this safety margin is 2.5% of the total device memory or at least 400 MB (previously it was hardcoded to 200 MB) to make sure we can always operate on low-memory devices.